### PR TITLE
uses blockstream api to submit transactions

### DIFF
--- a/packages/xchain-bitcoin/__mocks__/sochain.ts
+++ b/packages/xchain-bitcoin/__mocks__/sochain.ts
@@ -38,9 +38,9 @@ export default {
       return [200, resp]
     })
 
-    //Mock send_tx
-    mock.onPost(/\/send_tx/).reply(function () {
-      return [200, { data: { txid: 'TEST_OK' } }]
+    //Mock blockstream send tx
+    mock.onPost(/\/tx/).reply(function () {
+      return [200, 'TEST_OK']
     })
   },
 }

--- a/packages/xchain-bitcoin/src/blockstream-api.ts
+++ b/packages/xchain-bitcoin/src/blockstream-api.ts
@@ -1,0 +1,21 @@
+import axios from 'axios'
+import { BroadcastTxParams } from './types/common'
+
+/**
+ * Broadcast transaction.
+ *
+ * @see https://sochain.com/api#send-transaction
+ *
+ * @param {string} network
+ * @param {string} txHex
+ * @returns {string} Transaction ID.
+ */
+export const broadcastTx = async ({ network, txHex }: BroadcastTxParams): Promise<string> => {
+  try {
+    const url = network === 'testnet' ? 'https://blockstream.info/testnet/api/tx' : 'https://blockstream.info/api/tx'
+    const txid: string = (await axios.post(url, txHex)).data
+    return txid
+  } catch (error) {
+    return Promise.reject(error)
+  }
+}

--- a/packages/xchain-bitcoin/src/client.ts
+++ b/packages/xchain-bitcoin/src/client.ts
@@ -407,7 +407,7 @@ class Client implements BitcoinClient, XChainClient {
       psbt.finalizeAllInputs() // Finalise inputs
       const txHex = psbt.extractTransaction().toHex() // TX extracted and formatted to hex
 
-      return await Utils.broadcastTx({ network: this.net, txHex, nodeUrl: this.nodeUrl })
+      return await Utils.broadcastTx({ network: this.net, txHex })
     } catch (e) {
       return Promise.reject(e)
     }

--- a/packages/xchain-bitcoin/src/sochain-api.ts
+++ b/packages/xchain-bitcoin/src/sochain-api.ts
@@ -5,11 +5,9 @@ import {
   BtcUnspentTxsDTO,
   BtcAddressDTO,
   BtcGetBalanceDTO,
-  BtcBroadcastTransfer,
   Transaction,
   AddressParams,
   TxHashParams,
-  TxBroadcastParams,
 } from './types/sochain-api-types'
 import { assetToBase, assetAmount, BaseAmount } from '@xchainjs/xchain-util'
 import { BTC_DECIMAL } from './utils'
@@ -102,27 +100,6 @@ export const getUnspentTxs = async ({ nodeUrl, network, address }: AddressParams
     const resp = await axios.get(`${nodeUrl}/get_tx_unspent/${toSochainNetwork(network)}/${address}`)
     const response: SochainResponse<BtcUnspentTxsDTO> = resp.data
     return response.data.txs
-  } catch (error) {
-    return Promise.reject(error)
-  }
-}
-
-/**
- * Broadcast transaction.
- *
- * @see https://sochain.com/api#send-transaction
- *
- * @param {string} nodeUrl The sochain node url.
- * @param {string} network
- * @param {string} txHex
- * @returns {string} Transaction ID.
- */
-export const broadcastTx = async ({ nodeUrl, network, txHex }: TxBroadcastParams): Promise<string> => {
-  try {
-    const url = `${nodeUrl}/send_tx/${toSochainNetwork(network)}`
-    const data = { tx_hex: txHex }
-    const response: SochainResponse<BtcBroadcastTransfer> = (await axios.post(url, data)).data
-    return response.data.txid
   } catch (error) {
     return Promise.reject(error)
   }

--- a/packages/xchain-bitcoin/src/types/common.ts
+++ b/packages/xchain-bitcoin/src/types/common.ts
@@ -13,7 +13,7 @@ export type UTXO = {
 
 export type UTXOs = UTXO[]
 
-export type BroadcastTxParams = { network: Network; txHex: string; nodeUrl: string }
+export type BroadcastTxParams = { network: Network; txHex: string }
 
 // We might extract it into xchain-client later
 export type DerivePath = { mainnet: string; testnet: string }

--- a/packages/xchain-bitcoin/src/utils.ts
+++ b/packages/xchain-bitcoin/src/utils.ts
@@ -1,5 +1,6 @@
 import * as Bitcoin from 'bitcoinjs-lib' // https://github.com/bitcoinjs/bitcoinjs-lib
 import * as sochain from './sochain-api'
+import * as blockStream from './blockstream-api'
 import { Address, Balance, Fees, Network, TxHash, TxParams } from '@xchainjs/xchain-client'
 import { assetAmount, AssetBTC, assetToBase, assetToString, BaseAmount, baseAmount } from '@xchainjs/xchain-util'
 import { AddressParams, BtcAddressUTXOs } from './types/sochain-api-types'
@@ -247,8 +248,8 @@ export const buildTx = async ({
  * @param {BroadcastTxParams} params The transaction broadcast options.
  * @returns {TxHash} The transaction hash.
  */
-export const broadcastTx = async ({ network, txHex, nodeUrl }: BroadcastTxParams): Promise<TxHash> => {
-  return await sochain.broadcastTx({ nodeUrl: nodeUrl, network, txHex })
+export const broadcastTx = async ({ network, txHex }: BroadcastTxParams): Promise<TxHash> => {
+  return await blockStream.broadcastTx({ network, txHex })
 }
 
 /**


### PR DESCRIPTION
sochain submit txs was causing CORs errors. endpoint changed to blockstream, which has a public API and txs submit successfully. 

https://github.com/Blockstream/esplora/blob/master/API.md#post-tx