### PR TITLE
fix: litecoin export `Utils.validateAddress` and bitcoincash `Utils.validateAddress`

### DIFF
--- a/packages/xchain-bitcoin/CHANGELOG.md
+++ b/packages/xchain-bitcoin/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v.0.12.1 (2021-03-02)
+
+- Export `validateAddress`
+
 # v.0.12.0 (2021-03-02)
 
 ### Breaking change

--- a/packages/xchain-bitcoin/package.json
+++ b/packages/xchain-bitcoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-bitcoin",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Custom Bitcoin client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",

--- a/packages/xchain-bitcoin/src/index.ts
+++ b/packages/xchain-bitcoin/src/index.ts
@@ -9,5 +9,6 @@ export {
   BTC_DECIMAL,
   scanUTXOs,
   buildTx,
+  validateAddress,
 } from './utils'
 export { createTxInfo } from './ledger'

--- a/packages/xchain-bitcoincash/CHANGELOG.md
+++ b/packages/xchain-bitcoincash/CHANGELOG.md
@@ -1,9 +1,15 @@
+# v.0.7.2 (2021-03-15)
+
+
+### Fix 
+
+- Fix default mainnet url
+
 # v.0.7.1 (2021-03-05)
 
 ### Update
 
 - Update `getBalance` to include unconfirmed balances.
-
 # v.0.7.0 (2021-03-02)
 
 ### Breaking change

--- a/packages/xchain-bitcoincash/package.json
+++ b/packages/xchain-bitcoincash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-bitcoincash",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Custom bitcoincash client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",

--- a/packages/xchain-bitcoincash/src/client.ts
+++ b/packages/xchain-bitcoincash/src/client.ts
@@ -62,7 +62,7 @@ class Client implements BitcoinCashClient, XChainClient {
     phrase,
     nodeUrl = {
       testnet: 'https://testnet.bch.thorchain.info',
-      mainnet: 'https://mainnet.bch.thorchain.info',
+      mainnet: 'https://bch.thorchain.info',
     },
     nodeAuth = {
       username: 'thorchain',

--- a/packages/xchain-litecoin/CHANGELOG.md
+++ b/packages/xchain-litecoin/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fix
 
 - export Utils.`validateAddress`
+- Fix default mainnet url
 
 
 # v.0.4.0 (2021-03-02)

--- a/packages/xchain-litecoin/CHANGELOG.md
+++ b/packages/xchain-litecoin/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v.0.4.1 (2021-03-14)
+
+### Fix
+
+- export Utils.`validateAddress`
+
+
 # v.0.4.0 (2021-03-02)
 
 ### Breaking change

--- a/packages/xchain-litecoin/package.json
+++ b/packages/xchain-litecoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-litecoin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Custom Litecoin client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",

--- a/packages/xchain-litecoin/src/client.ts
+++ b/packages/xchain-litecoin/src/client.ts
@@ -68,7 +68,7 @@ class Client implements LitecoinClient, XChainClient {
     this.nodeUrl = !!nodeUrl
       ? nodeUrl
       : network === 'mainnet'
-      ? 'https://mainnet.ltc.thorchain.info'
+      ? 'https://ltc.thorchain.info'
       : 'https://testnet.ltc.thorchain.info'
 
     this.nodeAuth =

--- a/packages/xchain-litecoin/src/index.ts
+++ b/packages/xchain-litecoin/src/index.ts
@@ -1,4 +1,12 @@
 export * from './types'
 export * from './client'
-export { broadcastTx, getDerivePath, getDefaultFees, getDefaultFeesWithRates, getPrefix, LTC_DECIMAL } from './utils'
+export {
+  broadcastTx,
+  getDerivePath,
+  getDefaultFees,
+  getDefaultFeesWithRates,
+  getPrefix,
+  LTC_DECIMAL,
+  validateAddress,
+} from './utils'
 export { createTxInfo } from './ledger'


### PR DESCRIPTION
chore: fix mainnet urls for litecoin and bch