### PR TITLE
[xcain-binance] getTransactions add asset parameter #78

### DIFF
--- a/packages/xchain-binance/src/client.ts
+++ b/packages/xchain-binance/src/client.ts
@@ -265,6 +265,7 @@ class Client implements BinanceClient, XChainClient {
         limit: params && params.limit?.toString(),
         offset: params && params.offset?.toString(),
         startTime: params && params.startTime && params.startTime.getTime().toString(),
+        asset: params && params.asset
       })
     } catch (error) {
       return Promise.reject(error)

--- a/packages/xchain-client/src/types.ts
+++ b/packages/xchain-client/src/types.ts
@@ -47,6 +47,7 @@ export type TxHistoryParams = {
   offset?: number // Optional Offset
   limit?: number // Optional Limit of transactions
   startTime?: Date // Optional start time
+  asset?: string // Optional asset. Result transactions will be filtered by this asset
 }
 
 export type TxParams = {


### PR DESCRIPTION
- [x]  add optional parameter `asset` to the [TxHistoryParams](https://github.com/xchainjs/xchainjs-lib/blob/master/packages/xchain-client/src/types.ts#L45)
- [x]  added logic for `asset` parameter to the [xchain-binance](https://github.com/xchainjs/xchainjs-lib/blob/master/packages/xchain-binance/src/client.ts#L261)

closes #78 