### PR TITLE
clean lib folder before build when publishing to npm

### DIFF
--- a/packages/xchain-binance/CHANGELOG.md
+++ b/packages/xchain-binance/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # v.4.4.2 (2021-01-30)
 
-- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+- Clear lib folder on build
 
 # v.4.4.1 (2021-01-15)
 

--- a/packages/xchain-binance/CHANGELOG.md
+++ b/packages/xchain-binance/CHANGELOG.md
@@ -1,12 +1,16 @@
 # v.x.x.x
 
-# v.4.4.1 (2020-01-15)
+# v.4.4.2 (2021-01-30)
+
+- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+
+# v.4.4.1 (2021-01-15)
 
 ### Change
 
 - Export `getPrefix`
 
-# v.4.4.0 (2020-01-15)
+# v.4.4.0 (2021-01-15)
 
 ### Update
 

--- a/packages/xchain-binance/package.json
+++ b/packages/xchain-binance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-binance",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "Custom Binance client and utilities used by XChainJS clients",
   "keywords": [
     "BNB",
@@ -30,7 +30,7 @@
     "test": "jest",
     "compile": "tsc -p tsconfig.build.json",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn clean && yarn build"
   },
   "dependencies": {
     "@xchainjs/xchain-client": "^0.3.0",

--- a/packages/xchain-binance/package.json
+++ b/packages/xchain-binance/package.json
@@ -26,11 +26,11 @@
   },
   "scripts": {
     "clean": "rimraf lib/**",
-    "build": "rollup -c",
+    "build": "yarn clean && rollup -c",
     "test": "jest",
     "compile": "tsc -p tsconfig.build.json",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "prepublishOnly": "yarn clean && yarn build"
+    "prepublishOnly": "yarn build"
   },
   "dependencies": {
     "@xchainjs/xchain-client": "^0.3.0",

--- a/packages/xchain-bitcoin/CHANGELOG.md
+++ b/packages/xchain-bitcoin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # v.0.8.2 (2021-01-30)
 
-- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+- Clear lib folder on build
 
 # v.0.8.1 (2021-01-15)
 

--- a/packages/xchain-bitcoin/CHANGELOG.md
+++ b/packages/xchain-bitcoin/CHANGELOG.md
@@ -1,12 +1,16 @@
 # v.x.x.x
 
-# v.0.8.1 (2020-01-15)
+# v.0.8.2 (2021-01-30)
+
+- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+
+# v.0.8.1 (2021-01-15)
 
 ### Change
 
 - Export `getPrefix`
 
-# v.0.8.0 (2020-01-15)
+# v.0.8.0 (2021-01-15)
 
 ### Breaking change
 

--- a/packages/xchain-bitcoin/package.json
+++ b/packages/xchain-bitcoin/package.json
@@ -25,10 +25,10 @@
   },
   "scripts": {
     "clean": "rimraf lib/**",
-    "build": "rollup -c",
+    "build": "yarn clean && rollup -c",
     "test": "jest",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "prepublishOnly": "yarn clean && yarn build",
+    "prepublishOnly": "yarn build",
     "postversion": "git push --follow-tags"
   },
   "dependencies": {

--- a/packages/xchain-bitcoin/package.json
+++ b/packages/xchain-bitcoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-bitcoin",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Custom Bitcoin client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",
@@ -28,7 +28,7 @@
     "build": "rollup -c",
     "test": "jest",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "prepublishOnly": "yarn build",
+    "prepublishOnly": "yarn clean && yarn build",
     "postversion": "git push --follow-tags"
   },
   "dependencies": {

--- a/packages/xchain-bitcoincash/CHANGELOG.md
+++ b/packages/xchain-bitcoincash/CHANGELOG.md
@@ -1,1 +1,5 @@
 # v.x.x.x
+
+# v.0.1.1
+
+- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm

--- a/packages/xchain-bitcoincash/CHANGELOG.md
+++ b/packages/xchain-bitcoincash/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 # v.0.1.1
 
-- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+- Clear lib folder on build

--- a/packages/xchain-bitcoincash/__tests__/client.test.ts
+++ b/packages/xchain-bitcoincash/__tests__/client.test.ts
@@ -86,7 +86,7 @@ describe('BCHClient Test', () => {
       cashAddress: 'bchtest:qz35h5mfa8w2pqma2jq06lp7dnv5fxkp2svtllzmlf',
       slpAddress: 'slptest:qz35h5mfa8w2pqma2jq06lp7dnv5fxkp2shlcycvd5',
       currentPage: 0,
-      pagesTotal: 2
+      pagesTotal: 2,
     })
     const balance = await bchClient.getBalance()
     expect(balance.length).toEqual(1)
@@ -116,7 +116,7 @@ describe('BCHClient Test', () => {
       cashAddress: 'bchtest:qz35h5mfa8w2pqma2jq06lp7dnv5fxkp2svtllzmlf',
       slpAddress: 'slptest:qz35h5mfa8w2pqma2jq06lp7dnv5fxkp2shlcycvd5',
       currentPage: 0,
-      pagesTotal: 2
+      pagesTotal: 2,
     })
     const balance = await bchClient.getBalance('qz35h5mfa8w2pqma2jq06lp7dnv5fxkp2svtllzmlf')
     expect(balance.length).toEqual(1)

--- a/packages/xchain-bitcoincash/package.json
+++ b/packages/xchain-bitcoincash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-bitcoincash",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Custom bitcoincash client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",
@@ -29,7 +29,7 @@
     "build": "rollup -c",
     "test": "jest",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "prepublishOnly": "yarn build",
+    "prepublishOnly": "yarn clean && yarn build",
     "postversion": "git push --follow-tags"
   },
   "dependencies": {

--- a/packages/xchain-bitcoincash/package.json
+++ b/packages/xchain-bitcoincash/package.json
@@ -26,10 +26,10 @@
   },
   "scripts": {
     "clean": "rimraf lib/**",
-    "build": "rollup -c",
+    "build": "yarn clean && rollup -c",
     "test": "jest",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "prepublishOnly": "yarn clean && yarn build",
+    "prepublishOnly": "yarn build",
     "postversion": "git push --follow-tags"
   },
   "dependencies": {

--- a/packages/xchain-bitcoincash/src/client.ts
+++ b/packages/xchain-bitcoincash/src/client.ts
@@ -63,8 +63,8 @@ class Client implements BitcoinCashClient, XChainClient {
    */
   getDefaultClientURL = (): ClientUrl => {
     return {
-      'testnet': 'https://trest.bitcoin.com/v2',
-      'mainnet': 'https://rest.bitcoin.com/v2'
+      testnet: 'https://trest.bitcoin.com/v2',
+      mainnet: 'https://rest.bitcoin.com/v2',
     }
   }
 
@@ -95,7 +95,6 @@ class Client implements BitcoinCashClient, XChainClient {
   getClientUrlByNetwork = (network: Network): string => {
     return this.clientUrl[network]
   }
-
 
   /**
    * Set/update a new phrase.
@@ -137,8 +136,7 @@ class Client implements BitcoinCashClient, XChainClient {
   setNetwork = (network: Network): void => {
     if (network) {
       this.network = network
-    }
-    else {
+    } else {
       throw new Error('Network must be provided')
     }
   }
@@ -262,7 +260,7 @@ class Client implements BitcoinCashClient, XChainClient {
    *
    * @param {Address} address By default, it will return the balance of the current wallet. (optional)
    * @returns {Array<Balance>} The BTC balance of the address.
-   * 
+   *
    * @throws {"Invalid address"} Thrown if the given address is an invalid address.
    */
   getBalance = async (address?: string): Promise<Balance[]> => {
@@ -274,14 +272,14 @@ class Client implements BitcoinCashClient, XChainClient {
       if (!response) {
         throw new Error('Invalid address')
       }
-      
+
       return [
         {
           asset: utils.AssetBCH,
           amount: baseAmount(response.balanceSat, 8),
-        }
+        },
       ]
-    } catch(error) {
+    } catch (error) {
       return Promise.reject(error)
     }
   }

--- a/packages/xchain-client/CHANGELOG.md
+++ b/packages/xchain-client/CHANGELOG.md
@@ -1,7 +1,3 @@
-# v.0.3.1 (2021-1-30)
-
-- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
-
 # v.0.3.0 (2020-28-12)
 
 ### Breaking change

--- a/packages/xchain-client/CHANGELOG.md
+++ b/packages/xchain-client/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v.0.3.1 (2021-1-30)
+
+- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+
 # v.0.3.0 (2020-28-12)
 
 ### Breaking change

--- a/packages/xchain-client/package.json
+++ b/packages/xchain-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-client",
-  "version": "0.3.1",
+  "version": "0.3.0",
   "license": "MIT",
   "main": "lib/index",
   "types": "lib/index",
@@ -11,7 +11,7 @@
     "build": "yarn run clean && yarn run compile",
     "clean": "rimraf -rf ./lib",
     "compile": "tsc -p tsconfig.build.json",
-    "prepublishOnly": "yarn clean && yarn run build",
+    "prepublishOnly": "yarn run build",
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {},

--- a/packages/xchain-client/package.json
+++ b/packages/xchain-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-client",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "main": "lib/index",
   "types": "lib/index",
@@ -11,7 +11,7 @@
     "build": "yarn run clean && yarn run compile",
     "clean": "rimraf -rf ./lib",
     "compile": "tsc -p tsconfig.build.json",
-    "prepublishOnly": "yarn run build",
+    "prepublishOnly": "yarn clean && yarn run build",
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {},

--- a/packages/xchain-cosmos/CHANGELOG.md
+++ b/packages/xchain-cosmos/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # v.0.7.1 (2021-01-30)
 
-- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+- Clear lib folder on build
 
 # v.0.7.0 (2021-01-15)
 

--- a/packages/xchain-cosmos/CHANGELOG.md
+++ b/packages/xchain-cosmos/CHANGELOG.md
@@ -1,6 +1,10 @@
 # v.x.x.x
 
-# v.0.7.0 (2020-01-15)
+# v.0.7.1 (2021-01-30)
+
+- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+
+# v.0.7.0 (2021-01-15)
 
 ### Update
 

--- a/packages/xchain-cosmos/package.json
+++ b/packages/xchain-cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-cosmos",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Custom Cosmos client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",
@@ -28,7 +28,7 @@
     "build": "rollup -c",
     "test": "jest",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn clean && yarn build"
   },
   "devDependencies": {
     "cosmos-client": "^0.39.2"

--- a/packages/xchain-cosmos/package.json
+++ b/packages/xchain-cosmos/package.json
@@ -25,10 +25,10 @@
   },
   "scripts": {
     "clean": "rimraf lib/**",
-    "build": "rollup -c",
+    "build": "yarn clean && rollup -c",
     "test": "jest",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "prepublishOnly": "yarn clean && yarn build"
+    "prepublishOnly": "yarn build"
   },
   "devDependencies": {
     "cosmos-client": "^0.39.2"

--- a/packages/xchain-crypto/CHANGELOG.md
+++ b/packages/xchain-crypto/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # v.0.2.3 (2021-01-30)
 
-- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+- Clear lib folder on build
 
 ### Update
 

--- a/packages/xchain-crypto/CHANGELOG.md
+++ b/packages/xchain-crypto/CHANGELOG.md
@@ -1,4 +1,8 @@
-# v.x.x.x (2020-XX-XX)
+# v.x.x.x (2021-XX-XX)
+
+# v.0.2.3 (2021-01-30)
+
+- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
 
 ### Update
 

--- a/packages/xchain-crypto/package.json
+++ b/packages/xchain-crypto/package.json
@@ -12,10 +12,10 @@
   ],
   "scripts": {
     "clean": "rimraf lib/**",
-    "build": "rollup -c",
+    "build": "yarn clean && rollup -c",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "test": "jest --coverage",
-    "prepublishOnly": "yarn clean && yarn build"
+    "prepublishOnly": "yarn build"
   },
   "repository": {
     "type": "git",

--- a/packages/xchain-crypto/package.json
+++ b/packages/xchain-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-crypto",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "XChain Crypto is a crypto module needed by all XChain clients.",
   "main": "lib/index.js",
   "module": "lib/index.es.js",
@@ -15,7 +15,7 @@
     "build": "rollup -c",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "test": "jest --coverage",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn clean && yarn build"
   },
   "repository": {
     "type": "git",

--- a/packages/xchain-ethereum/CHANGELOG.md
+++ b/packages/xchain-ethereum/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v.0.8.1 (2020-01-30)
+
+- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+
 # v.0.8.0 (2020-01-27)
 
 ### Breaking change

--- a/packages/xchain-ethereum/CHANGELOG.md
+++ b/packages/xchain-ethereum/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v.0.8.1 (2020-01-30)
 
-- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+- Clear lib folder on build
 
 # v.0.8.0 (2020-01-27)
 

--- a/packages/xchain-ethereum/package.json
+++ b/packages/xchain-ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-ethereum",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Ethereum client for XChainJS",
   "keywords": [
     "XChain",
@@ -28,7 +28,7 @@
     "build": "rollup -c rollup.config.ts",
     "test": "jest",
     "lint": "eslint \"{src,__tests__, __mocks__}/**/*.ts\" --fix --max-warnings 0",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn clean && yarn build"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/xchain-ethereum/package.json
+++ b/packages/xchain-ethereum/package.json
@@ -25,10 +25,10 @@
   },
   "scripts": {
     "clean": "rimraf lib/**",
-    "build": "rollup -c rollup.config.ts",
+    "build": "yarn clean && rollup -c rollup.config.ts",
     "test": "jest",
     "lint": "eslint \"{src,__tests__, __mocks__}/**/*.ts\" --fix --max-warnings 0",
-    "prepublishOnly": "yarn clean && yarn build"
+    "prepublishOnly": "yarn build"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/xchain-litecoin/CHANGELOG.md
+++ b/packages/xchain-litecoin/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v.0.0.2 (2021-01-30)
+
+- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+
 # v.0.0.1 (2021-01-29)
 
 First release

--- a/packages/xchain-litecoin/CHANGELOG.md
+++ b/packages/xchain-litecoin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v.0.0.2 (2021-01-30)
 
-- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+- Clear lib folder on build
 
 # v.0.0.1 (2021-01-29)
 

--- a/packages/xchain-litecoin/package.json
+++ b/packages/xchain-litecoin/package.json
@@ -25,10 +25,10 @@
   },
   "scripts": {
     "clean": "rimraf lib/**",
-    "build": "rollup -c",
+    "build": "yarn clean && rollup -c",
     "test": "jest",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "prepublishOnly": "yarn clean && yarn build",
+    "prepublishOnly": "yarn build",
     "postversion": "git push --follow-tags"
   },
   "dependencies": {

--- a/packages/xchain-litecoin/package.json
+++ b/packages/xchain-litecoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-litecoin",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Custom Litecoin client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",
@@ -28,7 +28,7 @@
     "build": "rollup -c",
     "test": "jest",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "prepublishOnly": "yarn build",
+    "prepublishOnly": "yarn clean && yarn build",
     "postversion": "git push --follow-tags"
   },
   "dependencies": {

--- a/packages/xchain-polkadot/CHANGELOG.md
+++ b/packages/xchain-polkadot/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # v.0.4.1 (2020-01-30)
 
-- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+- Clear lib folder on build
 
 # v.0.4.0 (2020-01-15)
 

--- a/packages/xchain-polkadot/CHANGELOG.md
+++ b/packages/xchain-polkadot/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v.x.x.x
 
+# v.0.4.1 (2020-01-30)
+
+- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+
 # v.0.4.0 (2020-01-15)
 
 ### Update

--- a/packages/xchain-polkadot/package.json
+++ b/packages/xchain-polkadot/package.json
@@ -26,10 +26,10 @@
   },
   "scripts": {
     "clean": "rimraf lib/**",
-    "build": "rollup -c",
+    "build": "yarn clean && rollup -c",
     "test": "jest --detectOpenHandles",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "prepublishOnly": "yarn clean && yarn build",
+    "prepublishOnly": "yarn build",
     "start:example": "ts-node example/index.ts"
   },
   "devDependencies": {

--- a/packages/xchain-polkadot/package.json
+++ b/packages/xchain-polkadot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-polkadot",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Custom Polkadot client and utilities used by XChainJS clients",
   "keywords": [
     "THORChain",
@@ -29,7 +29,7 @@
     "build": "rollup -c",
     "test": "jest --detectOpenHandles",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "prepublishOnly": "yarn build",
+    "prepublishOnly": "yarn clean && yarn build",
     "start:example": "ts-node example/index.ts"
   },
   "devDependencies": {

--- a/packages/xchain-thorchain/CHANGELOG.md
+++ b/packages/xchain-thorchain/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # v.0.9.2 (2020-01-30)
 
-- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+- Clear lib folder on build
 
 # v.0.9.1 (2020-01-26)
 

--- a/packages/xchain-thorchain/CHANGELOG.md
+++ b/packages/xchain-thorchain/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v.x.x.x
 
+# v.0.9.2 (2020-01-30)
+
+- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+
 # v.0.9.1 (2020-01-26)
 
 ### Fix

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-thorchain",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Custom Thorchain client and utilities used by XChainJS clients",
   "keywords": [
     "THORChain",
@@ -28,7 +28,7 @@
     "build": "rollup -c",
     "test": "jest",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "prepublishOnly": "yarn build",
+    "prepublishOnly": "yarn clean && yarn build",
     "start:example": "ts-node example/index.ts"
   },
   "devDependencies": {

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -25,10 +25,10 @@
   },
   "scripts": {
     "clean": "rimraf lib/**",
-    "build": "rollup -c",
+    "build": "yarn clean && rollup -c",
     "test": "jest",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "prepublishOnly": "yarn clean && yarn build",
+    "prepublishOnly": "yarn build",
     "start:example": "ts-node example/index.ts"
   },
   "devDependencies": {

--- a/packages/xchain-util/CHANGELOG.md
+++ b/packages/xchain-util/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v.x.x.x
 
+# v.0.2.2 (2021-01-30)
+
+- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+- Fixes linting from redeclaring Litecoin in chain consts twice
+
 ### Update
 
 - add Bitcoin Cash chain const.

--- a/packages/xchain-util/CHANGELOG.md
+++ b/packages/xchain-util/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # v.0.2.2 (2021-01-30)
 
-- Adds yarn clean to package.json prepublishOnly to clear lib folder before building and publishing to npm
+- Clear lib folder on build
 - Fixes linting from redeclaring Litecoin in chain consts twice
 
 ### Update

--- a/packages/xchain-util/package.json
+++ b/packages/xchain-util/package.json
@@ -25,10 +25,10 @@
   },
   "scripts": {
     "clean": "rimraf lib/**",
-    "build": "rollup -c",
+    "build": "yarn clean && rollup -c",
     "test": "jest",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "prepublishOnly": "yarn clean && yarn build"
+    "prepublishOnly": "yarn build"
   },
   "peerDependencies": {
     "bignumber.js": "9.x"

--- a/packages/xchain-util/package.json
+++ b/packages/xchain-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-util",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Helper utilities for XChain clients",
   "keywords": [
     "THORChain",
@@ -28,7 +28,7 @@
     "build": "rollup -c",
     "test": "jest",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn clean && yarn build"
   },
   "peerDependencies": {
     "bignumber.js": "9.x"

--- a/packages/xchain-util/src/chain.const.ts
+++ b/packages/xchain-util/src/chain.const.ts
@@ -7,10 +7,6 @@ export const BNBChain = 'BNB'
  */
 export const BTCChain = 'BTC'
 /**
- * Litecoin Chain
- */
-export const LTCChain = 'LTC'
-/**
  * Ethereum Chain
  */
 export const ETHChain = 'ETH'


### PR DESCRIPTION
- adds `yarn clean` to `yarn prepublishOnly`
- fixes small linting bug in utils where Litecoin was declared twice in chain consts.