### PR TITLE
allows infura creds secret to be optional

### DIFF
--- a/packages/xchain-ethereum/CHANGELOG.md
+++ b/packages/xchain-ethereum/CHANGELOG.md
@@ -1,5 +1,8 @@
 # v.x.x.x (xxxx-xx-xx)
 
+# v.0.10.2-1 (2020-02-11)
+
+- Sets Infura creds as project ID if no secret is provided.
 # v.0.10.2 (2020-02-11)
 
 - Allow optional Infura credentials

--- a/packages/xchain-ethereum/package.json
+++ b/packages/xchain-ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-ethereum",
-  "version": "0.10.2",
+  "version": "0.10.2-1",
   "description": "Ethereum client for XChainJS",
   "keywords": [
     "XChain",

--- a/packages/xchain-ethereum/src/client.ts
+++ b/packages/xchain-ethereum/src/client.ts
@@ -89,9 +89,17 @@ export default class Client implements XChainClient, EthereumClient {
    */
   constructor({ network = 'testnet', explorerUrl, phrase, etherscanApiKey, infuraCreds }: ClientParams) {
     this.network = xchainNetworkToEths(network)
-    this.provider = infuraCreds
-      ? new ethers.providers.InfuraProvider(network, infuraCreds)
-      : getDefaultProvider(this.network)
+
+    if (infuraCreds) {
+      // Infura provider takes either a string of project id
+      // or an object of id and secret
+      this.provider = infuraCreds.projectSecret
+        ? new ethers.providers.InfuraProvider(network, infuraCreds)
+        : new ethers.providers.InfuraProvider(network, infuraCreds.projectId)
+    } else {
+      this.provider = getDefaultProvider(network)
+    }
+
     this.etherscan = new EtherscanProvider(this.network, etherscanApiKey)
     this.explorerUrl = explorerUrl || this.getDefaultExplorerURL()
 
@@ -258,9 +266,17 @@ export default class Client implements XChainClient, EthereumClient {
       throw new Error('Network must be provided')
     } else {
       this.network = xchainNetworkToEths(network)
-      this.provider = this.infuraCreds
-        ? new ethers.providers.InfuraProvider(network, this.infuraCreds)
-        : getDefaultProvider(this.network)
+
+      if (this.infuraCreds) {
+        // Infura provider takes either a string of project id
+        // or an object of id and secret
+        this.provider = this.infuraCreds.projectSecret
+          ? new ethers.providers.InfuraProvider(this.network, this.infuraCreds)
+          : new ethers.providers.InfuraProvider(this.network, this.infuraCreds.projectId)
+      } else {
+        this.provider = getDefaultProvider(this.network)
+      }
+
       this.etherscan = new EtherscanProvider(this.network)
     }
   }

--- a/packages/xchain-ethereum/src/types/client-types.ts
+++ b/packages/xchain-ethereum/src/types/client-types.ts
@@ -31,7 +31,7 @@ export type TxOverrides = {
 
 export type InfuraCreds = {
   projectId: string
-  projectSecret: string
+  projectSecret?: string
 }
 
 export type GasPrices = Record<C.FeeOptionKey, BaseAmount>


### PR DESCRIPTION
from ethers.js docs...

"The apiKey can be a string Project ID or an object with the properties projectId and projectSecret to specify a Project Secret which can be used on non-public sources (like on a server) to further secure your API access and quotas."

makes project secret optional.