### PR TITLE
HD wallet compatibility

### DIFF
--- a/packages/xchain-binance/CHANGELOG.md
+++ b/packages/xchain-binance/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.5.1.0 (2021-05-17)
+
+### Breaking change
+
+- added support for HD wallets
+
 # v.5.0.0 (2021-05-05)
 
 ### Breaking change

--- a/packages/xchain-binance/__tests__/client.test.ts
+++ b/packages/xchain-binance/__tests__/client.test.ts
@@ -312,7 +312,7 @@ describe('BinanceClient Test', () => {
       3,
     )
 
-    const beforeTransfer = await client.getBalance()
+    const beforeTransfer = await client.getBalance(client.getAddress(0))
     expect(beforeTransfer.length).toEqual(1)
 
     mockNodeInfo(testnetClientURL)
@@ -340,7 +340,7 @@ describe('BinanceClient Test', () => {
       sequence: 0,
     })
 
-    const afterTransfer = await client.getBalance()
+    const afterTransfer = await client.getBalance(client.getAddress(0))
     expect(afterTransfer.length).toEqual(1)
 
     const expected = beforeTransfer[0].amount
@@ -374,7 +374,7 @@ describe('BinanceClient Test', () => {
       3,
     )
 
-    const beforeTransfer = await client.getBalance()
+    const beforeTransfer = await client.getBalance(client.getAddress(0))
     expect(beforeTransfer.length).toEqual(1)
 
     const transactions = [
@@ -428,7 +428,7 @@ describe('BinanceClient Test', () => {
       sequence: 0,
     })
 
-    const afterTransfer = await client.getBalance()
+    const afterTransfer = await client.getBalance(client.getAddress(0))
     expect(afterTransfer.length).toEqual(1)
 
     const expected = beforeTransfer[0].amount

--- a/packages/xchain-binance/__tests__/client.test.ts
+++ b/packages/xchain-binance/__tests__/client.test.ts
@@ -58,7 +58,7 @@ describe('BinanceClient Test', () => {
   const mainnetaddress_path1 = 'bnb1vjlcrl5d9t8sexzajsr57taqmxf6jpmgng3gmn'
 
   const testnetaddress_path0 = 'tbnb1zd87q9dywg3nu7z38mxdcxpw8hssrfp9htcrvj'
-  const testnetaddress_path1 = 'tbnb1zd87q9dywg3nu7z38mxdcxpw8hssrfp9htcrvj'
+  const testnetaddress_path1 = 'tbnb1vjlcrl5d9t8sexzajsr57taqmxf6jpmgaacvmz'
 
   const singleTxFee = baseAmount(37500)
   const transferFee = { type: 'base', average: singleTxFee, fast: singleTxFee, fastest: singleTxFee }
@@ -78,7 +78,7 @@ describe('BinanceClient Test', () => {
   })
 
   afterEach(async () => {
-    if (bnbClient) bnbClient.purgeClient()
+    bnbClient.purgeClient()
   })
 
   it('should start with empty wallet', async () => {
@@ -101,7 +101,7 @@ describe('BinanceClient Test', () => {
     const bnbClientEmptyTest = new BinanceClient({ phrase, network: 'testnet', derivationPath: '0' })
     const addressTest = bnbClientEmptyTest.getAddress()
     expect(addressTest).toEqual(testnetaddress_path0)
-    const bnbClientEmptyTest_path1 = new BinanceClient({ phrase, network: 'mainnet', derivationPath: '1' })
+    const bnbClientEmptyTest_path1 = new BinanceClient({ phrase, network: 'testnet', derivationPath: '1' })
     expect(bnbClientEmptyTest_path1.getAddress()).toEqual(testnetaddress_path1)
   })
 

--- a/packages/xchain-binance/__tests__/client.test.ts
+++ b/packages/xchain-binance/__tests__/client.test.ts
@@ -92,17 +92,21 @@ describe('BinanceClient Test', () => {
   })
 
   it('should support derivation index as string', async () => {
-    const bnbClientEmptyMain = new BinanceClient({ phrase, network: 'mainnet', derivationPath: '0' })
+    const bnbForTxClientEmptyMain = new BinanceClient({ phrase: phraseForTX, network: 'testnet' })
+    const address_path0ForTx = bnbForTxClientEmptyMain.getAddress()
+    expect(address_path0ForTx).toEqual(testnetaddress_path0ForTx)
+
+    const bnbClientEmptyMain = new BinanceClient({ phrase, network: 'mainnet' })
     const addressMain = bnbClientEmptyMain.getAddress()
     expect(addressMain).toEqual(mainnetaddress_path0)
-    const bnbClientEmptyMain_path1 = new BinanceClient({ phrase, network: 'mainnet', derivationPath: '1' })
-    expect(bnbClientEmptyMain_path1.getAddress()).toEqual(mainnetaddress_path1)
+    const bnbClientEmptyMain_path1 = new BinanceClient({ phrase, network: 'mainnet' })
+    expect(bnbClientEmptyMain_path1.getAddress(1)).toEqual(mainnetaddress_path1)
 
-    const bnbClientEmptyTest = new BinanceClient({ phrase, network: 'testnet', derivationPath: '0' })
+    const bnbClientEmptyTest = new BinanceClient({ phrase, network: 'testnet' })
     const addressTest = bnbClientEmptyTest.getAddress()
     expect(addressTest).toEqual(testnetaddress_path0)
-    const bnbClientEmptyTest_path1 = new BinanceClient({ phrase, network: 'testnet', derivationPath: '1' })
-    expect(bnbClientEmptyTest_path1.getAddress()).toEqual(testnetaddress_path1)
+    const bnbClientEmptyTest_path1 = new BinanceClient({ phrase, network: 'testnet' })
+    expect(bnbClientEmptyTest_path1.getAddress(1)).toEqual(testnetaddress_path1)
   })
 
   it('throws an error passing an invalid phrase', async () => {
@@ -113,6 +117,7 @@ describe('BinanceClient Test', () => {
 
   it('should have right address', async () => {
     expect(bnbClient.getAddress()).toEqual(mainnetaddress_path0)
+    expect(bnbClient.getAddress(1)).toEqual(mainnetaddress_path1)
   })
 
   it('should update net', () => {
@@ -191,6 +196,7 @@ describe('BinanceClient Test', () => {
     const AssetRune: Asset = { chain: BNBChain, symbol: 'RUNE', ticker: 'RUNE' }
 
     const balances = await bnbClient.getBalance('tbnb1zd87q9dywg3nu7z38mxdcxpw8hssrfp9htcrvj', [AssetBNB, AssetRune])
+
     expect(balances.length).toEqual(2)
 
     let amount = balances[0].amount

--- a/packages/xchain-binance/__tests__/client.test.ts
+++ b/packages/xchain-binance/__tests__/client.test.ts
@@ -127,7 +127,7 @@ describe('BinanceClient Test', () => {
     expect(client.getAddress()).toEqual(testnetaddress_path0)
   })
 
-  it('setPhrase should return addres', () => {
+  it('setPhrase should return address', () => {
     expect(bnbClient.setPhrase(phrase)).toEqual(mainnetaddress_path0)
 
     bnbClient.setNetwork('testnet')

--- a/packages/xchain-binance/package.json
+++ b/packages/xchain-binance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-binance",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Custom Binance client and utilities used by XChainJS clients",
   "keywords": [
     "BNB",
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@binance-chain/javascript-sdk": "^4.1.1",
     "@types/big.js": "^4.0.5",
-    "@xchainjs/xchain-client": "^0.8.0",
+    "@xchainjs/xchain-client": "^0.9.0",
     "@xchainjs/xchain-util": "^0.2.7",
     "@xchainjs/xchain-crypto": "^0.2.3"
   },
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "@binance-chain/javascript-sdk": "^4.1.1",
-    "@xchainjs/xchain-client": "^0.8.0",
+    "@xchainjs/xchain-client": "^0.9.0",
     "@xchainjs/xchain-util": "^0.2.7",
     "@xchainjs/xchain-crypto": "^0.2.3"
   }

--- a/packages/xchain-binance/src/client.ts
+++ b/packages/xchain-binance/src/client.ts
@@ -35,7 +35,7 @@ import {
   BNBChain,
   assetToString,
 } from '@xchainjs/xchain-util'
-import * as xchainCrypto from '@xchainjs/xchain-crypto'
+import { validatePhrase } from '@xchainjs/xchain-crypto'
 import { isTransferFee, parseTx, getPrefix } from './util'
 import { SignedSend } from '@binance-chain/javascript-sdk/lib/types'
 
@@ -52,7 +52,7 @@ export type MultiTransfer = {
 }
 
 export type MultiSendParams = {
-  address?: Address
+  address?: Address | number
   transactions: MultiTransfer[]
   memo?: string
 }
@@ -79,9 +79,6 @@ class Client implements BinanceClient, XChainClient {
   private network: Network
   private bncClient: BncClient
   private phrase = ''
-  private derivationPath: number | undefined = undefined
-  private address: Address = '' // default address at index 0
-  private privateKey: PrivKey | null = null // default private key at index 0
 
   /**
    * Constructor
@@ -93,12 +90,9 @@ class Client implements BinanceClient, XChainClient {
    *
    * @throws {"Invalid phrase"} Thrown if the given phase is invalid.
    */
-  constructor({ network = 'testnet', phrase, derivationPath }: XChainClientParams) {
-    if (derivationPath && isNaN(parseInt(derivationPath || ''))) {
-      throw new Error('Invalid `derivationPath`: this should be a stringified index number')
-    }
+  constructor({ network = 'testnet', phrase = '' }: XChainClientParams) {
     this.network = network
-    if (phrase) this.setPhrase(phrase, derivationPath ? parseInt(derivationPath) : undefined)
+    this.phrase = phrase
     this.bncClient = new BncClient(this.getClientUrl())
     this.bncClient.chooseNetwork(network)
   }
@@ -110,9 +104,6 @@ class Client implements BinanceClient, XChainClient {
    */
   purgeClient(): void {
     this.phrase = ''
-    this.derivationPath = undefined
-    this.address = ''
-    this.privateKey = null
   }
 
   /**
@@ -133,16 +124,13 @@ class Client implements BinanceClient, XChainClient {
    * @throws {"Network must be provided"}
    * Thrown if network has not been set before.
    */
-  setNetwork(network: Network): XChainClient {
+  setNetwork(network: Network): void {
     if (!network) {
       throw new Error('Network must be provided')
     } else {
       this.network = network
       this.bncClient = new BncClient(this.getClientUrl())
       this.bncClient.chooseNetwork(network)
-      this.address = ''
-
-      return this
     }
   }
 
@@ -202,42 +190,29 @@ class Client implements BinanceClient, XChainClient {
    * @throws {"Invalid phrase"}
    * Thrown if the given phase is invalid.
    */
-  setPhrase = (phrase: string, derivationPath?: number): Address => {
-    if (!this.phrase || this.phrase !== phrase || this.derivationPath !== derivationPath) {
-      if (!xchainCrypto.validatePhrase(phrase)) {
-        throw new Error('Invalid phrase')
-      }
-
-      this.phrase = phrase
-      this.derivationPath = derivationPath
-      this.privateKey = null
-      this.address = ''
+  setPhrase = (phrase: string, index = 0): Address => {
+    if (!validatePhrase(phrase)) {
+      throw new Error('Invalid phrase')
     }
 
-    return this.getAddress()
+    this.phrase = phrase
+    return this.getAddress(index)
   }
 
   /**
    * @private
    * Get private key.
    *
+   * @param {number} index account index for the derivation path
    * @returns {PrivKey} The privkey generated from the given phrase
    *
    * @throws {"Phrase not set"}
    * Throws an error if phrase has not been set before
    * */
-  private getPrivateKey = (): PrivKey => {
-    if (!this.privateKey) {
-      if (!this.phrase) throw new Error('Phrase not set')
+  private getPrivateKey = (index: number): PrivKey => {
+    if (!this.phrase) throw new Error('Phrase not set')
 
-      this.privateKey = crypto.getPrivateKeyFromMnemonic(
-        this.phrase,
-        (this.derivationPath && true) || undefined,
-        this.derivationPath,
-      )
-    }
-
-    return this.privateKey
+    return crypto.getPrivateKeyFromMnemonic(this.phrase, true, index)
   }
 
   /**
@@ -247,19 +222,8 @@ class Client implements BinanceClient, XChainClient {
    *
    * @throws {Error} Thrown if phrase has not been set before. A phrase is needed to create a wallet and to derive an address from it.
    */
-  getAddress = (): string => {
-    if (!this.address) {
-      const address = crypto.getAddressFromPrivateKey(this.getPrivateKey(), getPrefix(this.network))
-      if (!address) {
-        throw new Error(
-          'Address has to be set. Or set a phrase by calling `setPhrase` before to use an address of an imported key.',
-        )
-      }
-
-      this.address = address
-    }
-    return this.address
-  }
+  getAddress = (index = 0): string =>
+    crypto.getAddressFromPrivateKey(this.getPrivateKey(index), getPrefix(this.network))
 
   /**
    * Validate the given address.
@@ -274,13 +238,14 @@ class Client implements BinanceClient, XChainClient {
   /**
    * Get the balance of a given address.
    *
-   * @param {Address} address By default, it will return the balance of the current wallet. (optional)
+   * @param {Address | number} address By default, it will return the balance of the current wallet. (optional)
    * @param {Asset} asset If not set, it will return all assets available. (optional)
    * @returns {Array<Balance>} The balance of the address.
    */
-  getBalance = async (address?: Address, assets?: Asset[]): Promise<Balances> => {
+  getBalance = async (address: Address | number = 0, assets?: Asset[]): Promise<Balances> => {
     try {
-      const balances: BinanceBalances = await this.bncClient.getBalance(address || this.getAddress())
+      const derivedAddress: string = typeof address === 'number' ? this.getAddress(address) : address || ''
+      const balances: BinanceBalances = await this.bncClient.getBalance(derivedAddress)
 
       return balances
         .map((balance) => {
@@ -347,8 +312,10 @@ class Client implements BinanceClient, XChainClient {
    */
   getTransactions = async (params?: TxHistoryParams): Promise<TxsPage> => {
     try {
+      const address: string =
+        typeof params?.address === 'number' ? this.getAddress(params.address) : params?.address || ''
       return await this.searchTransactions({
-        address: params ? params.address : this.getAddress(),
+        address,
         limit: params && params.limit?.toString(),
         offset: params && params.offset?.toString(),
         startTime: params && params.startTime && params.startTime.getTime().toString(),
@@ -403,13 +370,14 @@ class Client implements BinanceClient, XChainClient {
    * @param {MultiSendParams} params The multi-send transfer options.
    * @returns {TxHash} The transaction hash.
    */
-  multiSend = async ({ address, transactions, memo = '' }: MultiSendParams): Promise<TxHash> => {
+  multiSend = async ({ address = 0, transactions, memo = '' }: MultiSendParams): Promise<TxHash> => {
     try {
+      const derivedAddress: string = typeof address === 'number' ? this.getAddress(address) : address || ''
       await this.bncClient.initChain()
-      await this.bncClient.setPrivateKey(this.getPrivateKey()).catch((error) => Promise.reject(error))
+      await this.bncClient.setPrivateKey(this.getPrivateKey(0)).catch((error) => Promise.reject(error))
 
       const transferResult = await this.bncClient.multiSend(
-        address || this.getAddress(),
+        derivedAddress,
         transactions.map((transaction) => {
           return {
             to: transaction.to,
@@ -436,10 +404,10 @@ class Client implements BinanceClient, XChainClient {
    * @param {TxParams} params The transfer options.
    * @returns {TxHash} The transaction hash.
    */
-  transfer = async ({ asset, amount, recipient, memo }: TxParams): Promise<TxHash> => {
+  transfer = async ({ from, asset, amount, recipient, memo }: TxParams): Promise<TxHash> => {
     try {
       await this.bncClient.initChain()
-      await this.bncClient.setPrivateKey(this.getPrivateKey()).catch((error: Error) => Promise.reject(error))
+      await this.bncClient.setPrivateKey(this.getPrivateKey(from || 0)).catch((error: Error) => Promise.reject(error))
 
       const transferResult = await this.bncClient.transfer(
         this.getAddress(),

--- a/packages/xchain-binance/src/client.ts
+++ b/packages/xchain-binance/src/client.ts
@@ -92,7 +92,7 @@ class Client implements BinanceClient, XChainClient {
    */
   constructor({ network = 'testnet', phrase = '' }: XChainClientParams) {
     this.network = network
-    this.phrase = phrase
+    this.setPhrase(phrase)
     this.bncClient = new BncClient(this.getClientUrl())
     this.bncClient.chooseNetwork(network)
   }

--- a/packages/xchain-binance/src/client.ts
+++ b/packages/xchain-binance/src/client.ts
@@ -242,10 +242,9 @@ class Client implements BinanceClient, XChainClient {
    * @param {Asset} asset If not set, it will return all assets available. (optional)
    * @returns {Array<Balance>} The balance of the address.
    */
-  getBalance = async (address: Address | number = 0, assets?: Asset[]): Promise<Balances> => {
+  getBalance = async (address: Address, assets?: Asset[]): Promise<Balances> => {
     try {
-      const derivedAddress: string = typeof address === 'number' ? this.getAddress(address) : address || ''
-      const balances: BinanceBalances = await this.bncClient.getBalance(derivedAddress)
+      const balances: BinanceBalances = await this.bncClient.getBalance(address)
 
       return balances
         .map((balance) => {
@@ -312,10 +311,8 @@ class Client implements BinanceClient, XChainClient {
    */
   getTransactions = async (params?: TxHistoryParams): Promise<TxsPage> => {
     try {
-      const address: string =
-        typeof params?.address === 'number' ? this.getAddress(params.address) : params?.address || ''
       return await this.searchTransactions({
-        address,
+        address: params?.address.toString(),
         limit: params && params.limit?.toString(),
         offset: params && params.offset?.toString(),
         startTime: params && params.startTime && params.startTime.getTime().toString(),

--- a/packages/xchain-binance/src/client.ts
+++ b/packages/xchain-binance/src/client.ts
@@ -232,7 +232,7 @@ class Client implements BinanceClient, XChainClient {
 
       this.privateKey = crypto.getPrivateKeyFromMnemonic(
         this.phrase,
-        this.derivationPath ? true : false,
+        this.derivationPath && true || undefined,
         this.derivationPath,
       )
     }

--- a/packages/xchain-binance/src/client.ts
+++ b/packages/xchain-binance/src/client.ts
@@ -203,7 +203,7 @@ class Client implements BinanceClient, XChainClient {
    * Thrown if the given phase is invalid.
    */
   setPhrase = (phrase: string, derivationPath?: number): Address => {
-    if (!this.phrase || this.phrase !== phrase) {
+    if (!this.phrase || this.phrase !== phrase || this.derivationPath !== derivationPath) {
       if (!xchainCrypto.validatePhrase(phrase)) {
         throw new Error('Invalid phrase')
       }
@@ -232,7 +232,7 @@ class Client implements BinanceClient, XChainClient {
 
       this.privateKey = crypto.getPrivateKeyFromMnemonic(
         this.phrase,
-        this.derivationPath && true || undefined,
+        (this.derivationPath && true) || undefined,
         this.derivationPath,
       )
     }

--- a/packages/xchain-bitcoin/CHANGELOG.md
+++ b/packages/xchain-bitcoin/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.14.0 (2021-05-17)
+
+### Breaking change
+
+- added support for HD wallets
+
 # v.0.13.0 (2021-05-05)
 
 ### Breaking change

--- a/packages/xchain-bitcoin/__tests__/client.test.ts
+++ b/packages/xchain-bitcoin/__tests__/client.test.ts
@@ -88,7 +88,7 @@ describe('BitcoinClient Test', () => {
   it('should purge phrase and utxos', async () => {
     btcClient.purgeClient()
     expect(() => btcClient.getAddress()).toThrow('Phrase must be provided')
-    return expect(btcClient.getBalance(btcClient.getAddress())).rejects.toThrow('Phrase must be provided')
+    // return expect(btcClient.getBalance(btcClient.getAddress())).rejects.toThrow('Phrase must be provided')
   })
 
   it('should do broadcast a vault transfer with a memo', async () => {
@@ -109,13 +109,6 @@ describe('BitcoinClient Test', () => {
       console.log('ERR running test', err)
       throw err
     }
-  })
-
-  it('should NOT get the balance of an address without phrase', async () => {
-    btcClient.setNetwork('testnet')
-    btcClient.purgeClient()
-    const expectedError = 'Phrase must be provided'
-    return expect(btcClient.getBalance(btcClient.getAddress())).rejects.toThrow(expectedError)
   })
 
   it('should prevent a tx when fees and valueOut exceed balance', async () => {
@@ -204,7 +197,7 @@ describe('BitcoinClient Test', () => {
     btcClient.setPhrase(phraseOne)
     const invalidIndex = -1
     const expectedError = 'index must be greater than zero'
-    return expect(btcClient.getBalance(btcClient.getAddress(invalidIndex))).rejects.toThrow(expectedError)
+    expect(() => btcClient.getAddress(invalidIndex)).toThrow(expectedError)
   })
 
   it('should error when an invalid address is used in transfer', () => {

--- a/packages/xchain-bitcoin/__tests__/client.test.ts
+++ b/packages/xchain-bitcoin/__tests__/client.test.ts
@@ -88,7 +88,6 @@ describe('BitcoinClient Test', () => {
   it('should purge phrase and utxos', async () => {
     btcClient.purgeClient()
     expect(() => btcClient.getAddress()).toThrow('Phrase must be provided')
-    // return expect(btcClient.getBalance(btcClient.getAddress())).rejects.toThrow('Phrase must be provided')
   })
 
   it('should do broadcast a vault transfer with a memo', async () => {
@@ -109,6 +108,13 @@ describe('BitcoinClient Test', () => {
       console.log('ERR running test', err)
       throw err
     }
+  })
+  it('should get the balance of an address without phrase', async () => {
+    btcClient.setNetwork('testnet')
+    btcClient.purgeClient()
+    const balance = await btcClient.getBalance(addyThreePath0)
+    expect(balance.length).toEqual(1)
+    expect(balance[0].amount.amount().toNumber()).toEqual(15446)
   })
 
   it('should prevent a tx when fees and valueOut exceed balance', async () => {

--- a/packages/xchain-bitcoin/__tests__/client.test.ts
+++ b/packages/xchain-bitcoin/__tests__/client.test.ts
@@ -64,7 +64,7 @@ describe('BitcoinClient Test', () => {
     const expectedBalance = 15446
     btcClient.setNetwork('testnet')
     btcClient.setPhrase(phraseTwo)
-    const balance = await btcClient.getBalance()
+    const balance = await btcClient.getBalance(0)
     expect(balance.length).toEqual(1)
     expect(balance[0].amount.amount().toNumber()).toEqual(expectedBalance)
   })
@@ -73,7 +73,7 @@ describe('BitcoinClient Test', () => {
     btcClient.setNetwork('testnet')
     btcClient.setPhrase(phraseOne)
     const amount = baseAmount(2223)
-    const txid = await btcClient.transfer({ asset: AssetBTC, recipient: addyTwo, amount, feeRate: 1 })
+    const txid = await btcClient.transfer({ from: 0, asset: AssetBTC, recipient: addyTwo, amount, feeRate: 1 })
     expect(txid).toEqual(expect.any(String))
   })
 
@@ -111,12 +111,11 @@ describe('BitcoinClient Test', () => {
     }
   })
 
-  it('should get the balance of an address without phrase', async () => {
+  it('should NOT get the balance of an address without phrase', async () => {
     btcClient.setNetwork('testnet')
     btcClient.purgeClient()
-    const balance = await btcClient.getBalance(addyThreePath0)
-    expect(balance.length).toEqual(1)
-    expect(balance[0].amount.amount().toNumber()).toEqual(15446)
+    const expectedError = 'Phrase must be provided'
+    return expect(btcClient.getBalance(0)).rejects.toThrow(expectedError)
   })
 
   it('should prevent a tx when fees and valueOut exceed balance', async () => {
@@ -203,9 +202,9 @@ describe('BitcoinClient Test', () => {
   it('should error when an invalid address is used in getting balance', () => {
     btcClient.setNetwork('testnet')
     btcClient.setPhrase(phraseOne)
-    const invalidAddress = 'error_address'
-    const expectedError = 'Invalid address'
-    return expect(btcClient.getBalance(invalidAddress)).rejects.toThrow(expectedError)
+    const invalidIndex = -1
+    const expectedError = 'index must be greater than zero'
+    return expect(btcClient.getBalance(invalidIndex)).rejects.toThrow(expectedError)
   })
 
   it('should error when an invalid address is used in transfer', () => {
@@ -290,22 +289,23 @@ describe('BitcoinClient Test', () => {
 
   it('should derivate the address correctly', () => {
     btcClient.setNetwork('mainnet')
-    btcClient.setPhrase(phraseOne, 0)
-    expect(btcClient.getAddress()).toEqual(phraseOneMainnet_path0)
-    btcClient.setPhrase(phraseOne, 1)
-    expect(btcClient.getAddress()).toEqual(phraseOneMainnet_path1)
-    btcClient.setPhrase(phraseTwo, 0)
-    expect(btcClient.getAddress()).toEqual(phraseTwoMainnet_path0)
-    btcClient.setPhrase(phraseTwo, 1)
-    expect(btcClient.getAddress()).toEqual(phraseTwoMainnet_path1)
+
+    btcClient.setPhrase(phraseOne)
+    expect(btcClient.getAddress(0)).toEqual(phraseOneMainnet_path0)
+    expect(btcClient.getAddress(1)).toEqual(phraseOneMainnet_path1)
+
+    btcClient.setPhrase(phraseTwo)
+    expect(btcClient.getAddress(0)).toEqual(phraseTwoMainnet_path0)
+    expect(btcClient.getAddress(1)).toEqual(phraseTwoMainnet_path1)
+
     btcClient.setNetwork('testnet')
-    btcClient.setPhrase(phraseOne, 0)
-    expect(btcClient.getAddress()).toEqual(addyOnePath0)
-    btcClient.setPhrase(phraseOne, 1)
-    expect(btcClient.getAddress()).toEqual(addyOnePath1)
-    btcClient.setPhrase(phraseTwo, 0)
-    expect(btcClient.getAddress()).toEqual(addyThreePath0)
-    btcClient.setPhrase(phraseTwo, 1)
-    expect(btcClient.getAddress()).toEqual(addyThreePath1)
+
+    btcClient.setPhrase(phraseOne)
+    expect(btcClient.getAddress(0)).toEqual(addyOnePath0)
+    expect(btcClient.getAddress(1)).toEqual(addyOnePath1)
+
+    btcClient.setPhrase(phraseTwo)
+    expect(btcClient.getAddress(0)).toEqual(addyThreePath0)
+    expect(btcClient.getAddress(1)).toEqual(addyThreePath1)
   })
 })

--- a/packages/xchain-bitcoin/__tests__/client.test.ts
+++ b/packages/xchain-bitcoin/__tests__/client.test.ts
@@ -64,7 +64,7 @@ describe('BitcoinClient Test', () => {
     const expectedBalance = 15446
     btcClient.setNetwork('testnet')
     btcClient.setPhrase(phraseTwo)
-    const balance = await btcClient.getBalance(0)
+    const balance = await btcClient.getBalance(btcClient.getAddress())
     expect(balance.length).toEqual(1)
     expect(balance[0].amount.amount().toNumber()).toEqual(expectedBalance)
   })
@@ -88,7 +88,7 @@ describe('BitcoinClient Test', () => {
   it('should purge phrase and utxos', async () => {
     btcClient.purgeClient()
     expect(() => btcClient.getAddress()).toThrow('Phrase must be provided')
-    return expect(btcClient.getBalance()).rejects.toThrow('Phrase must be provided')
+    return expect(btcClient.getBalance(btcClient.getAddress())).rejects.toThrow('Phrase must be provided')
   })
 
   it('should do broadcast a vault transfer with a memo', async () => {
@@ -115,7 +115,7 @@ describe('BitcoinClient Test', () => {
     btcClient.setNetwork('testnet')
     btcClient.purgeClient()
     const expectedError = 'Phrase must be provided'
-    return expect(btcClient.getBalance(0)).rejects.toThrow(expectedError)
+    return expect(btcClient.getBalance(btcClient.getAddress())).rejects.toThrow(expectedError)
   })
 
   it('should prevent a tx when fees and valueOut exceed balance', async () => {
@@ -204,7 +204,7 @@ describe('BitcoinClient Test', () => {
     btcClient.setPhrase(phraseOne)
     const invalidIndex = -1
     const expectedError = 'index must be greater than zero'
-    return expect(btcClient.getBalance(invalidIndex)).rejects.toThrow(expectedError)
+    return expect(btcClient.getBalance(btcClient.getAddress(invalidIndex))).rejects.toThrow(expectedError)
   })
 
   it('should error when an invalid address is used in transfer', () => {

--- a/packages/xchain-bitcoin/__tests__/client.test.ts
+++ b/packages/xchain-bitcoin/__tests__/client.test.ts
@@ -3,7 +3,6 @@ import { MIN_TX_FEE } from '../src/const'
 import { baseAmount, AssetBTC } from '@xchainjs/xchain-util'
 
 import mockSochainApi from '../__mocks__/sochain'
-import { getDerivePath } from '../src/utils'
 mockSochainApi.init()
 
 const btcClient = new Client({ network: 'mainnet', sochainUrl: 'https://sochain.com/api/v2' })
@@ -291,22 +290,22 @@ describe('BitcoinClient Test', () => {
 
   it('should derivate the address correctly', () => {
     btcClient.setNetwork('mainnet')
-    btcClient.setPhrase(phraseOne, getDerivePath(0).mainnet)
+    btcClient.setPhrase(phraseOne, 0)
     expect(btcClient.getAddress()).toEqual(phraseOneMainnet_path0)
-    btcClient.setPhrase(phraseOne, getDerivePath(1).mainnet)
+    btcClient.setPhrase(phraseOne, 1)
     expect(btcClient.getAddress()).toEqual(phraseOneMainnet_path1)
-    btcClient.setPhrase(phraseTwo, getDerivePath(0).mainnet)
+    btcClient.setPhrase(phraseTwo, 0)
     expect(btcClient.getAddress()).toEqual(phraseTwoMainnet_path0)
-    btcClient.setPhrase(phraseTwo, getDerivePath(1).mainnet)
+    btcClient.setPhrase(phraseTwo, 1)
     expect(btcClient.getAddress()).toEqual(phraseTwoMainnet_path1)
     btcClient.setNetwork('testnet')
-    btcClient.setPhrase(phraseOne, getDerivePath(0).testnet)
+    btcClient.setPhrase(phraseOne, 0)
     expect(btcClient.getAddress()).toEqual(addyOnePath0)
-    btcClient.setPhrase(phraseOne, getDerivePath(1).testnet)
+    btcClient.setPhrase(phraseOne, 1)
     expect(btcClient.getAddress()).toEqual(addyOnePath1)
-    btcClient.setPhrase(phraseTwo, getDerivePath(0).testnet)
+    btcClient.setPhrase(phraseTwo, 0)
     expect(btcClient.getAddress()).toEqual(addyThreePath0)
-    btcClient.setPhrase(phraseTwo, getDerivePath(1).testnet)
+    btcClient.setPhrase(phraseTwo, 1)
     expect(btcClient.getAddress()).toEqual(addyThreePath1)
   })
 })

--- a/packages/xchain-bitcoin/package.json
+++ b/packages/xchain-bitcoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-bitcoin",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Custom Bitcoin client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/bitcoinjs-lib": "^5.0.0",
     "@types/wif": "^2.0.1",
-    "@xchainjs/xchain-client": "^0.8.0",
+    "@xchainjs/xchain-client": "^0.9.0",
     "@xchainjs/xchain-util": "^0.2.7",
     "@xchainjs/xchain-crypto": "^0.2.3",
     "axios": "^0.21.0",
@@ -44,7 +44,7 @@
     "axios-mock-adapter": "^1.19.0"
   },
   "peerDependencies": {
-    "@xchainjs/xchain-client": "^0.8.0",
+    "@xchainjs/xchain-client": "^0.9.0",
     "@xchainjs/xchain-util": "^0.2.7",
     "@xchainjs/xchain-crypto": "^0.2.3",
     "axios": "^0.21.0",

--- a/packages/xchain-bitcoin/src/client.ts
+++ b/packages/xchain-bitcoin/src/client.ts
@@ -275,9 +275,8 @@ class Client implements BitcoinClient, XChainClient {
    * @param {number} index By default, it will return the balance of the 0th address
    * @returns {Array<Balance>} The BTC balance of the address.
    */
-  getBalance = async (index = 0): Promise<Balance[]> => {
+  getBalance = async (address: Address): Promise<Balance[]> => {
     try {
-      const address: Address = this.getAddress(index)
       return Utils.getBalance({
         sochainUrl: this.sochainUrl,
         network: this.net,
@@ -301,12 +300,10 @@ class Client implements BitcoinClient, XChainClient {
     const limit = params?.limit || 10
 
     try {
-      const address = typeof params?.address === 'number' ? this.getAddress(params.address) : params?.address + ''
-
       const response = await sochain.getAddress({
+        address: params?.address + '',
         sochainUrl: this.sochainUrl,
         network: this.net,
-        address,
       })
       const total = response.txs.length
       const transactions: Tx[] = []

--- a/packages/xchain-bitcoin/src/client.ts
+++ b/packages/xchain-bitcoin/src/client.ts
@@ -60,7 +60,6 @@ class Client implements BitcoinClient, XChainClient {
     phrase,
   }: BitcoinClientParams) {
     this.net = network
-    // this.rootDerivationPaths = this.fixRootPAths(rootDerivationPaths)
     this.rootDerivationPaths = rootDerivationPaths
     this.setSochainUrl(sochainUrl)
     this.setBlockstreamUrl(blockstreamUrl)
@@ -96,10 +95,10 @@ class Client implements BitcoinClient, XChainClient {
    * @throws {"Invalid phrase"}
    * Thrown if the given phase is invalid.
    */
-  setPhrase = (phrase: string): Address => {
+  setPhrase = (phrase: string, walletIndex = 0): Address => {
     if (validatePhrase(phrase)) {
       this.phrase = phrase
-      return this.getAddress(0)
+      return this.getAddress(walletIndex)
     } else {
       throw new Error('Invalid phrase')
     }
@@ -196,7 +195,7 @@ class Client implements BitcoinClient, XChainClient {
     if (index < 0) {
       throw new Error('index must be greater than zero')
     }
-    if (this.phrase !== '') {
+    if (this.phrase) {
       const btcNetwork = Utils.btcNetwork(this.net)
       const btcKeys = this.getBtcKeys(this.phrase, index)
 
@@ -247,7 +246,7 @@ class Client implements BitcoinClient, XChainClient {
   /**
    * Get the BTC balance of a given address.
    *
-   * @param {number} index By default, it will return the balance of the 0th address
+   * @param {Address} addres the BTC address
    * @returns {Array<Balance>} The BTC balance of the address.
    */
   getBalance = async (address: Address): Promise<Balance[]> => {

--- a/packages/xchain-bitcoin/src/client.ts
+++ b/packages/xchain-bitcoin/src/client.ts
@@ -23,7 +23,6 @@ import { FeesWithRates, FeeRate, FeeRates } from './types/client-types'
  * BitcoinClient Interface
  */
 interface BitcoinClient {
-  // derivePath(): string
   getFeesWithRates(memo?: string): Promise<FeesWithRates>
   getFeesWithMemo(memo: string): Promise<Fees>
   getFeeRates(): Promise<FeeRates>
@@ -55,33 +54,18 @@ class Client implements BitcoinClient, XChainClient {
     sochainUrl = 'https://sochain.com/api/v2',
     blockstreamUrl = 'https://blockstream.info',
     rootDerivationPaths = {
-      mainnet: `m/44'/84'/0'/0'/0/`,
-      testnet: `m/44'/84'/1'/0'/0/`,
+      mainnet: `84'/0'/0'/0/`, //note this isn't bip44 compliant, but it keeps the wallets generated compatible to pre HD wallets
+      testnet: `84'/1'/0'/0/`,
     },
     phrase,
   }: BitcoinClientParams) {
     this.net = network
-    this.rootDerivationPaths = this.fixRootPAths(rootDerivationPaths)
+    // this.rootDerivationPaths = this.fixRootPAths(rootDerivationPaths)
+    this.rootDerivationPaths = rootDerivationPaths
     this.setSochainUrl(sochainUrl)
     this.setBlockstreamUrl(blockstreamUrl)
     phrase && this.setPhrase(phrase)
   }
-
-  fixRootPAths(rootDerivationPaths: RootDerivationPaths) {
-    // for some reason the librarydoesn like the m/44' prefix, so if anyone passes that in we strip it
-    return {
-      mainnet: rootDerivationPaths.mainnet.replace("m/44'/", ''),
-      testnet: rootDerivationPaths.testnet.replace("m/44'/", ''),
-    }
-  }
-  // /**
-  //  * Get the default sochain url.
-  //  *
-  //  * @returns {string} the default sochain url
-  //  */
-  // getDefaultSochainUrl = (): string => {
-  //   return 'https://sochain.com/api/v2'
-  // }
 
   /**
    * Set/Update the sochain url.
@@ -92,15 +76,6 @@ class Client implements BitcoinClient, XChainClient {
   setSochainUrl = (url: string): void => {
     this.sochainUrl = url
   }
-
-  // /**
-  //  * Get the default blockstream url.
-  //  *
-  //  * @returns {string} the default blockstream url
-  //  */
-  // getDefaultBlockstreamUrl = (): string => {
-  //   return 'https://blockstream.info'
-  // }
 
   /**
    * Set/Update the blockstream url.

--- a/packages/xchain-bitcoin/src/client.ts
+++ b/packages/xchain-bitcoin/src/client.ts
@@ -145,8 +145,6 @@ class Client implements BitcoinClient, XChainClient {
    * @returns {string} The bitcoin derivation path based on the network.
    */
   getFullDerivationPath(index: number): string {
-    // for some reason the bitcoinjs lib doesnt like the full path
-
     return this.rootDerivationPaths[this.net] + `${index}`
   }
 

--- a/packages/xchain-bitcoin/src/client.ts
+++ b/packages/xchain-bitcoin/src/client.ts
@@ -221,7 +221,7 @@ class Client implements BitcoinClient, XChainClient {
     if (index < 0) {
       throw new Error('index must be greater than zero')
     }
-    if (this.phrase) {
+    if (this.phrase !== '') {
       const btcNetwork = Utils.btcNetwork(this.net)
       const btcKeys = this.getBtcKeys(this.phrase, index)
 

--- a/packages/xchain-bitcoin/src/index.ts
+++ b/packages/xchain-bitcoin/src/index.ts
@@ -2,7 +2,7 @@ export * from './types'
 export * from './client'
 export {
   broadcastTx,
-  getDerivePath,
+  // getDerivePath,
   getDefaultFees,
   getDefaultFeesWithRates,
   getPrefix,

--- a/packages/xchain-bitcoin/src/index.ts
+++ b/packages/xchain-bitcoin/src/index.ts
@@ -2,7 +2,6 @@ export * from './types'
 export * from './client'
 export {
   broadcastTx,
-  // getDerivePath,
   getDefaultFees,
   getDefaultFeesWithRates,
   getPrefix,

--- a/packages/xchain-bitcoin/src/utils.ts
+++ b/packages/xchain-bitcoin/src/utils.ts
@@ -252,30 +252,6 @@ export const broadcastTx = async ({ network, txHex, blockstreamUrl }: BroadcastT
   return await blockStream.broadcastTx({ network, txHex, blockstreamUrl })
 }
 
-// /**
-//  * Get DerivePath.
-//  *
-//  * @param {number} index (optional)
-//  * @returns {DerivePath} The bitcoin derivation path by the index. (both mainnet and testnet)
-//  */
-// export const getDerivePath = (index = 0): DerivePath => ({
-//   mainnet: `84'/0'/0'/0/${index}`,
-//   testnet: `84'/1'/0'/0/${index}`,
-// })
-
-// /**
-//  * Get default root paths
-//  * @param {Network} network
-//  * @returns default root path
-//  */
-// export const getRootPath = (net: Network): string => {
-//   const rootPaths = {
-//     mainnet: `84'/0'/0'/0/`,
-//     testnet: `84'/1'/0'/0/`,
-//   }
-//   return rootPaths[net]
-// }
-
 /**
  * Calculate fees based on fee rate and memo.
  *

--- a/packages/xchain-bitcoin/src/utils.ts
+++ b/packages/xchain-bitcoin/src/utils.ts
@@ -5,7 +5,7 @@ import { Address, Balance, Fees, Network, TxHash, TxParams } from '@xchainjs/xch
 import { assetAmount, AssetBTC, assetToBase, assetToString, BaseAmount, baseAmount } from '@xchainjs/xchain-util'
 import { AddressParams, BtcAddressUTXOs } from './types/sochain-api-types'
 import { FeeRate, FeeRates, FeesWithRates, GetChangeParams } from './types/client-types'
-import { BroadcastTxParams, DerivePath, UTXO, UTXOs } from './types/common'
+import { BroadcastTxParams, UTXO, UTXOs } from './types/common'
 import { MIN_TX_FEE } from './const'
 
 const TX_EMPTY_SIZE = 4 + 1 + 1 + 4 //10
@@ -252,29 +252,29 @@ export const broadcastTx = async ({ network, txHex, blockstreamUrl }: BroadcastT
   return await blockStream.broadcastTx({ network, txHex, blockstreamUrl })
 }
 
-/**
- * Get DerivePath.
- *
- * @param {number} index (optional)
- * @returns {DerivePath} The bitcoin derivation path by the index. (both mainnet and testnet)
- */
-export const getDerivePath = (index = 0): DerivePath => ({
-  mainnet: `84'/0'/0'/0/${index}`,
-  testnet: `84'/1'/0'/0/${index}`,
-})
+// /**
+//  * Get DerivePath.
+//  *
+//  * @param {number} index (optional)
+//  * @returns {DerivePath} The bitcoin derivation path by the index. (both mainnet and testnet)
+//  */
+// export const getDerivePath = (index = 0): DerivePath => ({
+//   mainnet: `84'/0'/0'/0/${index}`,
+//   testnet: `84'/1'/0'/0/${index}`,
+// })
 
-/**
- * Get default root paths
- * @param {Network} network
- * @returns default root path
- */
-export const getRootPath = (net: Network): string => {
-  const rootPaths = {
-    mainnet: `84'/0'/0'/0/`,
-    testnet: `84'/1'/0'/0/`,
-  }
-  return rootPaths[net]
-}
+// /**
+//  * Get default root paths
+//  * @param {Network} network
+//  * @returns default root path
+//  */
+// export const getRootPath = (net: Network): string => {
+//   const rootPaths = {
+//     mainnet: `84'/0'/0'/0/`,
+//     testnet: `84'/1'/0'/0/`,
+//   }
+//   return rootPaths[net]
+// }
 
 /**
  * Calculate fees based on fee rate and memo.

--- a/packages/xchain-bitcoin/src/utils.ts
+++ b/packages/xchain-bitcoin/src/utils.ts
@@ -264,6 +264,19 @@ export const getDerivePath = (index = 0): DerivePath => ({
 })
 
 /**
+ * Get default root paths
+ * @param {Network} network
+ * @returns default root path
+ */
+export const getRootPath = (net: Network): string => {
+  const rootPaths = {
+    mainnet: `84'/0'/0'/0/`,
+    testnet: `84'/1'/0'/0/`,
+  }
+  return rootPaths[net]
+}
+
+/**
  * Calculate fees based on fee rate and memo.
  *
  * @param {FeeRate} feeRate

--- a/packages/xchain-bitcoincash/CHANGELOG.md
+++ b/packages/xchain-bitcoincash/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.10.0 (2021-05-17)
+
+### Breaking change
+
+- added support for HD wallets
+
 # v.0.9.0 (2021-05-05)
 
 ### Breaking change

--- a/packages/xchain-bitcoincash/__tests__/client.test.ts
+++ b/packages/xchain-bitcoincash/__tests__/client.test.ts
@@ -100,7 +100,7 @@ describe('BCHClient Test', () => {
       unconfirmed: 0,
       confirmed: 0,
     })
-    const balance = await bchClient.getBalance()
+    const balance = await bchClient.getBalance(bchClient.getAddress())
     expect(balance.length).toEqual(1)
     expect(balance[0].amount.amount().toNumber()).toEqual(0)
   })
@@ -117,7 +117,7 @@ describe('BCHClient Test', () => {
       unconfirmed: 100000000000,
       confirmed: 123817511737,
     })
-    const balance = await bchClient.getBalance(0)
+    const balance = await bchClient.getBalance(bchClient.getAddress())
     expect(balance.length).toEqual(1)
     expect(balance[0].amount.amount().isEqualTo('223817511737')).toBeTruthy()
   })

--- a/packages/xchain-bitcoincash/__tests__/client.test.ts
+++ b/packages/xchain-bitcoincash/__tests__/client.test.ts
@@ -9,7 +9,7 @@ import {
   mock_getUnspents,
 } from '../__mocks__/api'
 import { baseAmount } from '@xchainjs/xchain-util'
-import { BCH_DECIMAL } from '../src/utils'
+import { BCH_DECIMAL, getDerivePath } from '../src/utils'
 
 const bchClient = new Client({ network: 'mainnet' })
 
@@ -19,16 +19,40 @@ describe('BCHClient Test', () => {
 
   const MEMO = 'SWAP:THOR.RUNE'
   const phrase = 'atom green various power must another rent imitate gadget creek fat then'
-  const testnet_address = 'motwRaFk6Dj1FroSATNNLWYfYQHiz8z1oi'
-  const mainnet_address = '1Anw7uzLwXxBykMLeKb2BPAyTKsSfVDA8A'
+  const testnet_address_path0 = 'motwRaFk6Dj1FroSATNNLWYfYQHiz8z1oi'
+  const testnet_address_path1 = 'n37RAZYoe55EMMKGwxdC66Wv88BN2buYsf'
+  const mainnet_address_path0 = '1Anw7uzLwXxBykMLeKb2BPAyTKsSfVDA8A'
+  const mainnet_address_path1 = '1NSGMPxARx2Y1qaX2JxiHEFCuYP3f1NFGf'
 
   it('set phrase should return correct address', () => {
     bchClient.setNetwork('testnet')
-    expect(bchClient.setPhrase(phrase)).toEqual(testnet_address)
+    expect(bchClient.setPhrase(phrase)).toEqual(testnet_address_path0)
 
     bchClient.setNetwork('mainnet')
-    expect(bchClient.setPhrase(phrase)).toEqual(mainnet_address)
+    expect(bchClient.setPhrase(phrase)).toEqual(mainnet_address_path0)
   })
+
+  it('set phrase with derivation path should return correct address', () => {
+    bchClient.setNetwork('testnet')
+    expect(bchClient.setPhrase(phrase, getDerivePath(0).testnet)).toEqual(testnet_address_path0)
+
+    bchClient.setNetwork('mainnet')
+    expect(bchClient.setPhrase(phrase, getDerivePath(0).mainnet)).toEqual(mainnet_address_path0)
+
+    bchClient.setNetwork('testnet')
+    expect(bchClient.setPhrase(phrase, getDerivePath(1).testnet)).toEqual(testnet_address_path1)
+
+    const otherBchPath1Test = new Client({phrase, network: 'testnet', derivationPath: "m/44'/1'/0'/0/1"})
+    expect(otherBchPath1Test.getAddress()).toEqual(testnet_address_path1)
+
+    bchClient.setNetwork('mainnet')
+    expect(bchClient.setPhrase(phrase, getDerivePath(1).mainnet)).toEqual(mainnet_address_path1)
+
+    const otherBchPath1TestM = new Client({phrase, network: 'mainnet', derivationPath: "m/44'/145'/0'/0/1"})
+    expect(otherBchPath1TestM.getAddress()).toEqual(mainnet_address_path1)
+  })
+
+
 
   it('should throw an error for setting a bad phrase', () => {
     expect(() => bchClient.setPhrase('cat')).toThrow()
@@ -41,11 +65,11 @@ describe('BCHClient Test', () => {
   it('should validate the right address', () => {
     bchClient.setNetwork('testnet')
     bchClient.setPhrase(phrase)
-    expect(bchClient.getAddress()).toEqual(testnet_address)
-    expect(bchClient.validateAddress(testnet_address)).toBeTruthy()
+    expect(bchClient.getAddress()).toEqual(testnet_address_path0)
+    expect(bchClient.validateAddress(testnet_address_path0)).toBeTruthy()
 
     bchClient.setNetwork('mainnet')
-    expect(bchClient.validateAddress(mainnet_address)).toBeTruthy()
+    expect(bchClient.validateAddress(mainnet_address_path0)).toBeTruthy()
   })
 
   it('should return valid explorer url', () => {

--- a/packages/xchain-bitcoincash/__tests__/client.test.ts
+++ b/packages/xchain-bitcoincash/__tests__/client.test.ts
@@ -9,7 +9,7 @@ import {
   mock_getUnspents,
 } from '../__mocks__/api'
 import { baseAmount } from '@xchainjs/xchain-util'
-import { BCH_DECIMAL, getDerivePath } from '../src/utils'
+import { BCH_DECIMAL } from '../src/utils'
 
 const bchClient = new Client({ network: 'mainnet' })
 
@@ -34,25 +34,23 @@ describe('BCHClient Test', () => {
 
   it('set phrase with derivation path should return correct address', () => {
     bchClient.setNetwork('testnet')
-    expect(bchClient.setPhrase(phrase, getDerivePath(0).testnet)).toEqual(testnet_address_path0)
+    expect(bchClient.setPhrase(phrase)).toEqual(testnet_address_path0)
 
     bchClient.setNetwork('mainnet')
-    expect(bchClient.setPhrase(phrase, getDerivePath(0).mainnet)).toEqual(mainnet_address_path0)
+    expect(bchClient.setPhrase(phrase)).toEqual(mainnet_address_path0)
 
     bchClient.setNetwork('testnet')
-    expect(bchClient.setPhrase(phrase, getDerivePath(1).testnet)).toEqual(testnet_address_path1)
+    expect(bchClient.setPhrase(phrase, 1)).toEqual(testnet_address_path1)
 
-    const otherBchPath1Test = new Client({phrase, network: 'testnet', derivationPath: "m/44'/1'/0'/0/1"})
+    const otherBchPath1Test = new Client({ phrase, network: 'testnet', rootPath: "m/44'/1'/0'/0/", index: 1 })
     expect(otherBchPath1Test.getAddress()).toEqual(testnet_address_path1)
 
     bchClient.setNetwork('mainnet')
-    expect(bchClient.setPhrase(phrase, getDerivePath(1).mainnet)).toEqual(mainnet_address_path1)
+    expect(bchClient.setPhrase(phrase, 1)).toEqual(mainnet_address_path1)
 
-    const otherBchPath1TestM = new Client({phrase, network: 'mainnet', derivationPath: "m/44'/145'/0'/0/1"})
+    const otherBchPath1TestM = new Client({ phrase, network: 'mainnet', rootPath: "m/44'/145'/0'/0/", index: 1 })
     expect(otherBchPath1TestM.getAddress()).toEqual(mainnet_address_path1)
   })
-
-
 
   it('should throw an error for setting a bad phrase', () => {
     expect(() => bchClient.setPhrase('cat')).toThrow()

--- a/packages/xchain-bitcoincash/__tests__/client.test.ts
+++ b/packages/xchain-bitcoincash/__tests__/client.test.ts
@@ -35,21 +35,11 @@ describe('BCHClient Test', () => {
   it('set phrase with derivation path should return correct address', () => {
     bchClient.setNetwork('testnet')
     expect(bchClient.setPhrase(phrase)).toEqual(testnet_address_path0)
+    expect(bchClient.getAddress(1)).toEqual(testnet_address_path1)
 
     bchClient.setNetwork('mainnet')
     expect(bchClient.setPhrase(phrase)).toEqual(mainnet_address_path0)
-
-    bchClient.setNetwork('testnet')
-    expect(bchClient.setPhrase(phrase, 1)).toEqual(testnet_address_path1)
-
-    const otherBchPath1Test = new Client({ phrase, network: 'testnet', rootPath: "m/44'/1'/0'/0/", index: 1 })
-    expect(otherBchPath1Test.getAddress()).toEqual(testnet_address_path1)
-
-    bchClient.setNetwork('mainnet')
-    expect(bchClient.setPhrase(phrase, 1)).toEqual(mainnet_address_path1)
-
-    const otherBchPath1TestM = new Client({ phrase, network: 'mainnet', rootPath: "m/44'/145'/0'/0/", index: 1 })
-    expect(otherBchPath1TestM.getAddress()).toEqual(mainnet_address_path1)
+    expect(bchClient.getAddress(1)).toEqual(mainnet_address_path1)
   })
 
   it('should throw an error for setting a bad phrase', () => {

--- a/packages/xchain-bitcoincash/__tests__/client.test.ts
+++ b/packages/xchain-bitcoincash/__tests__/client.test.ts
@@ -109,7 +109,7 @@ describe('BCHClient Test', () => {
     bchClient.setNetwork('testnet')
     bchClient.setPhrase(phrase)
 
-    mock_getBalance(bchClient.getHaskoinURL(), 'qz35h5mfa8w2pqma2jq06lp7dnv5fxkp2svtllzmlf', {
+    mock_getBalance(bchClient.getHaskoinURL(), bchClient.getAddress(), {
       received: 123817511737,
       utxo: 1336,
       address: 'bchtest:qz35h5mfa8w2pqma2jq06lp7dnv5fxkp2svtllzmlf',
@@ -117,7 +117,7 @@ describe('BCHClient Test', () => {
       unconfirmed: 100000000000,
       confirmed: 123817511737,
     })
-    const balance = await bchClient.getBalance('qz35h5mfa8w2pqma2jq06lp7dnv5fxkp2svtllzmlf')
+    const balance = await bchClient.getBalance(0)
     expect(balance.length).toEqual(1)
     expect(balance[0].amount.amount().isEqualTo('223817511737')).toBeTruthy()
   })

--- a/packages/xchain-bitcoincash/package.json
+++ b/packages/xchain-bitcoincash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-bitcoincash",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Custom bitcoincash client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",
@@ -39,7 +39,7 @@
     "@psf/bitcoincashjs-lib": "^4.0.2",
     "@types/bchaddrjs": "0.4.0",
     "@types/uniqid": "^5.2.0",
-    "@xchainjs/xchain-client": "^0.8.0",
+    "@xchainjs/xchain-client": "^0.9.0",
     "@xchainjs/xchain-util": "^0.2.7",
     "@xchainjs/xchain-crypto": "^0.2.3",
     "axios": "^0.21.0",
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "@psf/bitcoincashjs-lib": "^4.0.2",
-    "@xchainjs/xchain-client": "^0.8.0",
+    "@xchainjs/xchain-client": "^0.9.0",
     "@xchainjs/xchain-util": "^0.2.7",
     "@xchainjs/xchain-crypto": "^0.2.3",
     "axios": "^0.21.0",

--- a/packages/xchain-bitcoincash/src/client.ts
+++ b/packages/xchain-bitcoincash/src/client.ts
@@ -135,10 +135,10 @@ class Client implements BitcoinCashClient, XChainClient {
    * @throws {"Invalid phrase"}
    * Thrown if the given phase is invalid.
    */
-  setPhrase = (phrase: string): Address => {
+  setPhrase = (phrase: string, walletIndex = 0): Address => {
     if (validatePhrase(phrase)) {
       this.phrase = phrase
-      return this.getAddress()
+      return this.getAddress(walletIndex)
     } else {
       throw new Error('Invalid phrase')
     }
@@ -225,10 +225,9 @@ class Client implements BitcoinCashClient, XChainClient {
       const rootSeed = getSeed(phrase)
       const masterHDNode = bitcash.HDNode.fromSeedBuffer(rootSeed, utils.bchNetwork(this.network))
 
-      const derive_path = derivationPath
-      return masterHDNode.derivePath(derive_path).keyPair
+      return masterHDNode.derivePath(derivationPath).keyPair
     } catch (error) {
-      throw new Error('Invalid phrase')
+      throw new Error(`Getting key pair failed: ${error?.message || error.toString()}`)
     }
   }
 

--- a/packages/xchain-bitcoincash/src/client.ts
+++ b/packages/xchain-bitcoincash/src/client.ts
@@ -245,8 +245,7 @@ class Client implements BitcoinCashClient, XChainClient {
   getAddress = (index = 0): Address => {
     if (this.phrase) {
       try {
-        const derivationPath = this.rootDerivationPaths[this.network] + `${index}`
-        const keys = this.getBCHKeys(this.phrase, derivationPath)
+        const keys = this.getBCHKeys(this.phrase, this.getFullDerivationPath(index))
         const address = keys.getAddress(index)
 
         return utils.toLegacyAddress(address)
@@ -256,6 +255,16 @@ class Client implements BitcoinCashClient, XChainClient {
     }
 
     throw new Error('Phrase must be provided')
+  }
+
+  /**
+   * Get getFullDerivationPath
+   *
+   * @param {number} index the HD wallet index
+   * @returns {string} The derivation path based on the network.
+   */
+  getFullDerivationPath(index: number): string {
+    return this.rootDerivationPaths[this.network] + `${index}`
   }
 
   /**

--- a/packages/xchain-bitcoincash/src/client.ts
+++ b/packages/xchain-bitcoincash/src/client.ts
@@ -35,6 +35,8 @@ type BitcoinCashClientParams = XChainClientParams & {
   haskoinUrl?: ClientUrl
   nodeUrl?: ClientUrl
   nodeAuth?: NodeAuth
+  rootPath?: string
+  index?: number
 }
 
 /**
@@ -43,7 +45,9 @@ type BitcoinCashClientParams = XChainClientParams & {
 class Client implements BitcoinCashClient, XChainClient {
   private network: Network
   private phrase = ''
-  private derivationPath: string =''
+  private rootPath = ''
+  private index = 0
+  private derivationPath = ''
   private haskoinUrl: ClientUrl
   private nodeUrl: ClientUrl
   private nodeAuth?: NodeAuth
@@ -69,17 +73,21 @@ class Client implements BitcoinCashClient, XChainClient {
       username: 'thorchain',
       password: 'password',
     },
-    derivationPath,
+    rootPath,
+    index = 0,
   }: BitcoinCashClientParams) {
     this.network = network
     this.haskoinUrl = haskoinUrl
     this.nodeUrl = nodeUrl
-    this.derivationPath = derivationPath || this.derivePath()
+    this.rootPath = rootPath || utils.getRootPath(network)
+    this.index = index
+    this.derivationPath = this.derivePath()
+    phrase && this.setPhrase(phrase, index)
     this.nodeAuth =
       // Leave possibility to send requests without auth info for user
       // by strictly passing nodeAuth as null value
       nodeAuth === null ? undefined : nodeAuth
-    phrase && this.setPhrase(phrase, this.derivationPath)
+    phrase && this.setPhrase(phrase, index)
   }
 
   /**
@@ -130,10 +138,11 @@ class Client implements BitcoinCashClient, XChainClient {
    * @throws {"Invalid phrase"}
    * Thrown if the given phase is invalid.
    */
-  setPhrase = (phrase: string, derivationPath?: string): Address => {
+  setPhrase = (phrase: string, index = 0): Address => {
     if (validatePhrase(phrase)) {
       this.phrase = phrase
-      this.derivationPath = derivationPath || this.derivePath()
+      this.index = index
+      this.derivationPath = this.derivePath()
       const address = this.getAddress()
       return address
     } else {
@@ -159,11 +168,13 @@ class Client implements BitcoinCashClient, XChainClient {
    * @throws {"Network must be provided"}
    * Thrown if network has not been set before.
    */
-  setNetwork = (network: Network): void => {
-    if (network) {
-      this.network = network
-    } else {
+  setNetwork = (net: Network): void => {
+    if (!net) {
       throw new Error('Network must be provided')
+    } else {
+      this.network = net
+      this.rootPath = utils.getRootPath(net)
+      this.derivationPath = this.derivePath()
     }
   }
 
@@ -182,7 +193,11 @@ class Client implements BitcoinCashClient, XChainClient {
    * @returns {string} The bitcoin cash derivation path based on the network.
    */
   derivePath(): string {
-    const { testnet, mainnet } = utils.getDerivePath()
+    // if rootPath is set
+    if (this.rootPath) {
+      return `${this.rootPath}${this.index}`
+    }
+    const { testnet, mainnet } = utils.getDerivePath(this.index)
     return utils.isTestnet(this.network) ? testnet : mainnet
   }
 
@@ -251,11 +266,11 @@ class Client implements BitcoinCashClient, XChainClient {
    * @throws {"Phrase must be provided"} Thrown if phrase has not been set before.
    * @throws {"Address not defined"} Thrown if failed creating account from phrase.
    */
-  getAddress = (): Address => {
+  getAddress = (index = 0): Address => {
     if (this.phrase) {
       try {
         const keys = this.getBCHKeys(this.phrase, this.derivationPath)
-        const address = keys.getAddress()
+        const address = keys.getAddress(index)
 
         return utils.toLegacyAddress(address)
       } catch (error) {

--- a/packages/xchain-bitcoincash/src/client.ts
+++ b/packages/xchain-bitcoincash/src/client.ts
@@ -26,7 +26,6 @@ import { broadcastTx } from './node-api'
  * BitcoinCashClient Interface
  */
 interface BitcoinCashClient {
-  // derivePath(): string
   getFeesWithRates(memo?: string): Promise<FeesWithRates>
   getFeesWithMemo(memo: string): Promise<Fees>
   getFeeRates(): Promise<FeeRates>
@@ -178,20 +177,6 @@ class Client implements BitcoinCashClient, XChainClient {
   getNetwork = (): Network => {
     return this.network
   }
-
-  // /**
-  //  * Get DerivePath
-  //  *
-  //  * @returns {string} The bitcoin cash derivation path based on the network.
-  //  */
-  // derivePath(): string {
-  //   // if rootPath is set
-  //   if (this.rootPath) {
-  //     return `${this.rootPath}${this.index}`
-  //   }
-  //   const { testnet, mainnet } = utils.getDerivePath(this.index)
-  //   return utils.isTestnet(this.network) ? testnet : mainnet
-  // }
 
   /**
    * Get the explorer url.

--- a/packages/xchain-bitcoincash/src/client.ts
+++ b/packages/xchain-bitcoincash/src/client.ts
@@ -292,8 +292,7 @@ class Client implements BitcoinCashClient, XChainClient {
    *
    * @throws {"Invalid address"} Thrown if the given address is an invalid address.
    */
-  getBalance = async (index = 0): Promise<Balance[]> => {
-    const address = this.getAddress(index)
+  getBalance = async (address: Address): Promise<Balance[]> => {
     return utils.getBalance({ haskoinUrl: this.getHaskoinURL(), address })
   }
 
@@ -308,14 +307,13 @@ class Client implements BitcoinCashClient, XChainClient {
    */
   getTransactions = async ({ address, offset, limit }: TxHistoryParams): Promise<TxsPage> => {
     try {
-      const theAddress = typeof address === 'number' ? this.getAddress(address) : address + ''
       offset = offset || 0
       limit = limit || 10
 
-      const account = await getAccount({ haskoinUrl: this.getHaskoinURL(), address: theAddress })
+      const account = await getAccount({ haskoinUrl: this.getHaskoinURL(), address })
       const txs = await getTransactions({
         haskoinUrl: this.getHaskoinURL(),
-        address: theAddress,
+        address,
         params: { offset, limit },
       })
 

--- a/packages/xchain-bitcoincash/src/types/bitcoincashjs-types.ts
+++ b/packages/xchain-bitcoincash/src/types/bitcoincashjs-types.ts
@@ -1,5 +1,5 @@
 export type KeyPair = {
-  getAddress(): string
+  getAddress(index: number): string
 }
 
 export type Transaction = {

--- a/packages/xchain-bitcoincash/src/utils.ts
+++ b/packages/xchain-bitcoincash/src/utils.ts
@@ -108,17 +108,6 @@ const getChange = async ({ valueOut, bchBalance }: GetChangeParams): Promise<num
   }
 }
 
-// /**
-//  * Get DerivePath.
-//  *
-//  * @param {number} index (optional)
-//  * @returns {DerivePath} The bitcoin cash derivation path by the index. (both mainnet and testnet)
-//  */
-// export const getDerivePath = (index = 0): DerivePath => ({
-//   mainnet: `m/44'/145'/0'/0/${index}`,
-//   testnet: `m/44'/1'/0'/0/${index}`,
-// })
-
 /**
  * Check if give network is a testnet.
  *

--- a/packages/xchain-bitcoincash/src/utils.ts
+++ b/packages/xchain-bitcoincash/src/utils.ts
@@ -5,7 +5,7 @@ import coininfo from 'coininfo'
 import { Address, Balance, Fees, Network, Tx, TxFrom, TxParams, TxTo } from '@xchainjs/xchain-client'
 import { AssetBCH, BaseAmount, baseAmount } from '@xchainjs/xchain-util/lib'
 import {
-  DerivePath,
+  // DerivePath,
   FeeRate,
   FeeRates,
   FeesWithRates,
@@ -108,16 +108,16 @@ const getChange = async ({ valueOut, bchBalance }: GetChangeParams): Promise<num
   }
 }
 
-/**
- * Get DerivePath.
- *
- * @param {number} index (optional)
- * @returns {DerivePath} The bitcoin cash derivation path by the index. (both mainnet and testnet)
- */
-export const getDerivePath = (index = 0): DerivePath => ({
-  mainnet: `m/44'/145'/0'/0/${index}`,
-  testnet: `m/44'/1'/0'/0/${index}`,
-})
+// /**
+//  * Get DerivePath.
+//  *
+//  * @param {number} index (optional)
+//  * @returns {DerivePath} The bitcoin cash derivation path by the index. (both mainnet and testnet)
+//  */
+// export const getDerivePath = (index = 0): DerivePath => ({
+//   mainnet: `m/44'/145'/0'/0/${index}`,
+//   testnet: `m/44'/1'/0'/0/${index}`,
+// })
 
 /**
  * Check if give network is a testnet.
@@ -358,17 +358,4 @@ export const getDefaultFeesWithRates = (): FeesWithRates => {
 export const getDefaultFees = (): Fees => {
   const { fees } = getDefaultFeesWithRates()
   return fees
-}
-
-/**
- * Get default root paths
- * @param {Network} network
- * @returns default root path
- */
-export const getRootPath = (net: Network): string => {
-  const rootPaths = {
-    mainnet: `m/44'/145'/0'/0/`,
-    testnet: `m/44'/1'/0'/0/`,
-  }
-  return rootPaths[net]
 }

--- a/packages/xchain-bitcoincash/src/utils.ts
+++ b/packages/xchain-bitcoincash/src/utils.ts
@@ -359,3 +359,16 @@ export const getDefaultFees = (): Fees => {
   const { fees } = getDefaultFeesWithRates()
   return fees
 }
+
+/**
+ * Get default root paths
+ * @param {Network} network
+ * @returns default root path
+ */
+export const getRootPath = (net: Network): string => {
+  const rootPaths = {
+    mainnet: `m/44'/145'/0'/0/`,
+    testnet: `m/44'/1'/0'/0/`,
+  }
+  return rootPaths[net]
+}

--- a/packages/xchain-bitcoincash/src/utils.ts
+++ b/packages/xchain-bitcoincash/src/utils.ts
@@ -4,17 +4,7 @@ import * as bchaddr from 'bchaddrjs'
 import coininfo from 'coininfo'
 import { Address, Balance, Fees, Network, Tx, TxFrom, TxParams, TxTo } from '@xchainjs/xchain-client'
 import { AssetBCH, BaseAmount, baseAmount } from '@xchainjs/xchain-util/lib'
-import {
-  // DerivePath,
-  FeeRate,
-  FeeRates,
-  FeesWithRates,
-  Transaction,
-  AddressParams,
-  GetChangeParams,
-  UTXOs,
-  UTXO,
-} from './types'
+import { FeeRate, FeeRates, FeesWithRates, Transaction, AddressParams, GetChangeParams, UTXOs, UTXO } from './types'
 import { getAccount, getRawTransaction, getUnspentTransactions } from './haskoin-api'
 import { Network as BCHNetwork, TransactionBuilder } from './types/bitcoincashjs-types'
 

--- a/packages/xchain-client/CHANGELOG.md
+++ b/packages/xchain-client/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.9.0 (2021-05-17)
+
+### Breaking change
+
+- added support for HD wallets
+
 # v.0.8.0 (2021-05-05)
 
 ### Breaking change

--- a/packages/xchain-client/package.json
+++ b/packages/xchain-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-client",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "MIT",
   "main": "lib/index",
   "types": "lib/index",

--- a/packages/xchain-client/src/types.ts
+++ b/packages/xchain-client/src/types.ts
@@ -99,7 +99,7 @@ export interface XChainClient {
 
   setPhrase(phrase: string): Address
 
-  getBalance(index: number, assets?: Asset[]): Promise<Balances>
+  getBalance(address: Address, assets?: Asset[]): Promise<Balances>
 
   getTransactions(params?: TxHistoryParams): Promise<TxsPage>
 

--- a/packages/xchain-client/src/types.ts
+++ b/packages/xchain-client/src/types.ts
@@ -95,9 +95,9 @@ export interface XChainClient {
   getExplorerTxUrl(txID: string): string
 
   validateAddress(address: string): boolean
-  getAddress(index: number): Address
+  getAddress(walletIndex: number): Address
 
-  setPhrase(phrase: string): Address
+  setPhrase(phrase: string, walletIndex: number): Address
 
   getBalance(address: Address, assets?: Asset[]): Promise<Balances>
 

--- a/packages/xchain-client/src/types.ts
+++ b/packages/xchain-client/src/types.ts
@@ -42,7 +42,7 @@ export type TxsPage = {
 }
 
 export type TxHistoryParams = {
-  address: Address | number // Address or HD index to get history for
+  address: Address // Address to get history for
   offset?: number // Optional Offset
   limit?: number // Optional Limit of transactions
   startTime?: Date // Optional start time

--- a/packages/xchain-client/src/types.ts
+++ b/packages/xchain-client/src/types.ts
@@ -77,7 +77,8 @@ export type Fees = FeeOption & {
 export type XChainClientParams = {
   network?: Network
   phrase?: string
-  derivationPath?: string
+  rootPath?: string;
+  index?: number;
 }
 
 export interface XChainClient {
@@ -91,7 +92,7 @@ export interface XChainClient {
   validateAddress(address: string): boolean
   getAddress(): Address
 
-  setPhrase(phrase: string): Address
+  setPhrase(phrase: string, index?: number): Address
 
   getBalance(address?: Address, assets?: Asset[]): Promise<Balances>
 

--- a/packages/xchain-client/src/types.ts
+++ b/packages/xchain-client/src/types.ts
@@ -27,7 +27,7 @@ export type TxFrom = {
 
 export type Tx = {
   asset: Asset // asset
-  from: TxFrom[] // list of "to" txs. BNC will have one `TxFrom` only, `BTC` might have many transactions going "in" (based on UTXO)
+  from: TxFrom[] // list of "from" txs. BNC will have one `TxFrom` only, `BTC` might have many transactions going "in" (based on UTXO)
   to: TxTo[] // list of "to" transactions. BNC will have one `TxTo` only, `BTC` might have many transactions going "out" (based on UTXO)
   date: Date // timestamp of tx
   type: TxType // type
@@ -42,7 +42,7 @@ export type TxsPage = {
 }
 
 export type TxHistoryParams = {
-  address: Address // Address to get history for
+  address: Address | number // Address or HD index to get history for
   offset?: number // Optional Offset
   limit?: number // Optional Limit of transactions
   startTime?: Date // Optional start time
@@ -50,6 +50,7 @@ export type TxHistoryParams = {
 }
 
 export type TxParams = {
+  from?: number // send from this HD index
   asset?: Asset
   amount: BaseAmount
   recipient: Address
@@ -74,11 +75,15 @@ export type Fees = FeeOption & {
   type: FeeType
 }
 
+export type RootDerivationPaths = {
+  mainnet: string
+  testnet: string
+}
+
 export type XChainClientParams = {
   network?: Network
   phrase?: string
-  rootPath?: string;
-  index?: number;
+  rootDerivationPaths?: RootDerivationPaths
 }
 
 export interface XChainClient {
@@ -90,11 +95,11 @@ export interface XChainClient {
   getExplorerTxUrl(txID: string): string
 
   validateAddress(address: string): boolean
-  getAddress(): Address
+  getAddress(index: number): Address
 
-  setPhrase(phrase: string, index?: number): Address
+  setPhrase(phrase: string): Address
 
-  getBalance(address?: Address, assets?: Asset[]): Promise<Balances>
+  getBalance(index: number, assets?: Asset[]): Promise<Balances>
 
   getTransactions(params?: TxHistoryParams): Promise<TxsPage>
 

--- a/packages/xchain-client/src/types.ts
+++ b/packages/xchain-client/src/types.ts
@@ -77,6 +77,7 @@ export type Fees = FeeOption & {
 export type XChainClientParams = {
   network?: Network
   phrase?: string
+  derivationPath?: string
 }
 
 export interface XChainClient {

--- a/packages/xchain-cosmos/CHANGELOG.md
+++ b/packages/xchain-cosmos/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.13.0 (2021-05-17)
+
+### Breaking change
+
+- added support for HD wallets
+
 # v.0.12.0 (2021-05-05)
 
 ### Breaking change

--- a/packages/xchain-cosmos/__tests__/client.test.ts
+++ b/packages/xchain-cosmos/__tests__/client.test.ts
@@ -81,6 +81,9 @@ describe('Client Test', () => {
     const cosmosClientEmptyTest = new Client({ phrase, network: 'testnet' })
     const addressTest = cosmosClientEmptyTest.getAddress()
     expect(addressTest).toEqual(address)
+
+    const addressTest1 = cosmosClientEmptyTest.getAddress(1)
+    expect(addressTest1).toEqual('cosmos1924f27fujxqnkt74u4d3ke3sfygugv9qp29hmk')
   })
 
   it('throws an error passing an invalid phrase', async () => {
@@ -126,7 +129,7 @@ describe('Client Test', () => {
   })
 
   it('has balances', async () => {
-    mockAccountsBalance(cosmosClient.getClientUrl(), 'cosmos1gehrq0pr5d79q8nxnaenvqh09g56jafm82thjv', {
+    mockAccountsBalance(cosmosClient.getClientUrl(), address, {
       height: 0,
       result: [
         {
@@ -135,8 +138,7 @@ describe('Client Test', () => {
         },
       ],
     })
-
-    const balances = await cosmosClient.getBalance('cosmos1gehrq0pr5d79q8nxnaenvqh09g56jafm82thjv')
+    const balances = await cosmosClient.getBalance(0)
     const expected = balances[0].amount.amount().isEqualTo(baseAmount(75000000, 6).amount())
     expect(expected).toBeTruthy()
     expect(balances[0].asset).toEqual(AssetMuon)
@@ -158,7 +160,7 @@ describe('Client Test', () => {
       txs: [],
     })
 
-    const transactions = await cosmosClient.getTransactions()
+    const transactions = await cosmosClient.getTransactions({ address: 0 })
     expect(transactions).toEqual(expected)
   })
 

--- a/packages/xchain-cosmos/__tests__/client.test.ts
+++ b/packages/xchain-cosmos/__tests__/client.test.ts
@@ -8,6 +8,10 @@ import { Client } from '../src/client'
 import { getDenom } from '../src/util'
 import { TxHistoryResponse, TxResponse } from '../src/cosmos/types'
 
+const getClientUrl = (client: Client): string => {
+  return client.getNetwork() === 'testnet' ? 'http://lcd.gaia.bigdipper.live:1317' : 'https://api.cosmos.network'
+}
+
 const mockAccountsAddress = (
   url: string,
   address: string,
@@ -119,7 +123,7 @@ describe('Client Test', () => {
   it('has no balances', async () => {
     cosmosClient.setNetwork('mainnet')
 
-    mockAccountsBalance(cosmosClient.getClientUrl(), address, {
+    mockAccountsBalance(getClientUrl(cosmosClient), address, {
       height: 0,
       result: [],
     })
@@ -129,7 +133,7 @@ describe('Client Test', () => {
   })
 
   it('has balances', async () => {
-    mockAccountsBalance(cosmosClient.getClientUrl(), address, {
+    mockAccountsBalance(getClientUrl(cosmosClient), 'cosmos1gehrq0pr5d79q8nxnaenvqh09g56jafm82thjv', {
       height: 0,
       result: [
         {
@@ -138,7 +142,7 @@ describe('Client Test', () => {
         },
       ],
     })
-    const balances = await cosmosClient.getBalance(address)
+    const balances = await cosmosClient.getBalance('cosmos1gehrq0pr5d79q8nxnaenvqh09g56jafm82thjv')
     const expected = balances[0].amount.amount().isEqualTo(baseAmount(75000000, 6).amount())
     expect(expected).toBeTruthy()
     expect(balances[0].asset).toEqual(AssetMuon)
@@ -151,7 +155,7 @@ describe('Client Test', () => {
       total: 0,
       txs: [],
     }
-    assertTxHstory(cosmosClient.getClientUrl(), address, {
+    assertTxHstory(getClientUrl(cosmosClient), address, {
       count: 0,
       limit: 30,
       page_number: 1,
@@ -165,7 +169,7 @@ describe('Client Test', () => {
   })
 
   it('has tx history', async () => {
-    assertTxHstory(cosmosClient.getClientUrl(), 'cosmos1xvt4e7xd0j9dwv2w83g50tpcltsl90h52003e2', {
+    assertTxHstory(getClientUrl(cosmosClient), 'cosmos1xvt4e7xd0j9dwv2w83g50tpcltsl90h52003e2', {
       count: 1,
       limit: 30,
       page_number: 1,
@@ -208,7 +212,7 @@ describe('Client Test', () => {
 
     cosmosClient.setNetwork('mainnet')
 
-    assertTxHstory(cosmosClient.getClientUrl(), 'cosmos1pjkpqxmvz47a5aw40l98fyktlg7k6hd9heq95z', {
+    assertTxHstory(getClientUrl(cosmosClient), 'cosmos1pjkpqxmvz47a5aw40l98fyktlg7k6hd9heq95z', {
       count: 1,
       limit: 30,
       page_number: 1,
@@ -262,7 +266,7 @@ describe('Client Test', () => {
       height: 0,
     }
 
-    mockAccountsAddress(cosmosClient.getClientUrl(), cosmosClient.getAddress(), {
+    mockAccountsAddress(getClientUrl(cosmosClient), cosmosClient.getAddress(), {
       height: 0,
       result: {
         coins: [
@@ -276,7 +280,7 @@ describe('Client Test', () => {
       },
     })
     assertTxsPost(
-      cosmosClient.getClientUrl(),
+      getClientUrl(cosmosClient),
       cosmosClient.getAddress(),
       to_address,
       [
@@ -302,7 +306,7 @@ describe('Client Test', () => {
   it('get transaction data', async () => {
     cosmosClient.setNetwork('mainnet')
 
-    assertTxHashGet(cosmosClient.getClientUrl(), '19BFC1E8EBB10AA1EC6B82E380C6F5FD349D367737EA8D55ADB4A24F0F7D1066', {
+    assertTxHashGet(getClientUrl(cosmosClient), '19BFC1E8EBB10AA1EC6B82E380C6F5FD349D367737EA8D55ADB4A24F0F7D1066', {
       height: 1047,
       txhash: '19BFC1E8EBB10AA1EC6B82E380C6F5FD349D367737EA8D55ADB4A24F0F7D1066',
       data: '0A090A076465706F736974',

--- a/packages/xchain-cosmos/__tests__/client.test.ts
+++ b/packages/xchain-cosmos/__tests__/client.test.ts
@@ -67,7 +67,11 @@ describe('Client Test', () => {
   let cosmosClient: Client
 
   const phrase = 'foster blouse cattle fiction deputy social brown toast various sock awkward print'
-  const address = 'cosmos16mzuy68a9xzqpsp88dt4f2tl0d49drhepn68fg'
+  const address0_mainnet = 'cosmos16mzuy68a9xzqpsp88dt4f2tl0d49drhepn68fg'
+  const address1_mainnet = 'cosmos1924f27fujxqnkt74u4d3ke3sfygugv9qp29hmk'
+
+  const address0_testnet = 'cosmos13hrqe0g38nqnjgnstkfrlm2zd790g5yegntshv'
+  const address1_testnet = 'cosmos1re8rf3sv2tkx88xx6825tjqtfntrrfj0h4u94u'
 
   beforeEach(() => {
     cosmosClient = new Client({ phrase, network: 'testnet' })
@@ -79,15 +83,12 @@ describe('Client Test', () => {
 
   it('should start with empty wallet', async () => {
     const cosmosClientEmptyMain = new Client({ phrase, network: 'mainnet' })
-    const addressMain = cosmosClientEmptyMain.getAddress()
-    expect(addressMain).toEqual(address)
+    expect(cosmosClientEmptyMain.getAddress()).toEqual(address0_mainnet)
+    expect(cosmosClientEmptyMain.getAddress(1)).toEqual(address1_mainnet)
 
     const cosmosClientEmptyTest = new Client({ phrase, network: 'testnet' })
-    const addressTest = cosmosClientEmptyTest.getAddress()
-    expect(addressTest).toEqual(address)
-
-    const addressTest1 = cosmosClientEmptyTest.getAddress(1)
-    expect(addressTest1).toEqual('cosmos1924f27fujxqnkt74u4d3ke3sfygugv9qp29hmk')
+    expect(cosmosClientEmptyTest.getAddress()).toEqual(address0_testnet)
+    expect(cosmosClientEmptyTest.getAddress(1)).toEqual(address1_testnet)
   })
 
   it('throws an error passing an invalid phrase', async () => {
@@ -101,7 +102,7 @@ describe('Client Test', () => {
   })
 
   it('should have right address', async () => {
-    expect(cosmosClient.getAddress()).toEqual(address)
+    expect(cosmosClient.getAddress()).toEqual(address0_testnet)
   })
 
   it('should update net', async () => {
@@ -123,12 +124,12 @@ describe('Client Test', () => {
   it('has no balances', async () => {
     cosmosClient.setNetwork('mainnet')
 
-    mockAccountsBalance(getClientUrl(cosmosClient), address, {
+    mockAccountsBalance(getClientUrl(cosmosClient), address0_mainnet, {
       height: 0,
       result: [],
     })
 
-    const result = await cosmosClient.getBalance(address)
+    const result = await cosmosClient.getBalance(address0_mainnet)
     expect(result).toEqual([])
   })
 
@@ -155,7 +156,7 @@ describe('Client Test', () => {
       total: 0,
       txs: [],
     }
-    assertTxHstory(getClientUrl(cosmosClient), address, {
+    assertTxHstory(getClientUrl(cosmosClient), address0_mainnet, {
       count: 0,
       limit: 30,
       page_number: 1,
@@ -164,7 +165,7 @@ describe('Client Test', () => {
       txs: [],
     })
 
-    const transactions = await cosmosClient.getTransactions({ address })
+    const transactions = await cosmosClient.getTransactions({ address: address0_mainnet })
     expect(transactions).toEqual(expected)
   })
 

--- a/packages/xchain-cosmos/__tests__/client.test.ts
+++ b/packages/xchain-cosmos/__tests__/client.test.ts
@@ -124,7 +124,7 @@ describe('Client Test', () => {
       result: [],
     })
 
-    const result = await cosmosClient.getBalance()
+    const result = await cosmosClient.getBalance(address)
     expect(result).toEqual([])
   })
 
@@ -138,7 +138,7 @@ describe('Client Test', () => {
         },
       ],
     })
-    const balances = await cosmosClient.getBalance(0)
+    const balances = await cosmosClient.getBalance(address)
     const expected = balances[0].amount.amount().isEqualTo(baseAmount(75000000, 6).amount())
     expect(expected).toBeTruthy()
     expect(balances[0].asset).toEqual(AssetMuon)
@@ -160,7 +160,7 @@ describe('Client Test', () => {
       txs: [],
     })
 
-    const transactions = await cosmosClient.getTransactions({ address: 0 })
+    const transactions = await cosmosClient.getTransactions({ address })
     expect(transactions).toEqual(expected)
   })
 

--- a/packages/xchain-cosmos/__tests__/sdk-client.test.ts
+++ b/packages/xchain-cosmos/__tests__/sdk-client.test.ts
@@ -63,7 +63,6 @@ describe('SDK Client Test', () => {
     server: 'https://api.cosmos.network',
     chainId: 'cosmoshub-3',
     prefix: 'cosmos',
-    network: 'mainnet',
   })
   const cosmosTestnetClient: CosmosSDKClient = new CosmosSDKClient({
     server: 'http://lcd.gaia.bigdipper.live:1317',
@@ -75,21 +74,12 @@ describe('SDK Client Test', () => {
     server: 'http://104.248.96.152:1317',
     chainId: 'thorchain',
     prefix: 'thor',
-    network: 'mainnet',
-    rootDerivationPaths: {
-      mainnet: "m/44'/931'/0'/0/",
-      testnet: "m/44'/931'/0'/0/",
-    },
   })
 
   const thorTestnetClient: CosmosSDKClient = new CosmosSDKClient({
     server: 'http://13.238.212.224:1317',
     chainId: 'thorchain',
     prefix: 'tthor',
-    rootDerivationPaths: {
-      mainnet: "m/44'/931'/0'/0/",
-      testnet: "m/44'/931'/0'/0/",
-    },
   })
 
   const cosmos_phrase = 'foster blouse cattle fiction deputy social brown toast various sock awkward print'
@@ -99,17 +89,28 @@ describe('SDK Client Test', () => {
   const thor_mainnet_address = 'thor19kacmmyuf2ysyvq3t9nrl9495l5cvktjs0yfws'
   const thor_testnet_address = 'tthor19kacmmyuf2ysyvq3t9nrl9495l5cvktj5c4eh4'
 
+  const derivationPaths = {
+    thor: {
+      mainnet: `m/44'/931'/0'/0/0`,
+      testnet: `m/44'/931'/0'/0/0`,
+    },
+    cosmos: {
+      mainnet: `44'/118'/0'/0/`,
+      testnet: `44'/118'/0'/0/`,
+    },
+  }
+
   it('getPrivKeyFromMnemonic -> getAddressFromPrivKey', async () => {
-    let privKey = cosmosMainnetClient.getPrivKeyFromMnemonic(cosmos_phrase)
+    let privKey = cosmosMainnetClient.getPrivKeyFromMnemonic(cosmos_phrase, derivationPaths.cosmos.mainnet + '0')
     expect(cosmosMainnetClient.getAddressFromPrivKey(privKey)).toEqual(cosmos_address)
 
-    let address = cosmosTestnetClient.getAddressFromMnemonic(cosmos_phrase)
+    let address = cosmosTestnetClient.getAddressFromMnemonic(cosmos_phrase, derivationPaths.cosmos.testnet + '0')
     expect(address).toEqual(cosmos_address)
 
-    address = thorMainnetClient.getAddressFromMnemonic(thor_phrase)
+    address = thorMainnetClient.getAddressFromMnemonic(thor_phrase, derivationPaths.thor.mainnet + '0')
     expect(address).toEqual(thor_mainnet_address)
 
-    privKey = thorTestnetClient.getPrivKeyFromMnemonic(thor_phrase)
+    privKey = thorTestnetClient.getPrivKeyFromMnemonic(thor_phrase, derivationPaths.thor.testnet + '0')
     expect(thorTestnetClient.getAddressFromPrivKey(privKey)).toEqual(thor_testnet_address)
   })
 
@@ -316,7 +317,7 @@ describe('SDK Client Test', () => {
     codec.registerCodec('cosmos-sdk/MsgMultiSend', MsgMultiSend, MsgMultiSend.fromJSON)
 
     const result = await cosmosTestnetClient.transfer({
-      privkey: cosmosTestnetClient.getPrivKeyFromMnemonic(cosmos_phrase),
+      privkey: cosmosTestnetClient.getPrivKeyFromMnemonic(cosmos_phrase, derivationPaths.cosmos.testnet + '0'),
       from: cosmos_address,
       to: 'cosmos1gehrq0pr5d79q8nxnaenvqh09g56jafm82thjv',
       amount: 10000,

--- a/packages/xchain-cosmos/__tests__/sdk-client.test.ts
+++ b/packages/xchain-cosmos/__tests__/sdk-client.test.ts
@@ -83,60 +83,95 @@ describe('SDK Client Test', () => {
   })
 
   const cosmos_phrase = 'foster blouse cattle fiction deputy social brown toast various sock awkward print'
-  const cosmos_address = 'cosmos16mzuy68a9xzqpsp88dt4f2tl0d49drhepn68fg'
+  const cosmos_mainnet_address0 = 'cosmos16mzuy68a9xzqpsp88dt4f2tl0d49drhepn68fg'
+  const cosmos_mainnet_address1 = 'cosmos1924f27fujxqnkt74u4d3ke3sfygugv9qp29hmk'
+
+  const cosmos_testnet_address0 = 'cosmos13hrqe0g38nqnjgnstkfrlm2zd790g5yegntshv'
+  const cosmos_testnet_address1 = 'cosmos1re8rf3sv2tkx88xx6825tjqtfntrrfj0h4u94u'
 
   const thor_phrase = 'rural bright ball negative already grass good grant nation screen model pizza'
-  const thor_mainnet_address = 'thor19kacmmyuf2ysyvq3t9nrl9495l5cvktjs0yfws'
-  const thor_testnet_address = 'tthor19kacmmyuf2ysyvq3t9nrl9495l5cvktj5c4eh4'
+  const thor_mainnet_address0 = 'thor19kacmmyuf2ysyvq3t9nrl9495l5cvktjs0yfws'
+  const thor_mainnet_address1 = 'thor1hrf34g3lxwvpk7gjte0xvahf3txnq8ecgaf4nc'
+
+  const thor_testnet_address0 = 'tthor19kacmmyuf2ysyvq3t9nrl9495l5cvktj5c4eh4'
+  const thor_testnet_address1 = 'tthor1hrf34g3lxwvpk7gjte0xvahf3txnq8ecv2c92a'
 
   const derivationPaths = {
     thor: {
-      mainnet: `m/44'/931'/0'/0/0`,
-      testnet: `m/44'/931'/0'/0/0`,
+      mainnet: `m/44'/931'/0'/0/`,
+      testnet: `m/44'/931'/0'/0/`,
     },
     cosmos: {
       mainnet: `44'/118'/0'/0/`,
-      testnet: `44'/118'/0'/0/`,
+      testnet: `44'/118'/1'/0/`,
     },
   }
 
   it('getPrivKeyFromMnemonic -> getAddressFromPrivKey', async () => {
-    let privKey = cosmosMainnetClient.getPrivKeyFromMnemonic(cosmos_phrase, derivationPaths.cosmos.mainnet + '0')
-    expect(cosmosMainnetClient.getAddressFromPrivKey(privKey)).toEqual(cosmos_address)
+    //Cosmos Mainnet
+    let privKeyMainnet0 = cosmosMainnetClient.getPrivKeyFromMnemonic(
+      cosmos_phrase,
+      derivationPaths.cosmos.mainnet + '0',
+    )
+    expect(cosmosMainnetClient.getAddressFromPrivKey(privKeyMainnet0)).toEqual(cosmos_mainnet_address0)
 
-    let address = cosmosTestnetClient.getAddressFromMnemonic(cosmos_phrase, derivationPaths.cosmos.testnet + '0')
-    expect(address).toEqual(cosmos_address)
+    let privKeyMainnet1 = cosmosMainnetClient.getPrivKeyFromMnemonic(
+      cosmos_phrase,
+      derivationPaths.cosmos.mainnet + '1',
+    )
+    expect(cosmosMainnetClient.getAddressFromPrivKey(privKeyMainnet1)).toEqual(cosmos_mainnet_address1)
 
-    address = thorMainnetClient.getAddressFromMnemonic(thor_phrase, derivationPaths.thor.mainnet + '0')
-    expect(address).toEqual(thor_mainnet_address)
+    //Cosmos testnet
+    let privKeyTestnet0 = cosmosTestnetClient.getPrivKeyFromMnemonic(
+      cosmos_phrase,
+      derivationPaths.cosmos.testnet + '0',
+    )
+    expect(cosmosTestnetClient.getAddressFromPrivKey(privKeyTestnet0)).toEqual(cosmos_testnet_address0)
 
-    privKey = thorTestnetClient.getPrivKeyFromMnemonic(thor_phrase, derivationPaths.thor.testnet + '0')
-    expect(thorTestnetClient.getAddressFromPrivKey(privKey)).toEqual(thor_testnet_address)
+    let privKeyTestnet1 = cosmosTestnetClient.getPrivKeyFromMnemonic(
+      cosmos_phrase,
+      derivationPaths.cosmos.testnet + '1',
+    )
+    expect(cosmosTestnetClient.getAddressFromPrivKey(privKeyTestnet1)).toEqual(cosmos_testnet_address1)
+
+    //Thor Mainnet
+    privKeyMainnet0 = thorMainnetClient.getPrivKeyFromMnemonic(thor_phrase, derivationPaths.thor.mainnet + '0')
+    expect(thorMainnetClient.getAddressFromPrivKey(privKeyMainnet0)).toEqual(thor_mainnet_address0)
+
+    privKeyMainnet1 = thorMainnetClient.getPrivKeyFromMnemonic(thor_phrase, derivationPaths.thor.mainnet + '1')
+    expect(thorMainnetClient.getAddressFromPrivKey(privKeyMainnet1)).toEqual(thor_mainnet_address1)
+
+    //thor testnet
+    privKeyTestnet0 = thorTestnetClient.getPrivKeyFromMnemonic(thor_phrase, derivationPaths.thor.testnet + '0')
+    expect(thorTestnetClient.getAddressFromPrivKey(privKeyTestnet0)).toEqual(thor_testnet_address0)
+
+    privKeyTestnet1 = thorTestnetClient.getPrivKeyFromMnemonic(thor_phrase, derivationPaths.thor.testnet + '1')
+    expect(thorTestnetClient.getAddressFromPrivKey(privKeyTestnet1)).toEqual(thor_testnet_address1)
   })
 
   it('checkAddress', async () => {
-    expect(cosmosMainnetClient.checkAddress(cosmos_address)).toBeTruthy()
-    expect(cosmosTestnetClient.checkAddress(cosmos_address)).toBeTruthy()
+    expect(cosmosMainnetClient.checkAddress(cosmos_mainnet_address0)).toBeTruthy()
+    expect(cosmosTestnetClient.checkAddress(cosmos_testnet_address0)).toBeTruthy()
     expect(cosmosMainnetClient.checkAddress('thor19kacmmyuf2ysyvq3t9nrl9495l5cvktjs0yfws')).toBeFalsy()
     expect(cosmosTestnetClient.checkAddress('tthor19kacmmyuf2ysyvq3t9nrl9495l5cvktj5c4eh4')).toBeFalsy()
 
-    expect(thorMainnetClient.checkAddress('thor19kacmmyuf2ysyvq3t9nrl9495l5cvktjs0yfws')).toBeTruthy()
-    expect(thorTestnetClient.checkAddress('tthor19kacmmyuf2ysyvq3t9nrl9495l5cvktj5c4eh4')).toBeTruthy()
-    expect(thorMainnetClient.checkAddress(cosmos_address)).toBeFalsy()
-    expect(thorTestnetClient.checkAddress(cosmos_address)).toBeFalsy()
+    expect(thorMainnetClient.checkAddress(thor_mainnet_address0)).toBeTruthy()
+    expect(thorTestnetClient.checkAddress(thor_testnet_address0)).toBeTruthy()
+    expect(thorMainnetClient.checkAddress(cosmos_mainnet_address0)).toBeFalsy()
+    expect(thorTestnetClient.checkAddress(cosmos_testnet_address0)).toBeFalsy()
     expect(thorMainnetClient.checkAddress('tthor19kacmmyuf2ysyvq3t9nrl9495l5cvktj5c4eh4')).toBeFalsy()
     expect(thorTestnetClient.checkAddress('thor19kacmmyuf2ysyvq3t9nrl9495l5cvktjs0yfws')).toBeFalsy()
   })
 
   it('getBalance', async () => {
-    mockAccountsBalance(cosmosMainnetClient.server, cosmos_address, {
+    mockAccountsBalance(cosmosMainnetClient.server, cosmos_mainnet_address0, {
       height: 0,
       result: [],
     })
-    let balances = await cosmosMainnetClient.getBalance(cosmos_address)
+    let balances = await cosmosMainnetClient.getBalance(cosmos_mainnet_address0)
     expect(balances).toEqual([])
 
-    mockAccountsBalance(cosmosTestnetClient.server, 'cosmos1gehrq0pr5d79q8nxnaenvqh09g56jafm82thjv', {
+    mockAccountsBalance(cosmosTestnetClient.server, cosmos_testnet_address0, {
       height: 0,
       result: [
         {
@@ -145,11 +180,12 @@ describe('SDK Client Test', () => {
         },
       ],
     })
-    balances = await cosmosTestnetClient.getBalance('cosmos1gehrq0pr5d79q8nxnaenvqh09g56jafm82thjv')
+
+    balances = await cosmosTestnetClient.getBalance(cosmos_testnet_address0)
     expect(parseInt(balances[0].amount || '0')).toEqual(75000000)
     expect(balances[0].denom).toEqual('umuon')
 
-    mockAccountsBalance(thorMainnetClient.server, thor_mainnet_address, {
+    mockAccountsBalance(thorMainnetClient.server, thor_mainnet_address0, {
       height: 0,
       result: [
         {
@@ -158,21 +194,21 @@ describe('SDK Client Test', () => {
         },
       ],
     })
-    balances = await thorMainnetClient.getBalance(thor_mainnet_address)
+    balances = await thorMainnetClient.getBalance(thor_mainnet_address0)
     expect(balances.length).toEqual(1)
     expect(balances[0].denom).toEqual('thor')
     expect(parseInt(balances[0].amount || '0')).toEqual(100)
 
-    mockAccountsBalance(thorTestnetClient.server, thor_testnet_address, {
+    mockAccountsBalance(thorTestnetClient.server, thor_testnet_address0, {
       height: 0,
       result: [],
     })
-    balances = await thorTestnetClient.getBalance(thor_testnet_address)
+    balances = await thorTestnetClient.getBalance(thor_testnet_address0)
     expect(balances).toEqual([])
   })
 
   it('searchTx', async () => {
-    assertTxHstory(cosmosMainnetClient.server, cosmos_address, {
+    assertTxHstory(cosmosMainnetClient.server, cosmos_mainnet_address0, {
       count: 0,
       limit: 30,
       page_number: 1,
@@ -180,7 +216,7 @@ describe('SDK Client Test', () => {
       total_count: 0,
       txs: [],
     })
-    let txHistory = await cosmosMainnetClient.searchTx({ messageSender: cosmos_address })
+    let txHistory = await cosmosMainnetClient.searchTx({ messageSender: cosmos_mainnet_address0 })
     expect(parseInt(txHistory.total_count?.toString() || '0')).toEqual(0)
 
     assertTxHstory(cosmosTestnetClient.server, 'cosmos1xvt4e7xd0j9dwv2w83g50tpcltsl90h52003e2', {
@@ -204,7 +240,7 @@ describe('SDK Client Test', () => {
                   type: 'cosmos-sdk/MsgSend',
                   value: {
                     from_address: 'cosmos1xvt4e7xd0j9dwv2w83g50tpcltsl90h52003e2',
-                    to_address: cosmos_address,
+                    to_address: cosmos_testnet_address0,
                     amount: [
                       {
                         denom: 'umuon',
@@ -223,7 +259,7 @@ describe('SDK Client Test', () => {
     txHistory = await cosmosTestnetClient.searchTx({ messageSender: 'cosmos1xvt4e7xd0j9dwv2w83g50tpcltsl90h52003e2' })
     expect(parseInt(txHistory.total_count?.toString() || '0')).toBeGreaterThan(0)
 
-    assertTxHstory(thorMainnetClient.server, thor_mainnet_address, {
+    assertTxHstory(thorMainnetClient.server, thor_mainnet_address0, {
       count: 0,
       limit: 30,
       page_number: 1,
@@ -231,10 +267,10 @@ describe('SDK Client Test', () => {
       total_count: 0,
       txs: [],
     })
-    txHistory = await thorMainnetClient.searchTx({ messageSender: thor_mainnet_address })
+    txHistory = await thorMainnetClient.searchTx({ messageSender: thor_mainnet_address0 })
     expect(parseInt(txHistory.total_count?.toString() || '0')).toEqual(0)
 
-    assertTxHstory(thorTestnetClient.server, thor_testnet_address, {
+    assertTxHstory(thorTestnetClient.server, thor_testnet_address0, {
       count: 1,
       limit: 30,
       page_number: 1,
@@ -272,7 +308,7 @@ describe('SDK Client Test', () => {
       ],
     })
 
-    txHistory = await thorTestnetClient.searchTx({ messageSender: thor_testnet_address })
+    txHistory = await thorTestnetClient.searchTx({ messageSender: thor_testnet_address0 })
     expect(parseInt(txHistory.total_count?.toString() || '0')).toEqual(1)
   })
 
@@ -284,7 +320,7 @@ describe('SDK Client Test', () => {
       height: 0,
     }
 
-    mockAccountsAddress(cosmosTestnetClient.server, cosmos_address, {
+    mockAccountsAddress(cosmosTestnetClient.server, cosmos_testnet_address0, {
       height: 0,
       result: {
         coins: [
@@ -300,7 +336,7 @@ describe('SDK Client Test', () => {
 
     assertTxsPost(
       cosmosTestnetClient.server,
-      cosmos_address,
+      cosmos_testnet_address0,
       'cosmos1gehrq0pr5d79q8nxnaenvqh09g56jafm82thjv',
       'cosmos-sdk/MsgSend',
       [
@@ -318,7 +354,7 @@ describe('SDK Client Test', () => {
 
     const result = await cosmosTestnetClient.transfer({
       privkey: cosmosTestnetClient.getPrivKeyFromMnemonic(cosmos_phrase, derivationPaths.cosmos.testnet + '0'),
-      from: cosmos_address,
+      from: cosmos_testnet_address0,
       to: 'cosmos1gehrq0pr5d79q8nxnaenvqh09g56jafm82thjv',
       amount: 10000,
       asset: 'muon',
@@ -327,7 +363,7 @@ describe('SDK Client Test', () => {
 
     expect(result).toEqual(expected_txsPost_result)
 
-    mockAccountsAddress(thorTestnetClient.server, thor_testnet_address, {
+    mockAccountsAddress(thorTestnetClient.server, thor_testnet_address0, {
       height: 0,
       result: {
         coins: [
@@ -342,7 +378,7 @@ describe('SDK Client Test', () => {
     })
     assertTxsPost(
       thorTestnetClient.server,
-      thor_testnet_address,
+      thor_testnet_address0,
       'tthor19kacmmyuf2ysyvq3t9nrl9495l5cvktj5c4eh4',
       'thorchain/MsgSend',
       [
@@ -371,7 +407,7 @@ describe('SDK Client Test', () => {
               type: 'cosmos-sdk/MsgSend',
               value: {
                 from_address: 'cosmos1xvt4e7xd0j9dwv2w83g50tpcltsl90h52003e2',
-                to_address: cosmos_address,
+                to_address: cosmos_mainnet_address0,
                 amount: [
                   {
                     denom: 'thor',

--- a/packages/xchain-cosmos/package.json
+++ b/packages/xchain-cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-cosmos",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Custom Cosmos client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",
@@ -31,7 +31,7 @@
     "prepublishOnly": "yarn build"
   },
   "devDependencies": {
-    "@xchainjs/xchain-client": "^0.8.0",
+    "@xchainjs/xchain-client": "^0.9.0",
     "@xchainjs/xchain-util": "^0.2.7",
     "@xchainjs/xchain-crypto": "^0.2.3",
     "axios": "^0.21.0",
@@ -43,7 +43,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@xchainjs/xchain-client": "^0.8.0",
+    "@xchainjs/xchain-client": "^0.9.0",
     "@xchainjs/xchain-util": "^0.2.7",
     "@xchainjs/xchain-crypto": "^0.2.3",
     "axios": "^0.21.0",

--- a/packages/xchain-cosmos/src/client.ts
+++ b/packages/xchain-cosmos/src/client.ts
@@ -255,9 +255,9 @@ class Client implements CosmosClient, XChainClient {
    * @param {Asset} asset If not set, it will return all assets available. (optional)
    * @returns {Array<Balance>} The balance of the address.
    */
-  getBalance = async (index = 0, assets?: Asset[]): Promise<Balances> => {
+  getBalance = async (address: Address, assets?: Asset[]): Promise<Balances> => {
     try {
-      const balances = await this.getCosmosClientSdk(index).getBalance(this.getAddress(index))
+      const balances = await this.getCosmosClientSdk().getBalance(address)
       const mainAsset = this.getMainAsset()
 
       return balances
@@ -285,7 +285,6 @@ class Client implements CosmosClient, XChainClient {
    */
   getTransactions = async (params?: TxHistoryParams): Promise<TxsPage> => {
     const messageAction = undefined
-    const messageSender = typeof params?.address === 'number' ? this.getAddress(params.address) : params?.address + ''
     const page = (params && params.offset) || undefined
     const limit = (params && params.limit) || undefined
     const txMinHeight = undefined
@@ -297,7 +296,7 @@ class Client implements CosmosClient, XChainClient {
       const mainAsset = this.getMainAsset()
       const txHistory = await this.getCosmosClientSdk(0).searchTx({
         messageAction,
-        messageSender,
+        messageSender: params?.address,
         page,
         limit,
         txMinHeight,

--- a/packages/xchain-cosmos/src/client.ts
+++ b/packages/xchain-cosmos/src/client.ts
@@ -159,7 +159,7 @@ class Client implements CosmosClient, XChainClient {
    * @throws {"Invalid phrase"}
    * Thrown if the given phase is invalid.
    */
-  setPhrase = (phrase: string): Address => {
+  setPhrase = (phrase: string, walletIndex = 0): Address => {
     if (this.phrase !== phrase) {
       if (!xchainCrypto.validatePhrase(phrase)) {
         throw new Error('Invalid phrase')
@@ -168,7 +168,7 @@ class Client implements CosmosClient, XChainClient {
       this.phrase = phrase
     }
 
-    return this.getAddress(0)
+    return this.getAddress(walletIndex)
   }
 
   /**
@@ -183,7 +183,7 @@ class Client implements CosmosClient, XChainClient {
   private getPrivateKey = (index = 0): PrivKey => {
     if (!this.phrase) throw new Error('Phrase not set')
 
-    return this.getSDKClient()?.getPrivKeyFromMnemonic(this.phrase, this.getFullDerivationPath(index))
+    return this.getSDKClient().getPrivKeyFromMnemonic(this.phrase, this.getFullDerivationPath(index))
   }
   getSDKClient = (): CosmosSDKClient => {
     return this.sdkClients.get(this.network) || TESTNET_SDK

--- a/packages/xchain-cosmos/src/client.ts
+++ b/packages/xchain-cosmos/src/client.ts
@@ -279,7 +279,7 @@ class Client implements CosmosClient, XChainClient {
       const mainAsset = this.getMainAsset()
       const txHistory = await this.getSDKClient().searchTx({
         messageAction,
-        messageSender: params?.address,
+        messageSender: (params && params.address) || this.getAddress(),
         page,
         limit,
         txMinHeight,

--- a/packages/xchain-cosmos/src/client.ts
+++ b/packages/xchain-cosmos/src/client.ts
@@ -64,7 +64,7 @@ class Client implements CosmosClient, XChainClient {
     phrase,
     rootDerivationPaths = {
       mainnet: `44'/118'/0'/0/`,
-      testnet: `44'/118'/0'/0/`, //TODO: shoudn't this be 44'/118'/0'/1/ ?
+      testnet: `44'/118'/1'/0/`,
     },
   }: XChainClientParams) {
     this.network = network

--- a/packages/xchain-ethereum/CHANGELOG.md
+++ b/packages/xchain-ethereum/CHANGELOG.md
@@ -1,4 +1,8 @@
-# v.x.x.x
+# v.0.20.0 (2021-05-17)
+
+### Breaking change
+
+- added support for HD wallets
 
 # v.0.19.0 (2021-05-05)
 

--- a/packages/xchain-ethereum/__tests__/client.mainnet.test.ts
+++ b/packages/xchain-ethereum/__tests__/client.mainnet.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { baseAmount, AssetETH } from '@xchainjs/xchain-util'
+import { baseAmount, AssetETH, assetToString } from '@xchainjs/xchain-util'
 import Client from '../src/client'
 import { ETH_DECIMAL } from '../src/utils'
 import { mock_ethplorer_api_getAddress, mock_ethplorer_api_getTxInfo } from '../__mocks__/ethplorer-api'
@@ -72,59 +72,58 @@ describe('Client Test', () => {
     ).toBeTruthy()
   })
 
-  // it('gets a balance from address', async () => {
-  //   const ethClient = new Client({
-  //     network: 'mainnet',
-  //     phrase,
-  //     ethplorerUrl,
-  //   })
+  it('gets a balance from address', async () => {
+    const ethClient = new Client({
+      network: 'mainnet',
+      phrase,
+      ethplorerUrl,
+    })
 
-  //   mock_ethplorer_api_getAddress(ethplorerUrl, '0x12d4444f96c644385d8ab355f6ddf801315b6254', {
-  //     address: '0x12d4444f96c644385d8ab355f6ddf801315b6254',
-  //     ETH: {
-  //       balance: 100,
-  //       price: {
-  //         rate: 1196.5425814145788,
-  //         diff: 11.71,
-  //         diff7d: 62.3,
-  //         ts: 1609987982,
-  //         marketCapUsd: 136582198332.62915,
-  //         availableSupply: 114147377.999,
-  //         volume24h: 44933107598.39366,
-  //         diff30d: 108.688017487141,
-  //         volDiff1: 7.230942506781318,
-  //         volDiff7: 81.97257329720685,
-  //         volDiff30: 16.64321146720964,
-  //       },
-  //     },
-  //     tokens: [
-  //       {
-  //         balance: 1000,
-  //         tokenInfo: {
-  //           address: '0x2306934ca884caa042dc595371003093092b2bbf',
-  //           decimals: '18',
-  //           name: 'tomatos.finance',
-  //           owner: '0x',
-  //           symbol: 'TOMATOS',
-  //           totalSupply: '1000000000000000000000000000',
-  //           lastUpdated: 1609117980,
-  //           issuancesCount: 0,
-  //           holdersCount: 3181,
-  //           ethTransfersCount: 0,
-  //           price: false,
-  //         },
-  //       },
-  //     ],
-  //     countTxs: 1,
-  //   })
-
-  //   const balance = await ethClient.getBalance(0)
-  //   expect(balance.length).toEqual(2)
-  //   expect(assetToString(balance[0].asset)).toEqual(assetToString(AssetETH))
-  //   expect(balance[0].amount.amount().isEqualTo(baseAmount('100000000000000000000', ETH_DECIMAL).amount())).toBeTruthy()
-  //   expect(balance[1].asset.symbol).toEqual('TOMATOS-0x2306934CA884CAA042DC595371003093092b2BBf')
-  //   expect(balance[1].amount.amount().isEqualTo(baseAmount(1000, 18).amount())).toBeTruthy()
-  // })
+    mock_ethplorer_api_getAddress(ethplorerUrl, '0xb8c0c226d6fe17e5d9132741836c3ae82a5b6c4e', {
+      address: '0xb8c0c226d6fe17e5d9132741836c3ae82a5b6c4e',
+      ETH: {
+        balance: 100,
+        price: {
+          rate: 1196.5425814145788,
+          diff: 11.71,
+          diff7d: 62.3,
+          ts: 1609987982,
+          marketCapUsd: 136582198332.62915,
+          availableSupply: 114147377.999,
+          volume24h: 44933107598.39366,
+          diff30d: 108.688017487141,
+          volDiff1: 7.230942506781318,
+          volDiff7: 81.97257329720685,
+          volDiff30: 16.64321146720964,
+        },
+      },
+      tokens: [
+        {
+          balance: 1000,
+          tokenInfo: {
+            address: '0x2306934ca884caa042dc595371003093092b2bbf',
+            decimals: '18',
+            name: 'tomatos.finance',
+            owner: '0x',
+            symbol: 'TOMATOS',
+            totalSupply: '1000000000000000000000000000',
+            lastUpdated: 1609117980,
+            issuancesCount: 0,
+            holdersCount: 3181,
+            ethTransfersCount: 0,
+            price: false,
+          },
+        },
+      ],
+      countTxs: 1,
+    })
+    const balance = await ethClient.getBalance(ethClient.getAddress(0))
+    expect(balance.length).toEqual(2)
+    expect(assetToString(balance[0].asset)).toEqual(assetToString(AssetETH))
+    expect(balance[0].amount.amount().isEqualTo(baseAmount('100000000000000000000', ETH_DECIMAL).amount())).toBeTruthy()
+    expect(balance[1].asset.symbol).toEqual('TOMATOS-0x2306934CA884CAA042DC595371003093092b2BBf')
+    expect(balance[1].amount.amount().isEqualTo(baseAmount(1000, 18).amount())).toBeTruthy()
+  })
 
   it('get transaction data', async () => {
     const ethClient = new Client({

--- a/packages/xchain-ethereum/__tests__/client.mainnet.test.ts
+++ b/packages/xchain-ethereum/__tests__/client.mainnet.test.ts
@@ -25,21 +25,14 @@ describe('Client Test', () => {
   })
 
   it('derive path correctly with bip44', () => {
-    const ethClientPath0 = new Client({
+    const ethClient = new Client({
       network: 'mainnet',
       phrase,
       ethplorerUrl,
     })
 
-    const ethClientPath1 = new Client({
-      network: 'mainnet',
-      phrase,
-      derivationPath: "m/44'/60'/0'/0/1",
-      ethplorerUrl,
-    })
-
-    expect(ethClientPath0.getAddress()).toEqual(addrPath0.toLowerCase())
-    expect(ethClientPath1.getAddress()).toEqual(addrPath1.toLowerCase())
+    expect(ethClient.getAddress(0)).toEqual(addrPath0.toLowerCase())
+    expect(ethClient.getAddress(1)).toEqual(addrPath1.toLowerCase())
   })
 
   it('gets a balance without address args', async () => {
@@ -125,7 +118,7 @@ describe('Client Test', () => {
       countTxs: 1,
     })
 
-    const balance = await ethClient.getBalance('0x12d4444f96c644385d8ab355f6ddf801315b6254')
+    const balance = await ethClient.getBalance(0)
     expect(balance.length).toEqual(2)
     expect(assetToString(balance[0].asset)).toEqual(assetToString(AssetETH))
     expect(balance[0].amount.amount().isEqualTo(baseAmount('100000000000000000000', ETH_DECIMAL).amount())).toBeTruthy()

--- a/packages/xchain-ethereum/__tests__/client.mainnet.test.ts
+++ b/packages/xchain-ethereum/__tests__/client.mainnet.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { baseAmount, AssetETH, assetToString } from '@xchainjs/xchain-util'
+import { baseAmount, AssetETH } from '@xchainjs/xchain-util'
 import Client from '../src/client'
 import { ETH_DECIMAL } from '../src/utils'
 import { mock_ethplorer_api_getAddress, mock_ethplorer_api_getTxInfo } from '../__mocks__/ethplorer-api'
@@ -72,59 +72,59 @@ describe('Client Test', () => {
     ).toBeTruthy()
   })
 
-  it('gets a balance from address', async () => {
-    const ethClient = new Client({
-      network: 'mainnet',
-      phrase,
-      ethplorerUrl,
-    })
+  // it('gets a balance from address', async () => {
+  //   const ethClient = new Client({
+  //     network: 'mainnet',
+  //     phrase,
+  //     ethplorerUrl,
+  //   })
 
-    mock_ethplorer_api_getAddress(ethplorerUrl, '0x12d4444f96c644385d8ab355f6ddf801315b6254', {
-      address: '0x12d4444f96c644385d8ab355f6ddf801315b6254',
-      ETH: {
-        balance: 100,
-        price: {
-          rate: 1196.5425814145788,
-          diff: 11.71,
-          diff7d: 62.3,
-          ts: 1609987982,
-          marketCapUsd: 136582198332.62915,
-          availableSupply: 114147377.999,
-          volume24h: 44933107598.39366,
-          diff30d: 108.688017487141,
-          volDiff1: 7.230942506781318,
-          volDiff7: 81.97257329720685,
-          volDiff30: 16.64321146720964,
-        },
-      },
-      tokens: [
-        {
-          balance: 1000,
-          tokenInfo: {
-            address: '0x2306934ca884caa042dc595371003093092b2bbf',
-            decimals: '18',
-            name: 'tomatos.finance',
-            owner: '0x',
-            symbol: 'TOMATOS',
-            totalSupply: '1000000000000000000000000000',
-            lastUpdated: 1609117980,
-            issuancesCount: 0,
-            holdersCount: 3181,
-            ethTransfersCount: 0,
-            price: false,
-          },
-        },
-      ],
-      countTxs: 1,
-    })
+  //   mock_ethplorer_api_getAddress(ethplorerUrl, '0x12d4444f96c644385d8ab355f6ddf801315b6254', {
+  //     address: '0x12d4444f96c644385d8ab355f6ddf801315b6254',
+  //     ETH: {
+  //       balance: 100,
+  //       price: {
+  //         rate: 1196.5425814145788,
+  //         diff: 11.71,
+  //         diff7d: 62.3,
+  //         ts: 1609987982,
+  //         marketCapUsd: 136582198332.62915,
+  //         availableSupply: 114147377.999,
+  //         volume24h: 44933107598.39366,
+  //         diff30d: 108.688017487141,
+  //         volDiff1: 7.230942506781318,
+  //         volDiff7: 81.97257329720685,
+  //         volDiff30: 16.64321146720964,
+  //       },
+  //     },
+  //     tokens: [
+  //       {
+  //         balance: 1000,
+  //         tokenInfo: {
+  //           address: '0x2306934ca884caa042dc595371003093092b2bbf',
+  //           decimals: '18',
+  //           name: 'tomatos.finance',
+  //           owner: '0x',
+  //           symbol: 'TOMATOS',
+  //           totalSupply: '1000000000000000000000000000',
+  //           lastUpdated: 1609117980,
+  //           issuancesCount: 0,
+  //           holdersCount: 3181,
+  //           ethTransfersCount: 0,
+  //           price: false,
+  //         },
+  //       },
+  //     ],
+  //     countTxs: 1,
+  //   })
 
-    const balance = await ethClient.getBalance(0)
-    expect(balance.length).toEqual(2)
-    expect(assetToString(balance[0].asset)).toEqual(assetToString(AssetETH))
-    expect(balance[0].amount.amount().isEqualTo(baseAmount('100000000000000000000', ETH_DECIMAL).amount())).toBeTruthy()
-    expect(balance[1].asset.symbol).toEqual('TOMATOS-0x2306934CA884CAA042DC595371003093092b2BBf')
-    expect(balance[1].amount.amount().isEqualTo(baseAmount(1000, 18).amount())).toBeTruthy()
-  })
+  //   const balance = await ethClient.getBalance(0)
+  //   expect(balance.length).toEqual(2)
+  //   expect(assetToString(balance[0].asset)).toEqual(assetToString(AssetETH))
+  //   expect(balance[0].amount.amount().isEqualTo(baseAmount('100000000000000000000', ETH_DECIMAL).amount())).toBeTruthy()
+  //   expect(balance[1].asset.symbol).toEqual('TOMATOS-0x2306934CA884CAA042DC595371003093092b2BBf')
+  //   expect(balance[1].amount.amount().isEqualTo(baseAmount(1000, 18).amount())).toBeTruthy()
+  // })
 
   it('get transaction data', async () => {
     const ethClient = new Client({

--- a/packages/xchain-ethereum/__tests__/client.mainnet.test.ts
+++ b/packages/xchain-ethereum/__tests__/client.mainnet.test.ts
@@ -5,6 +5,11 @@ import { ETH_DECIMAL } from '../src/utils'
 import { mock_ethplorer_api_getAddress, mock_ethplorer_api_getTxInfo } from '../__mocks__/ethplorer-api'
 
 const phrase = 'canyon throw labor waste awful century ugly they found post source draft'
+// https://iancoleman.io/bip39/
+// m/44'/60'/0'/0/0
+const addrPath0 = '0xb8c0c226d6FE17E5d9132741836C3ae82A5B6C4E'
+// m/44'/60'/0'/0/1
+const addrPath1 = '0x1804137641b5CB781226b361976F15B4067ee0F9'
 const ethplorerUrl = 'https://api.ethplorer.io'
 
 /**
@@ -17,6 +22,24 @@ describe('Client Test', () => {
 
   afterEach(() => {
     nock.cleanAll()
+  })
+
+  it('derive path correctly with bip44', () => {
+    const ethClientPath0 = new Client({
+      network: 'mainnet',
+      phrase,
+      ethplorerUrl,
+    })
+
+    const ethClientPath1 = new Client({
+      network: 'mainnet',
+      phrase,
+      derivationPath: "m/44'/60'/0'/0/1",
+      ethplorerUrl,
+    })
+
+    expect(ethClientPath0.getAddress()).toEqual(addrPath0.toLowerCase())
+    expect(ethClientPath1.getAddress()).toEqual(addrPath1.toLowerCase())
   })
 
   it('gets a balance without address args', async () => {

--- a/packages/xchain-ethereum/__tests__/client.mainnet.test.ts
+++ b/packages/xchain-ethereum/__tests__/client.mainnet.test.ts
@@ -64,7 +64,7 @@ describe('Client Test', () => {
       countTxs: 1,
     })
 
-    const balances = await ethClient.getBalance()
+    const balances = await ethClient.getBalance(ethClient.getAddress())
     expect(balances.length).toEqual(1)
     expect(balances[0].asset).toEqual(AssetETH)
     expect(

--- a/packages/xchain-ethereum/__tests__/client.testnet.test.ts
+++ b/packages/xchain-ethereum/__tests__/client.testnet.test.ts
@@ -528,7 +528,7 @@ describe('Client Test', () => {
     )
 
     let isApproved = await ethClient.isApproved(
-      0,
+      // 0,
       '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
       '0x4f96fe3b7a6cf9725f59d353f723c1bdb64ca6aa',
       baseAmount(100, ETH_DECIMAL),
@@ -536,7 +536,7 @@ describe('Client Test', () => {
     expect(isApproved).toEqual(true)
 
     isApproved = await ethClient.isApproved(
-      0,
+      // 0,
       '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
       '0x4f96fe3b7a6cf9725f59d353f723c1bdb64ca6aa',
       baseAmount(101, ETH_DECIMAL),
@@ -604,7 +604,7 @@ describe('Client Test', () => {
     mock_all_api(etherscanUrl, ropstenInfuraUrl, ropstenAlchemyUrl, 'eth_estimateGas', '0x5208')
 
     const gasLimit = await ethClient.estimateCall(
-      0,
+      // 0,
       '0xd15ffaef3112460bf3bcd81087fcbbce394e2ae7',
       erc20ABI,
       'transfer',

--- a/packages/xchain-ethereum/__tests__/client.testnet.test.ts
+++ b/packages/xchain-ethereum/__tests__/client.testnet.test.ts
@@ -141,7 +141,7 @@ describe('Client Test', () => {
 
     mock_etherscan_balance_api(etherscanUrl, '96713467036431545')
 
-    const balance = await ethClient.getBalance()
+    const balance = await ethClient.getBalance(ethClient.getAddress(0))
     expect(balance.length).toEqual(1)
     expect(assetToString(balance[0].asset)).toEqual(assetToString(AssetETH))
     expect(balance[0].amount.amount().isEqualTo(baseAmount('96713467036431545', ETH_DECIMAL).amount())).toBeTruthy()
@@ -156,7 +156,7 @@ describe('Client Test', () => {
 
     mock_etherscan_balance_api(etherscanUrl, '96713467036431545')
 
-    const balance = await ethClient.getBalance(0)
+    const balance = await ethClient.getBalance(ethClient.getAddress(0))
     expect(balance.length).toEqual(1)
     expect(assetToString(balance[0].asset)).toEqual(assetToString(AssetETH))
     expect(balance[0].amount.amount().isEqualTo(baseAmount('96713467036431545', ETH_DECIMAL).amount())).toBeTruthy()
@@ -191,7 +191,7 @@ describe('Client Test', () => {
     if (asestUSDT) {
       assets.push(asestUSDT)
     }
-    const balance = await ethClient.getBalance(undefined, assets.length ? assets : undefined)
+    const balance = await ethClient.getBalance(address, assets.length ? assets : undefined)
     expect(balance.length).toEqual(2)
     expect(assetToString(balance[0].asset)).toEqual(assetToString(assets[0] ?? AssetETH))
     expect(balance[0].amount.decimal).toEqual(18)
@@ -204,7 +204,7 @@ describe('Client Test', () => {
   it('throws error on bad index', async () => {
     const ethClient = new Client({ network: 'testnet', phrase })
 
-    const balances = ethClient.getBalance(-1)
+    const balances = ethClient.getBalance(ethClient.getAddress(-1))
     expect(balances).rejects.toThrowError()
   })
 

--- a/packages/xchain-ethereum/__tests__/client.testnet.test.ts
+++ b/packages/xchain-ethereum/__tests__/client.testnet.test.ts
@@ -203,9 +203,7 @@ describe('Client Test', () => {
 
   it('throws error on bad index', async () => {
     const ethClient = new Client({ network: 'testnet', phrase })
-
-    const balances = ethClient.getBalance(ethClient.getAddress(-1))
-    expect(balances).rejects.toThrowError()
+    expect(() => ethClient.getAddress(-1)).toThrow()
   })
 
   it('get eth transaction history', async () => {

--- a/packages/xchain-ethereum/__tests__/client.testnet.test.ts
+++ b/packages/xchain-ethereum/__tests__/client.testnet.test.ts
@@ -553,7 +553,6 @@ describe('Client Test', () => {
     mock_all_api(etherscanUrl, ropstenInfuraUrl, ropstenAlchemyUrl, 'eth_estimateGas', '0x5208')
 
     const gasLimit = await ethClient.estimateApprove({
-      walletIndex: 0,
       spender: '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
       sender: '0xdac17f958d2ee523a2206206994597c13d831ec7',
       amount: baseAmount(100, ETH_DECIMAL),

--- a/packages/xchain-ethereum/__tests__/client.testnet.test.ts
+++ b/packages/xchain-ethereum/__tests__/client.testnet.test.ts
@@ -155,7 +155,7 @@ describe('Client Test', () => {
 
     mock_etherscan_balance_api(etherscanUrl, '96713467036431545')
 
-    const balance = await ethClient.getBalance('0x8d8ac01b3508ca869cb631bb2977202fbb574a0d')
+    const balance = await ethClient.getBalance(0)
     expect(balance.length).toEqual(1)
     expect(assetToString(balance[0].asset)).toEqual(assetToString(AssetETH))
     expect(balance[0].amount.amount().isEqualTo(baseAmount('96713467036431545', ETH_DECIMAL).amount())).toBeTruthy()
@@ -200,10 +200,10 @@ describe('Client Test', () => {
     expect(balance[1].amount.amount().isEqualTo(baseAmount('96713467036431546', 18).amount())).toBeTruthy()
   })
 
-  it('throws error on bad address', async () => {
+  it('throws error on bad index', async () => {
     const ethClient = new Client({ network: 'testnet', phrase })
 
-    const balances = ethClient.getBalance('0xbad')
+    const balances = ethClient.getBalance(-1)
     expect(balances).rejects.toThrowError()
   })
 
@@ -529,6 +529,7 @@ describe('Client Test', () => {
     )
 
     let isApproved = await ethClient.isApproved(
+      0,
       '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
       '0x4f96fe3b7a6cf9725f59d353f723c1bdb64ca6aa',
       baseAmount(100, ETH_DECIMAL),
@@ -536,6 +537,7 @@ describe('Client Test', () => {
     expect(isApproved).toEqual(true)
 
     isApproved = await ethClient.isApproved(
+      0,
       '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
       '0x4f96fe3b7a6cf9725f59d353f723c1bdb64ca6aa',
       baseAmount(101, ETH_DECIMAL),
@@ -555,6 +557,7 @@ describe('Client Test', () => {
     mock_all_api(etherscanUrl, ropstenInfuraUrl, ropstenAlchemyUrl, 'eth_estimateGas', '0x5208')
 
     const gasLimit = await ethClient.estimateApprove({
+      walletIndex: 0,
       spender: '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
       sender: '0xdac17f958d2ee523a2206206994597c13d831ec7',
       amount: baseAmount(100, ETH_DECIMAL),
@@ -581,6 +584,7 @@ describe('Client Test', () => {
     )
 
     const tx = await ethClient.approve({
+      walletIndex: 0,
       spender: '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
       sender: '0xd15ffaef3112460bf3bcd81087fcbbce394e2ae7',
       feeOptionKey: 'fastest',
@@ -600,13 +604,19 @@ describe('Client Test', () => {
     mock_all_api(etherscanUrl, ropstenInfuraUrl, ropstenAlchemyUrl, 'eth_gasPrice', '0xb2d05e00')
     mock_all_api(etherscanUrl, ropstenInfuraUrl, ropstenAlchemyUrl, 'eth_estimateGas', '0x5208')
 
-    const gasLimit = await ethClient.estimateCall('0xd15ffaef3112460bf3bcd81087fcbbce394e2ae7', erc20ABI, 'transfer', [
-      '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
-      BigNumber.from(baseAmount('10000000000000', ETH_DECIMAL).amount().toString()),
-      {
-        from: ethClient.getAddress(),
-      },
-    ])
+    const gasLimit = await ethClient.estimateCall(
+      0,
+      '0xd15ffaef3112460bf3bcd81087fcbbce394e2ae7',
+      erc20ABI,
+      'transfer',
+      [
+        '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
+        BigNumber.from(baseAmount('10000000000000', ETH_DECIMAL).amount().toString()),
+        {
+          from: ethClient.getAddress(),
+        },
+      ],
+    )
 
     expect(gasLimit.toString()).toEqual('21000')
   })
@@ -645,6 +655,7 @@ describe('Client Test', () => {
     const prices = await ethClient.estimateGasPrices()
 
     const txResult = await ethClient.call<TransactionResponse>(
+      0,
       '0xd15ffaef3112460bf3bcd81087fcbbce394e2ae7',
       erc20ABI,
       'transfer',

--- a/packages/xchain-ethereum/__tests__/client.testnet.test.ts
+++ b/packages/xchain-ethereum/__tests__/client.testnet.test.ts
@@ -151,7 +151,6 @@ describe('Client Test', () => {
     const ethClient = new Client({
       network: 'testnet',
       phrase,
-      // ethplorerUrl: etherscanUrl,
     })
 
     mock_etherscan_balance_api(etherscanUrl, '96713467036431545')
@@ -528,7 +527,6 @@ describe('Client Test', () => {
     )
 
     let isApproved = await ethClient.isApproved(
-      // 0,
       '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
       '0x4f96fe3b7a6cf9725f59d353f723c1bdb64ca6aa',
       baseAmount(100, ETH_DECIMAL),
@@ -536,7 +534,6 @@ describe('Client Test', () => {
     expect(isApproved).toEqual(true)
 
     isApproved = await ethClient.isApproved(
-      // 0,
       '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
       '0x4f96fe3b7a6cf9725f59d353f723c1bdb64ca6aa',
       baseAmount(101, ETH_DECIMAL),
@@ -603,19 +600,13 @@ describe('Client Test', () => {
     mock_all_api(etherscanUrl, ropstenInfuraUrl, ropstenAlchemyUrl, 'eth_gasPrice', '0xb2d05e00')
     mock_all_api(etherscanUrl, ropstenInfuraUrl, ropstenAlchemyUrl, 'eth_estimateGas', '0x5208')
 
-    const gasLimit = await ethClient.estimateCall(
-      // 0,
-      '0xd15ffaef3112460bf3bcd81087fcbbce394e2ae7',
-      erc20ABI,
-      'transfer',
-      [
-        '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
-        BigNumber.from(baseAmount('10000000000000', ETH_DECIMAL).amount().toString()),
-        {
-          from: ethClient.getAddress(),
-        },
-      ],
-    )
+    const gasLimit = await ethClient.estimateCall('0xd15ffaef3112460bf3bcd81087fcbbce394e2ae7', erc20ABI, 'transfer', [
+      '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
+      BigNumber.from(baseAmount('10000000000000', ETH_DECIMAL).amount().toString()),
+      {
+        from: ethClient.getAddress(),
+      },
+    ])
 
     expect(gasLimit.toString()).toEqual('21000')
   })

--- a/packages/xchain-ethereum/__tests__/client.testnet.test.ts
+++ b/packages/xchain-ethereum/__tests__/client.testnet.test.ts
@@ -154,7 +154,7 @@ describe('Client Test', () => {
       // ethplorerUrl: etherscanUrl,
     })
 
-    // mock_etherscan_balance_api(etherscanUrl, '96713467036431545')
+    mock_etherscan_balance_api(etherscanUrl, '96713467036431545')
 
     const balance = await ethClient.getBalance(0)
     expect(balance.length).toEqual(1)

--- a/packages/xchain-ethereum/__tests__/client.testnet.test.ts
+++ b/packages/xchain-ethereum/__tests__/client.testnet.test.ts
@@ -59,14 +59,14 @@ describe('Client Test', () => {
   })
 
   it('should set new phrase', () => {
-    const ethClient = new Client({})
+    const ethClient = new Client({ phrase })
     const newWallet = ethClient.setPhrase(newPhrase)
     expect(ethClient.getWallet().mnemonic.phrase).toEqual(newPhrase)
     expect(newWallet).toBeTruthy()
   })
 
   it('should fail to set new phrase', () => {
-    const ethClient = new Client({})
+    const ethClient = new Client({ phrase })
     expect(() => ethClient.setPhrase('bad bad phrase')).toThrowError()
   })
 
@@ -118,17 +118,17 @@ describe('Client Test', () => {
   })
 
   it('should get network', () => {
-    const ethClient = new Client({ network: 'testnet' })
+    const ethClient = new Client({ phrase, network: 'testnet' })
     expect(ethClient.getNetwork()).toEqual('testnet')
   })
 
   it('should fail a bad address', () => {
-    const ethClient = new Client({ network: 'testnet' })
+    const ethClient = new Client({ phrase, network: 'testnet' })
     expect(ethClient.validateAddress('0xBADbadBad')).toBeFalsy()
   })
 
   it('should pass a good address', () => {
-    const ethClient = new Client({ network: 'testnet' })
+    const ethClient = new Client({ phrase, network: 'testnet' })
     const goodAddress = ethClient.validateAddress(address)
     expect(goodAddress).toBeTruthy()
   })
@@ -151,9 +151,10 @@ describe('Client Test', () => {
     const ethClient = new Client({
       network: 'testnet',
       phrase,
+      // ethplorerUrl: etherscanUrl,
     })
 
-    mock_etherscan_balance_api(etherscanUrl, '96713467036431545')
+    // mock_etherscan_balance_api(etherscanUrl, '96713467036431545')
 
     const balance = await ethClient.getBalance(0)
     expect(balance.length).toEqual(1)

--- a/packages/xchain-ethereum/package.json
+++ b/packages/xchain-ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-ethereum",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Ethereum client for XChainJS",
   "keywords": [
     "XChain",
@@ -35,14 +35,14 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@xchainjs/xchain-client": "^0.8.0",
+    "@xchainjs/xchain-client": "^0.9.0",
     "@xchainjs/xchain-util": "^0.2.7",
     "@xchainjs/xchain-crypto": "^0.2.3",
     "axios": "^0.21.0",
     "ethers": "^5.1.0"
   },
   "peerDependencies": {
-    "@xchainjs/xchain-client": "^0.8.0",
+    "@xchainjs/xchain-client": "^0.9.0",
     "@xchainjs/xchain-util": "^0.2.7",
     "@xchainjs/xchain-crypto": "^0.2.3",
     "axios": "^0.21.0",

--- a/packages/xchain-ethereum/src/client.ts
+++ b/packages/xchain-ethereum/src/client.ts
@@ -72,7 +72,7 @@ export interface EthereumClient {
     asset: Address,
     abi: ethers.ContractInterface,
     func: string,
-    params: Array<any>,
+    params: Array<unknown>,
   ): Promise<T>
   estimateCall(
     walletIndex: number,
@@ -563,7 +563,7 @@ export default class Client implements XChainClient, EthereumClient {
     contractAddress: Address,
     abi: ethers.ContractInterface,
     func: string,
-    params: Array<any>,
+    params: Array<unknown>,
   ): Promise<T> => {
     if (!contractAddress) {
       return Promise.reject(new Error('contractAddress must be provided'))

--- a/packages/xchain-ethereum/src/client.ts
+++ b/packages/xchain-ethereum/src/client.ts
@@ -119,6 +119,7 @@ export default class Client implements XChainClient, EthereumClient {
     ethplorerApiKey = 'freekey',
     explorerUrl,
     phrase,
+    derivationPath,
     etherscanApiKey,
     infuraCreds,
   }: ClientParams) {
@@ -145,7 +146,7 @@ export default class Client implements XChainClient, EthereumClient {
     }
 
     if (phrase) {
-      this.setPhrase(phrase)
+      this.setPhrase(phrase, derivationPath)
       this.changeWallet(this.getWallet().connect(this.provider))
     }
   }
@@ -327,12 +328,12 @@ export default class Client implements XChainClient, EthereumClient {
    * @throws {"Invalid phrase"}
    * Thrown if the given phase is invalid.
    */
-  setPhrase = (phrase: string): Address => {
+  setPhrase = (phrase: string, derivationPath?: string): Address => {
     if (!Crypto.validatePhrase(phrase)) {
       throw new Error('Invalid phrase')
     }
 
-    this.changeWallet(ethers.Wallet.fromMnemonic(phrase))
+    this.changeWallet(ethers.Wallet.fromMnemonic(phrase, derivationPath))
     return this.getAddress()
   }
 

--- a/packages/xchain-ethereum/src/client.ts
+++ b/packages/xchain-ethereum/src/client.ts
@@ -341,8 +341,6 @@ export default class Client implements XChainClient, EthereumClient {
   getBalance = async (index = 0, assets?: Asset[]): Promise<Balances> => {
     try {
       const ethAddress = this.getAddress(index)
-      console.log(`ethAddress = ${ethAddress}`)
-      console.log(`this.getNetwork() = ${this.getNetwork()}`)
       if (this.getNetwork() === 'mainnet') {
         // use ethplorerAPI for mainnet - ignore assets
         const account = await ethplorerAPI.getAddress(this.ethplorerUrl, ethAddress, this.ethplorerApiKey)

--- a/packages/xchain-ethereum/src/client.ts
+++ b/packages/xchain-ethereum/src/client.ts
@@ -326,12 +326,12 @@ export default class Client implements XChainClient, EthereumClient {
    * @throws {"Invalid phrase"}
    * Thrown if the given phase is invalid.
    */
-  setPhrase = (phrase: string): Address => {
+  setPhrase = (phrase: string, walletIndex = 0): Address => {
     if (!Crypto.validatePhrase(phrase)) {
       throw new Error('Invalid phrase')
     }
     this.hdNode = HDNode.fromMnemonic(phrase)
-    return this.getAddress(0)
+    return this.getAddress(walletIndex)
   }
 
   /**

--- a/packages/xchain-ethereum/src/client.ts
+++ b/packages/xchain-ethereum/src/client.ts
@@ -179,6 +179,9 @@ export default class Client implements XChainClient, EthereumClient {
    * Thrown if phrase has not been set before. A phrase is needed to create a wallet and to derive an address from it.
    */
   getAddress = (index = 0): Address => {
+    if (index < 0) {
+      throw new Error('index must be greater than zero')
+    }
     if (!this.phrase) {
       throw new Error('Phrase must be provided')
     }

--- a/packages/xchain-ethereum/src/types/client-types.ts
+++ b/packages/xchain-ethereum/src/types/client-types.ts
@@ -42,6 +42,7 @@ export type FeesParams = C.FeesParams & C.TxParams
 export type FeesWithGasPricesAndLimits = { fees: C.Fees; gasPrices: GasPrices; gasLimit: BigNumber }
 
 export type ApproveParams = {
+  walletIndex: number
   spender: Address
   sender: Address
   feeOptionKey?: FeeOptionKey

--- a/packages/xchain-litecoin/CHANGELOG.md
+++ b/packages/xchain-litecoin/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.6.0 (2021-05-17)
+
+### Breaking change
+
+- added support for HD wallets
+
 # v.0.5.0 (2021-05-05)
 
 ### Breaking change

--- a/packages/xchain-litecoin/__tests__/client.test.ts
+++ b/packages/xchain-litecoin/__tests__/client.test.ts
@@ -108,7 +108,6 @@ describe('LitecoinClient Test', () => {
   it('should purge phrase and utxos', async () => {
     ltcClient.purgeClient()
     expect(() => ltcClient.getAddress()).toThrow('Phrase must be provided')
-    // return expect(ltcClient.getBalance(ltcClient.getAddress())).rejects.toThrow('Phrase must be provided')
   })
 
   it('should do broadcast a vault transfer with a memo', async () => {
@@ -131,13 +130,13 @@ describe('LitecoinClient Test', () => {
     }
   })
 
-  // it('should get the balance of an address without phrase', async () => {
-  //   ltcClient.setNetwork('testnet')
-  //   ltcClient.purgeClient()
-  //   const balance = await ltcClient.getBalance(3)
-  //   expect(balance.length).toEqual(1)
-  //   expect(balance[0].amount.amount().toNumber()).toEqual(2223)
-  // })
+  it('should get the balance of an address without phrase', async () => {
+    ltcClient.setNetwork('testnet')
+    ltcClient.purgeClient()
+    const balance = await ltcClient.getBalance(addyThree)
+    expect(balance.length).toEqual(1)
+    expect(balance[0].amount.amount().toNumber()).toEqual(2223)
+  })
 
   it('should prevent a tx when fees and valueOut exceed balance', async () => {
     ltcClient.setNetwork('testnet')
@@ -220,12 +219,12 @@ describe('LitecoinClient Test', () => {
     expect(fastest > fast)
   })
 
-  it('should error when an invalid index is used in getting address', () => {
+  it('should error when an invalid address is used in getting balance', () => {
     ltcClient.setNetwork('testnet')
     ltcClient.setPhrase(phraseOne)
-
-    const expectedError = 'index must be greater than zero'
-    expect(() => ltcClient.getAddress(-1)).toThrow(expectedError)
+    const invalidAddress = 'error_address'
+    const expectedError = 'Invalid address'
+    return expect(ltcClient.getBalance(invalidAddress)).rejects.toThrow(expectedError)
   })
 
   it('should error when an invalid address is used in transfer', () => {

--- a/packages/xchain-litecoin/__tests__/client.test.ts
+++ b/packages/xchain-litecoin/__tests__/client.test.ts
@@ -3,7 +3,7 @@ import { MIN_TX_FEE } from '../src/const'
 import { baseAmount, AssetLTC } from '@xchainjs/xchain-util'
 
 import mockSochainApi from '../__mocks__/sochain'
-import { getDerivePath } from '../src/utils'
+// import { getDerivePath } from '../src/utils'
 mockSochainApi.init()
 
 const ltcClient = new Client({ network: 'testnet' })
@@ -22,7 +22,6 @@ describe('LitecoinClient Test', () => {
   const testnet_address_path1 = 'tltc1qut59ufcscqnkp8fgac68pj2ps5dzjjg4eggfqd'
   const mainnet_address_path0 = 'ltc1qll0eutk38yy3jms0c85v4ey68z83c78h3fmsh3'
   const mainnet_address_path1 = 'ltc1qsr5wh2sudyc7axh087lg7py6dsagphef63acgq'
-
 
   // const phraseTwo = 'green atom various power must another rent imitate gadget creek fat then'
   const addyTwo = 'tltc1ql68zjjdjx37499luueaw09avednqtge4u23q36'
@@ -54,24 +53,17 @@ describe('LitecoinClient Test', () => {
     expect(valid).toBeTruthy()
   })
 
-  it('set phrase with derivation path should return correct address', () => {
+  it('set phrase should return correct address', () => {
     ltcClient.setNetwork('testnet')
-    expect(ltcClient.setPhrase(phraseOne, getDerivePath(0).testnet)).toEqual(testnet_address_path0)
+    expect(ltcClient.setPhrase(phraseOne)).toEqual(testnet_address_path0)
+    expect(ltcClient.getAddress(1)).toEqual(testnet_address_path1)
 
     ltcClient.setNetwork('mainnet')
-    expect(ltcClient.setPhrase(phraseOne, getDerivePath(0).mainnet)).toEqual(mainnet_address_path0)
+    expect(ltcClient.setPhrase(phraseOne)).toEqual(mainnet_address_path0)
+    expect(ltcClient.getAddress(1)).toEqual(mainnet_address_path1)
 
-    ltcClient.setNetwork('testnet')
-    expect(ltcClient.setPhrase(phraseOne, getDerivePath(1).testnet)).toEqual(testnet_address_path1)
-
-    const otherLtcPath1Test = new Client({phrase: phraseOne, network: 'testnet', derivationPath: "m/84'/1'/0'/0/1"})
-    expect(otherLtcPath1Test.getAddress()).toEqual(testnet_address_path1)
-
-    ltcClient.setNetwork('mainnet')
-    expect(ltcClient.setPhrase(phraseOne, getDerivePath(1).mainnet)).toEqual(mainnet_address_path1)
-
-    const otherLtcPath1TestM = new Client({phrase: phraseOne, network: 'mainnet', derivationPath: "m/84'/2'/0'/0/1"})
-    expect(otherLtcPath1TestM.getAddress()).toEqual(mainnet_address_path1)
+    // const otherLtcPath1TestM = new Client({ phrase: phraseOne, network: 'mainnet', derivationPath: "m/84'/2'/0'/0/1" })
+    // expect(otherLtcPath1TestM.getAddress()).toEqual(mainnet_address_path1)
   })
 
   it('should get the right balance', async () => {
@@ -139,13 +131,13 @@ describe('LitecoinClient Test', () => {
     }
   })
 
-  it('should get the balance of an address without phrase', async () => {
-    ltcClient.setNetwork('testnet')
-    ltcClient.purgeClient()
-    const balance = await ltcClient.getBalance(addyThree)
-    expect(balance.length).toEqual(1)
-    expect(balance[0].amount.amount().toNumber()).toEqual(2223)
-  })
+  // it('should get the balance of an address without phrase', async () => {
+  //   ltcClient.setNetwork('testnet')
+  //   ltcClient.purgeClient()
+  //   const balance = await ltcClient.getBalance(3)
+  //   expect(balance.length).toEqual(1)
+  //   expect(balance[0].amount.amount().toNumber()).toEqual(2223)
+  // })
 
   it('should prevent a tx when fees and valueOut exceed balance', async () => {
     ltcClient.setNetwork('testnet')
@@ -153,7 +145,7 @@ describe('LitecoinClient Test', () => {
 
     const asset = AssetLTC
     const amount = baseAmount(9999999999)
-    return expect(ltcClient.transfer({ asset, recipient: addyTwo, amount, feeRate: 1 })).rejects.toThrow(
+    return expect(ltcClient.transfer({ from: 0, asset, recipient: addyTwo, amount, feeRate: 1 })).rejects.toThrow(
       'Balance insufficient for transaction',
     )
   })
@@ -228,12 +220,10 @@ describe('LitecoinClient Test', () => {
     expect(fastest > fast)
   })
 
-  it('should error when an invalid address is used in getting balance', () => {
+  it('should error when an invalid index is used in getting balance', () => {
     ltcClient.setNetwork('testnet')
     ltcClient.setPhrase(phraseOne)
-    const invalidAddress = 'error_address'
-    const expectedError = 'Invalid address'
-    return expect(ltcClient.getBalance(invalidAddress)).rejects.toThrow(expectedError)
+    return expect(ltcClient.getBalance(-1)).rejects.toThrow()
   })
 
   it('should error when an invalid address is used in transfer', () => {

--- a/packages/xchain-litecoin/__tests__/client.test.ts
+++ b/packages/xchain-litecoin/__tests__/client.test.ts
@@ -3,7 +3,6 @@ import { MIN_TX_FEE } from '../src/const'
 import { baseAmount, AssetLTC } from '@xchainjs/xchain-util'
 
 import mockSochainApi from '../__mocks__/sochain'
-// import { getDerivePath } from '../src/utils'
 mockSochainApi.init()
 
 const ltcClient = new Client({ network: 'testnet' })
@@ -61,9 +60,6 @@ describe('LitecoinClient Test', () => {
     ltcClient.setNetwork('mainnet')
     expect(ltcClient.setPhrase(phraseOne)).toEqual(mainnet_address_path0)
     expect(ltcClient.getAddress(1)).toEqual(mainnet_address_path1)
-
-    // const otherLtcPath1TestM = new Client({ phrase: phraseOne, network: 'mainnet', derivationPath: "m/84'/2'/0'/0/1" })
-    // expect(otherLtcPath1TestM.getAddress()).toEqual(mainnet_address_path1)
   })
 
   it('should get the right balance', async () => {

--- a/packages/xchain-litecoin/__tests__/client.test.ts
+++ b/packages/xchain-litecoin/__tests__/client.test.ts
@@ -70,7 +70,7 @@ describe('LitecoinClient Test', () => {
     const expectedBalance = 2223
     ltcClient.setNetwork('testnet')
     ltcClient.setPhrase(phraseThree)
-    const balance = await ltcClient.getBalance()
+    const balance = await ltcClient.getBalance(ltcClient.getAddress())
     expect(balance.length).toEqual(1)
     expect(balance[0].amount.amount().toNumber()).toEqual(expectedBalance)
   })
@@ -80,11 +80,11 @@ describe('LitecoinClient Test', () => {
     ltcClient.setNetwork('testnet')
     ltcClient.setPhrase(phraseThree)
 
-    const balance = await ltcClient.getBalance()
+    const balance = await ltcClient.getBalance(ltcClient.getAddress())
     expect(balance.length).toEqual(1)
     expect(balance[0].amount.amount().toNumber()).toEqual(expectedBalance)
 
-    const newBalance = await ltcClient.getBalance()
+    const newBalance = await ltcClient.getBalance(ltcClient.getAddress())
     expect(newBalance.length).toEqual(1)
     expect(newBalance[0].amount.amount().toNumber()).toEqual(expectedBalance)
   })
@@ -108,7 +108,7 @@ describe('LitecoinClient Test', () => {
   it('should purge phrase and utxos', async () => {
     ltcClient.purgeClient()
     expect(() => ltcClient.getAddress()).toThrow('Phrase must be provided')
-    return expect(ltcClient.getBalance()).rejects.toThrow('Phrase must be provided')
+    return expect(ltcClient.getBalance(ltcClient.getAddress())).rejects.toThrow('Phrase must be provided')
   })
 
   it('should do broadcast a vault transfer with a memo', async () => {
@@ -223,7 +223,7 @@ describe('LitecoinClient Test', () => {
   it('should error when an invalid index is used in getting balance', () => {
     ltcClient.setNetwork('testnet')
     ltcClient.setPhrase(phraseOne)
-    return expect(ltcClient.getBalance(-1)).rejects.toThrow()
+    return expect(ltcClient.getBalance(ltcClient.getAddress(-1))).rejects.toThrow()
   })
 
   it('should error when an invalid address is used in transfer', () => {

--- a/packages/xchain-litecoin/__tests__/client.test.ts
+++ b/packages/xchain-litecoin/__tests__/client.test.ts
@@ -108,7 +108,7 @@ describe('LitecoinClient Test', () => {
   it('should purge phrase and utxos', async () => {
     ltcClient.purgeClient()
     expect(() => ltcClient.getAddress()).toThrow('Phrase must be provided')
-    return expect(ltcClient.getBalance(ltcClient.getAddress())).rejects.toThrow('Phrase must be provided')
+    // return expect(ltcClient.getBalance(ltcClient.getAddress())).rejects.toThrow('Phrase must be provided')
   })
 
   it('should do broadcast a vault transfer with a memo', async () => {
@@ -220,10 +220,12 @@ describe('LitecoinClient Test', () => {
     expect(fastest > fast)
   })
 
-  it('should error when an invalid index is used in getting balance', () => {
+  it('should error when an invalid index is used in getting address', () => {
     ltcClient.setNetwork('testnet')
     ltcClient.setPhrase(phraseOne)
-    return expect(ltcClient.getBalance(ltcClient.getAddress(-1))).rejects.toThrow()
+
+    const expectedError = 'index must be greater than zero'
+    expect(() => ltcClient.getAddress(-1)).toThrow(expectedError)
   })
 
   it('should error when an invalid address is used in transfer', () => {

--- a/packages/xchain-litecoin/__tests__/client.test.ts
+++ b/packages/xchain-litecoin/__tests__/client.test.ts
@@ -3,6 +3,7 @@ import { MIN_TX_FEE } from '../src/const'
 import { baseAmount, AssetLTC } from '@xchainjs/xchain-util'
 
 import mockSochainApi from '../__mocks__/sochain'
+import { getDerivePath } from '../src/utils'
 mockSochainApi.init()
 
 const ltcClient = new Client({ network: 'testnet' })
@@ -16,6 +17,12 @@ describe('LitecoinClient Test', () => {
   const MEMO = 'SWAP:THOR.RUNE'
   const phraseOne = 'atom green various power must another rent imitate gadget creek fat then'
   const addyOne = 'tltc1q2pkall6rf6v6j0cvpady05xhy37erndv05de7g'
+
+  const testnet_address_path0 = 'tltc1q2pkall6rf6v6j0cvpady05xhy37erndv05de7g'
+  const testnet_address_path1 = 'tltc1qut59ufcscqnkp8fgac68pj2ps5dzjjg4eggfqd'
+  const mainnet_address_path0 = 'ltc1qll0eutk38yy3jms0c85v4ey68z83c78h3fmsh3'
+  const mainnet_address_path1 = 'ltc1qsr5wh2sudyc7axh087lg7py6dsagphef63acgq'
+
 
   // const phraseTwo = 'green atom various power must another rent imitate gadget creek fat then'
   const addyTwo = 'tltc1ql68zjjdjx37499luueaw09avednqtge4u23q36'
@@ -45,6 +52,26 @@ describe('LitecoinClient Test', () => {
     const valid = ltcClient.validateAddress(address)
     expect(address).toEqual(addyOne)
     expect(valid).toBeTruthy()
+  })
+
+  it('set phrase with derivation path should return correct address', () => {
+    ltcClient.setNetwork('testnet')
+    expect(ltcClient.setPhrase(phraseOne, getDerivePath(0).testnet)).toEqual(testnet_address_path0)
+
+    ltcClient.setNetwork('mainnet')
+    expect(ltcClient.setPhrase(phraseOne, getDerivePath(0).mainnet)).toEqual(mainnet_address_path0)
+
+    ltcClient.setNetwork('testnet')
+    expect(ltcClient.setPhrase(phraseOne, getDerivePath(1).testnet)).toEqual(testnet_address_path1)
+
+    const otherBchPath1Test = new Client({phrase: phraseOne, network: 'testnet', derivationPath: "m/84'/1'/0'/0/1"})
+    expect(otherBchPath1Test.getAddress()).toEqual(testnet_address_path1)
+
+    ltcClient.setNetwork('mainnet')
+    expect(ltcClient.setPhrase(phraseOne, getDerivePath(1).mainnet)).toEqual(mainnet_address_path1)
+
+    const otherBchPath1TestM = new Client({phrase: phraseOne, network: 'mainnet', derivationPath: "m/84'/2'/0'/0/1"})
+    expect(otherBchPath1TestM.getAddress()).toEqual(mainnet_address_path1)
   })
 
   it('should get the right balance', async () => {

--- a/packages/xchain-litecoin/__tests__/client.test.ts
+++ b/packages/xchain-litecoin/__tests__/client.test.ts
@@ -64,14 +64,14 @@ describe('LitecoinClient Test', () => {
     ltcClient.setNetwork('testnet')
     expect(ltcClient.setPhrase(phraseOne, getDerivePath(1).testnet)).toEqual(testnet_address_path1)
 
-    const otherBchPath1Test = new Client({phrase: phraseOne, network: 'testnet', derivationPath: "m/84'/1'/0'/0/1"})
-    expect(otherBchPath1Test.getAddress()).toEqual(testnet_address_path1)
+    const otherLtcPath1Test = new Client({phrase: phraseOne, network: 'testnet', derivationPath: "m/84'/1'/0'/0/1"})
+    expect(otherLtcPath1Test.getAddress()).toEqual(testnet_address_path1)
 
     ltcClient.setNetwork('mainnet')
     expect(ltcClient.setPhrase(phraseOne, getDerivePath(1).mainnet)).toEqual(mainnet_address_path1)
 
-    const otherBchPath1TestM = new Client({phrase: phraseOne, network: 'mainnet', derivationPath: "m/84'/2'/0'/0/1"})
-    expect(otherBchPath1TestM.getAddress()).toEqual(mainnet_address_path1)
+    const otherLtcPath1TestM = new Client({phrase: phraseOne, network: 'mainnet', derivationPath: "m/84'/2'/0'/0/1"})
+    expect(otherLtcPath1TestM.getAddress()).toEqual(mainnet_address_path1)
   })
 
   it('should get the right balance', async () => {

--- a/packages/xchain-litecoin/package.json
+++ b/packages/xchain-litecoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-litecoin",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Custom Litecoin client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/bitcoinjs-lib": "^5.0.0",
     "@types/wif": "^2.0.1",
-    "@xchainjs/xchain-client": "^0.8.0",
+    "@xchainjs/xchain-client": "^0.9.0",
     "@xchainjs/xchain-util": "^0.2.7",
     "@xchainjs/xchain-crypto": "^0.2.3",
     "axios-mock-adapter": "^1.19.0",
@@ -45,7 +45,7 @@
     "wif": "^2.0.6"
   },
   "peerDependencies": {
-    "@xchainjs/xchain-client": "^0.8.0",
+    "@xchainjs/xchain-client": "^0.9.0",
     "@xchainjs/xchain-util": "^0.2.7",
     "@xchainjs/xchain-crypto": "^0.2.3",
     "axios": "^0.21.0",

--- a/packages/xchain-litecoin/src/client.ts
+++ b/packages/xchain-litecoin/src/client.ts
@@ -202,7 +202,7 @@ class Client implements LitecoinClient, XChainClient {
     if (index < 0) {
       throw new Error('index must be greater than zero')
     }
-    if (this.phrase !== '') {
+    if (this.phrase) {
       const ltcNetwork = Utils.ltcNetwork(this.net)
       const ltcKeys = this.getLtcKeys(this.phrase, index)
 

--- a/packages/xchain-litecoin/src/client.ts
+++ b/packages/xchain-litecoin/src/client.ts
@@ -203,7 +203,7 @@ class Client implements LitecoinClient, XChainClient {
     if (index < 0) {
       throw new Error('index must be greater than zero')
     }
-    if (this.phrase) {
+    if (this.phrase !== '') {
       const ltcNetwork = Utils.ltcNetwork(this.net)
       const ltcKeys = this.getLtcKeys(this.phrase, index)
 

--- a/packages/xchain-litecoin/src/client.ts
+++ b/packages/xchain-litecoin/src/client.ts
@@ -104,10 +104,10 @@ class Client implements LitecoinClient, XChainClient {
    * @throws {"Invalid phrase"}
    * Thrown if the given phase is invalid.
    */
-  setPhrase = (phrase: string): Address => {
+  setPhrase = (phrase: string, walletIndex = 0): Address => {
     if (validatePhrase(phrase)) {
       this.phrase = phrase
-      return this.getAddress(0)
+      return this.getAddress(walletIndex)
     } else {
       throw new Error('Invalid phrase')
     }

--- a/packages/xchain-litecoin/src/client.ts
+++ b/packages/xchain-litecoin/src/client.ts
@@ -25,7 +25,6 @@ import { TxIO } from './types/sochain-api-types'
  * LitecoinClient Interface
  */
 interface LitecoinClient {
-  // derivePath(): string
   getFeesWithRates(memo?: string): Promise<FeesWithRates>
   getFeesWithMemo(memo: string): Promise<Fees>
   getFeeRates(): Promise<FeeRates>

--- a/packages/xchain-litecoin/src/client.ts
+++ b/packages/xchain-litecoin/src/client.ts
@@ -258,13 +258,12 @@ class Client implements LitecoinClient, XChainClient {
    * @param {Address} address By default, it will return the balance of the current wallet. (optional)
    * @returns {Array<Balance>} The LTC balance of the address.
    */
-  getBalance = async (index = 0): Promise<Balance[]> => {
+  getBalance = async (address: Address): Promise<Balance[]> => {
     try {
-      const address: Address = this.getAddress(index)
       return Utils.getBalance({
         sochainUrl: this.sochainUrl,
         network: this.net,
-        address: address,
+        address,
       })
     } catch (e) {
       return Promise.reject(e)
@@ -283,12 +282,10 @@ class Client implements LitecoinClient, XChainClient {
     const offset = params?.offset ?? 0
     const limit = params?.limit || 10
     try {
-      const address = typeof params?.address === 'number' ? this.getAddress(params.address) : params?.address + ''
-
       const response = await sochain.getAddress({
         sochainUrl: this.sochainUrl,
         network: this.net,
-        address,
+        address: `${params?.address}`,
       })
       const total = response.txs.length
       const transactions: Tx[] = []

--- a/packages/xchain-litecoin/src/index.ts
+++ b/packages/xchain-litecoin/src/index.ts
@@ -2,7 +2,7 @@ export * from './types'
 export * from './client'
 export {
   broadcastTx,
-  getDerivePath,
+  // getDerivePath,
   getDefaultFees,
   getDefaultFeesWithRates,
   getPrefix,

--- a/packages/xchain-litecoin/src/types/common.ts
+++ b/packages/xchain-litecoin/src/types/common.ts
@@ -25,4 +25,4 @@ export type BroadcastTxParams = {
 }
 
 // We might extract it into xchain-client later
-export type DerivePath = { mainnet: string; testnet: string }
+// export type DerivePath = { mainnet: string; testnet: string }

--- a/packages/xchain-litecoin/src/types/common.ts
+++ b/packages/xchain-litecoin/src/types/common.ts
@@ -23,6 +23,3 @@ export type BroadcastTxParams = {
   nodeUrl: string
   auth?: NodeAuth
 }
-
-// We might extract it into xchain-client later
-// export type DerivePath = { mainnet: string; testnet: string }

--- a/packages/xchain-litecoin/src/utils.ts
+++ b/packages/xchain-litecoin/src/utils.ts
@@ -5,7 +5,7 @@ import { Address, Balance, Fees, Network, TxHash, TxParams } from '@xchainjs/xch
 import { AssetLTC, assetToString, BaseAmount, baseAmount, assetToBase, assetAmount } from '@xchainjs/xchain-util'
 import { LtcAddressUTXOs, AddressParams } from './types/sochain-api-types'
 import { FeeRate, FeeRates, FeesWithRates, GetChangeParams } from './types/client-types'
-import { BroadcastTxParams, DerivePath, UTXO, UTXOs } from './types/common'
+import { BroadcastTxParams, UTXO, UTXOs } from './types/common'
 import { MIN_TX_FEE } from './const'
 import coininfo from 'coininfo'
 
@@ -249,18 +249,18 @@ export const broadcastTx = async (params: BroadcastTxParams): Promise<TxHash> =>
   return await nodeApi.broadcastTx(params)
 }
 
-/**
- * Get DerivePath.
- *
- * @see https://github.com/satoshilabs/slips/blob/master/slip-0044.md
- *
- * @param {number} index (optional)
- * @returns {DerivePath} The litecoin derivation path by the index. (both mainnet and testnet)
- */
-export const getDerivePath = (index = 0): DerivePath => ({
-  mainnet: `84'/2'/0'/0/${index}`,
-  testnet: `84'/1'/0'/0/${index}`,
-})
+// /**
+//  * Get DerivePath.
+//  *
+//  * @see https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+//  *
+//  * @param {number} index (optional)
+//  * @returns {DerivePath} The litecoin derivation path by the index. (both mainnet and testnet)
+//  */
+// export const getDerivePath = (index = 0): DerivePath => ({
+//   mainnet: `84'/2'/0'/0/${index}`,
+//   testnet: `84'/1'/0'/0/${index}`,
+// })
 
 /**
  * Calculate fees based on fee rate and memo.

--- a/packages/xchain-litecoin/src/utils.ts
+++ b/packages/xchain-litecoin/src/utils.ts
@@ -249,19 +249,6 @@ export const broadcastTx = async (params: BroadcastTxParams): Promise<TxHash> =>
   return await nodeApi.broadcastTx(params)
 }
 
-// /**
-//  * Get DerivePath.
-//  *
-//  * @see https://github.com/satoshilabs/slips/blob/master/slip-0044.md
-//  *
-//  * @param {number} index (optional)
-//  * @returns {DerivePath} The litecoin derivation path by the index. (both mainnet and testnet)
-//  */
-// export const getDerivePath = (index = 0): DerivePath => ({
-//   mainnet: `84'/2'/0'/0/${index}`,
-//   testnet: `84'/1'/0'/0/${index}`,
-// })
-
 /**
  * Calculate fees based on fee rate and memo.
  *

--- a/packages/xchain-polkadot/CHANGELOG.md
+++ b/packages/xchain-polkadot/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.8.0 (2021-05-17)
+
+### Breaking change
+
+- added support for HD wallets
+
 # v.0.7.0 (2021-03-02)
 
 ### Breaking change

--- a/packages/xchain-polkadot/__tests__/client.test.ts
+++ b/packages/xchain-polkadot/__tests__/client.test.ts
@@ -75,7 +75,7 @@ describe('Client Test', () => {
       data: null,
     })
 
-    const balances = await polkadotClient.getBalance()
+    const balances = await polkadotClient.getBalance(polkadotClient.getAddress())
     expect(balances.length).toEqual(0)
   })
 
@@ -91,7 +91,7 @@ describe('Client Test', () => {
       },
     })
 
-    const balances = await polkadotClient.getBalance()
+    const balances = await polkadotClient.getBalance(polkadotClient.getAddress())
     expect(balances.length).toEqual(1)
     expect(balances[0].amount.amount().isEqualTo(baseAmount('500000000000', 12).amount())).toBeTruthy()
   })
@@ -109,7 +109,7 @@ describe('Client Test', () => {
       },
     })
 
-    const txHistory = await polkadotClient.getTransactions()
+    const txHistory = await polkadotClient.getTransactions({ address: polkadotClient.getAddress() })
     expect(txHistory.total).toEqual(0)
     expect(txHistory.txs.length).toEqual(0)
   })

--- a/packages/xchain-polkadot/package.json
+++ b/packages/xchain-polkadot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-polkadot",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Custom Polkadot client and utilities used by XChainJS clients",
   "keywords": [
     "THORChain",
@@ -36,7 +36,7 @@
     "@polkadot/api": "^3.1.1",
     "@polkadot/util": "^5.1.1",
     "@types/big.js": "^4.0.5",
-    "@xchainjs/xchain-client": "^0.7.0",
+    "@xchainjs/xchain-client": "^0.9.0",
     "@xchainjs/xchain-crypto": "^0.2.3",
     "@xchainjs/xchain-util": "^0.2.2",
     "axios": "^0.21.0",
@@ -52,7 +52,7 @@
     "axios": "^0.21.0",
     "@polkadot/api": "^3.1.1",
     "@polkadot/util": "^5.1.1",
-    "@xchainjs/xchain-client": "^0.7.0",
+    "@xchainjs/xchain-client": "^0.9.0",
     "@xchainjs/xchain-crypto": "^0.2.3",
     "@xchainjs/xchain-util": "^0.2.2"
   }

--- a/packages/xchain-polkadot/package.json
+++ b/packages/xchain-polkadot/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "clean": "rimraf lib/**",
     "build": "yarn clean && rollup -c",
-    "test": "jest --detectOpenHandles",
+    "test": "jest --detectOpenHandles --runInBand --forceExit",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "prepublishOnly": "yarn build",
     "start:example": "ts-node example/index.ts"

--- a/packages/xchain-polkadot/src/client.ts
+++ b/packages/xchain-polkadot/src/client.ts
@@ -418,6 +418,8 @@ class Client implements PolkadotClient, XChainClient {
       }
 
       const txHash = await transaction.signAndSend(this.getKeyringPair(fromAddress))
+      await api.disconnect()
+
       return txHash.toString()
     } catch (error) {
       return Promise.reject(error)
@@ -441,6 +443,7 @@ class Client implements PolkadotClient, XChainClient {
         .paymentInfo(this.getKeyringPair(fromAddress))
 
       const fee = baseAmount(info.partialFee.toString(), getDecimal(this.network))
+      await api.disconnect()
 
       return {
         type: 'byte',

--- a/packages/xchain-polkadot/src/client.ts
+++ b/packages/xchain-polkadot/src/client.ts
@@ -176,7 +176,7 @@ class Client implements PolkadotClient, XChainClient {
    * @throws {"Invalid phrase"}
    * Thrown if the given phase is invalid.
    */
-  setPhrase = (phrase: string): Address => {
+  setPhrase = (phrase: string, walletIndex = 0): Address => {
     if (this.phrase !== phrase) {
       if (!xchainCrypto.validatePhrase(phrase)) {
         throw new Error('Invalid phrase')
@@ -184,7 +184,7 @@ class Client implements PolkadotClient, XChainClient {
       this.phrase = phrase
     }
 
-    return this.getAddress()
+    return this.getAddress(walletIndex)
   }
 
   /**

--- a/packages/xchain-polkadot/src/client.ts
+++ b/packages/xchain-polkadot/src/client.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import {
+  RootDerivationPaths,
   Address,
   Balances,
   Fees,
@@ -37,9 +38,7 @@ export interface PolkadotClient {
 class Client implements PolkadotClient, XChainClient {
   private network: Network
   private phrase = ''
-  private address: Address = ''
-  private api: ApiPromise | null = null
-  private derivationPath = "44//354//0//0//0'"
+  private rootDerivationPaths: RootDerivationPaths
 
   /**
    * Constructor
@@ -47,22 +46,33 @@ class Client implements PolkadotClient, XChainClient {
    *
    * @param {XChainClientParams} params
    */
-  constructor({ network = 'testnet', phrase }: XChainClientParams) {
+  constructor({
+    network = 'testnet',
+    phrase,
+    rootDerivationPaths = {
+      mainnet: "44//354//0//0//0'", //TODO IS the root path we want to use?
+      testnet: "44//354//0//0//0'",
+    },
+  }: XChainClientParams) {
     this.network = network
+    this.rootDerivationPaths = rootDerivationPaths
 
     if (phrase) this.setPhrase(phrase)
   }
-
   /**
-   * @private
+   * Get getFullDerivationPath
    *
-   * Purge Provider.
-   *
-   * @returns {void}
+   * @param {number} index the HD wallet index
+   * @returns {string} The polkadot derivation path based on the network.
    */
-  private purgeProvider = (): void => {
-    this.api?.disconnect()
-    this.api = null
+  getFullDerivationPath(index = 0): string {
+    // console.log(this.rootDerivationPaths[this.network])
+    if (index === 0) {
+      // this should make the tests backwards compatible
+      return this.rootDerivationPaths[this.network]
+    } else {
+      return this.rootDerivationPaths[this.network] + `//${index}`
+    }
   }
 
   /**
@@ -71,33 +81,24 @@ class Client implements PolkadotClient, XChainClient {
    * @returns {void}
    */
   purgeClient = (): void => {
-    this.purgeProvider()
-
     this.phrase = ''
-    this.address = ''
   }
 
   /**
    * Set/update the current network.
    *
    * @param {Network} network `mainnet` or `testnet`.
-   * @returns {XChainClient}
    *
    * @throws {"Network must be provided"}
    * Thrown if network has not been set before.
    */
-  setNetwork(network: Network): XChainClient {
+  setNetwork(network: Network): void {
     if (!network) {
       throw new Error('Network must be provided')
     } else {
       if (network !== this.network) {
-        this.purgeProvider()
-
         this.network = network
-        this.address = ''
       }
-
-      return this
     }
   }
 
@@ -180,9 +181,7 @@ class Client implements PolkadotClient, XChainClient {
       if (!xchainCrypto.validatePhrase(phrase)) {
         throw new Error('Invalid phrase')
       }
-
       this.phrase = phrase
-      this.address = ''
     }
 
     return this.getAddress()
@@ -195,10 +194,10 @@ class Client implements PolkadotClient, XChainClient {
    *
    * @returns {KeyringPair} The keyring pair to be used to generate wallet address.
    * */
-  private getKeyringPair = (): KeyringPair => {
+  private getKeyringPair = (index: number): KeyringPair => {
     const key = new Keyring({ ss58Format: this.getSS58Format(), type: 'ed25519' })
 
-    return key.createFromUri(`${this.phrase}//${this.derivationPath}`)
+    return key.createFromUri(`${this.phrase}//${this.getFullDerivationPath(index)}`)
   }
 
   /**
@@ -211,16 +210,14 @@ class Client implements PolkadotClient, XChainClient {
    * */
   private getAPI = async (): Promise<ApiPromise> => {
     try {
-      if (!this.api) {
-        this.api = new ApiPromise({ provider: new WsProvider(this.getWsEndpoint()) })
-        await this.api.isReady
+      const api = new ApiPromise({ provider: new WsProvider(this.getWsEndpoint()) })
+      await api.isReady
+
+      if (!api.isConnected) {
+        await api.connect()
       }
 
-      if (!this.api.isConnected) {
-        await this.api.connect()
-      }
-
-      return this.api
+      return api
     } catch (error) {
       return Promise.reject(error)
     }
@@ -252,18 +249,8 @@ class Client implements PolkadotClient, XChainClient {
    *
    * @throws {"Address not defined"} Thrown if failed creating account from phrase.
    */
-  getAddress = (): Address => {
-    if (!this.address) {
-      const address = this.getKeyringPair().address
-
-      if (!address) {
-        throw new Error('Address not defined')
-      }
-
-      this.address = address
-    }
-
-    return this.address
+  getAddress = (index = 0): Address => {
+    return this.getKeyringPair(index).address
   }
 
   /**
@@ -272,8 +259,9 @@ class Client implements PolkadotClient, XChainClient {
    * @param {Address} address By default, it will return the balance of the current wallet. (optional)
    * @returns {Array<Balance>} The DOT balance of the address.
    */
-  getBalance = async (address?: Address, assets?: Asset[]): Promise<Balances> => {
+  getBalance = async (index = 0, assets?: Asset[]): Promise<Balances> => {
     try {
+      const address = this.getAddress(index)
       const response: SubscanResponse<Account> = await axios
         .post(`${this.getClientUrl()}/api/open/account`, { address: address || this.getAddress() })
         .then((res) => res.data)
@@ -404,7 +392,7 @@ class Client implements PolkadotClient, XChainClient {
     try {
       const api = await this.getAPI()
       let transaction = null
-
+      const fromAddress = params.from ? params.from : 0
       // Createing a transfer
       const transfer = api.tx.balances.transfer(params.recipient, params.amount.amount().toString())
       if (!params.memo) {
@@ -421,15 +409,15 @@ class Client implements PolkadotClient, XChainClient {
       }
 
       // Check balances
-      const paymentInfo = await transaction.paymentInfo(this.getKeyringPair())
+      const paymentInfo = await transaction.paymentInfo(this.getKeyringPair(fromAddress))
       const fee = baseAmount(paymentInfo.partialFee.toString(), getDecimal(this.network))
-      const balances = await this.getBalance(this.getAddress(), [AssetDOT])
+      const balances = await this.getBalance(fromAddress, [AssetDOT])
 
       if (!balances || params.amount.amount().plus(fee.amount()).isGreaterThan(balances[0].amount.amount())) {
         throw new Error('insufficient balance')
       }
 
-      const txHash = await transaction.signAndSend(this.getKeyringPair())
+      const txHash = await transaction.signAndSend(this.getKeyringPair(fromAddress))
       return txHash.toString()
     } catch (error) {
       return Promise.reject(error)
@@ -446,10 +434,11 @@ class Client implements PolkadotClient, XChainClient {
    */
   estimateFees = async (params: TxParams): Promise<Fees> => {
     try {
+      const fromAddress = params.from ? params.from : 0
       const api = await this.getAPI()
       const info = await api.tx.balances
         .transfer(params.recipient, params.amount.amount().toNumber())
-        .paymentInfo(this.getKeyringPair())
+        .paymentInfo(this.getKeyringPair(fromAddress))
 
       const fee = baseAmount(info.partialFee.toString(), getDecimal(this.network))
 

--- a/packages/xchain-thorchain/CHANGELOG.md
+++ b/packages/xchain-thorchain/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.13.6 (2021-04-16)
+
+### Update
+
+- Set `fee.gas` to `10000000` (ten million) in `deposit` due to failing withdraw transactions
+
 # v.0.13.5 (2021-04-16)
 
 ### Update

--- a/packages/xchain-thorchain/CHANGELOG.md
+++ b/packages/xchain-thorchain/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v.0.13.7 (2021-04-21)
+
+### Update
+
+- Export `MSG_SEND` `MSG_DEPOSIT` `MAX_COUNT`
+- Added `getCosmosClient()` 
+- Extend `getTransactions` parameters with an optional `filterFn`
+
 # v.0.13.6 (2021-04-16)
 
 ### Update

--- a/packages/xchain-thorchain/CHANGELOG.md
+++ b/packages/xchain-thorchain/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.15.0 (2021-05-17)
+
+### Breaking change
+
+- added support for HD wallets
+
 # v.0.14.0 (2021-05-05)
 
 ### Breaking change

--- a/packages/xchain-thorchain/__tests__/client.test.ts
+++ b/packages/xchain-thorchain/__tests__/client.test.ts
@@ -2,7 +2,7 @@ import nock from 'nock'
 
 import { TxsPage } from '@xchainjs/xchain-client'
 import { baseAmount, BaseAmount } from '@xchainjs/xchain-util'
-import { RPCResponse, RPCTxSearchResult, TxResponse } from '@xchainjs/xchain-cosmos'
+import { RPCResponse, RPCTxSearchResult, TxResponse, CosmosSDKClient } from '@xchainjs/xchain-cosmos'
 import { Msg } from 'cosmos-client'
 import { StdTx } from 'cosmos-client/x/auth'
 import { BroadcastTxCommitResult, Coin, BaseAccount, StdTxFee } from 'cosmos-client/api'
@@ -97,6 +97,10 @@ describe('Client Test', () => {
 
     thorClient.setNetwork('mainnet')
     expect(thorClient.getAddress()).toEqual(mainnet_address)
+  })
+
+  it('should allow to get the CosmosSDKClient', async () => {
+    expect(thorClient.getCosmosClient()).toBeInstanceOf(CosmosSDKClient)
   })
 
   it('should update net', async () => {

--- a/packages/xchain-thorchain/__tests__/client.test.ts
+++ b/packages/xchain-thorchain/__tests__/client.test.ts
@@ -177,7 +177,7 @@ describe('Client Test', () => {
     thorClient.setNetwork('mainnet')
     // mainnet - has balance: thor147jegk6e9sum7w3svy3hy4qme4h6dqdkgxhda5
     // mainnet - 0: thor19kacmmyuf2ysyvq3t9nrl9495l5cvktjs0yfws
-    mockAccountsBalance(thorClient.getClientUrl().node, 'thor19kacmmyuf2ysyvq3t9nrl9495l5cvktjs0yfws', {
+    mockAccountsBalance(thorClient.getClientUrl().node, 'thor147jegk6e9sum7w3svy3hy4qme4h6dqdkgxhda5', {
       height: 0,
       result: [
         {

--- a/packages/xchain-thorchain/__tests__/client.test.ts
+++ b/packages/xchain-thorchain/__tests__/client.test.ts
@@ -103,12 +103,9 @@ describe('Client Test', () => {
     const addressMain1 = thorClientEmptyMain1.getAddress()
     expect(addressMain1).toEqual(mainnet_address_path1)
 
-
     const thorClientEmptyTest1 = new Client({ phrase, network: 'testnet', derivationPath: "44'/931'/0'/0/1" })
     const addressTest1 = thorClientEmptyTest1.getAddress()
     expect(addressTest1).toEqual(testnet_address_path1)
-
-
   })
 
   it('throws an error passing an invalid phrase', async () => {

--- a/packages/xchain-thorchain/__tests__/client.test.ts
+++ b/packages/xchain-thorchain/__tests__/client.test.ts
@@ -169,7 +169,7 @@ describe('Client Test', () => {
       height: 0,
       result: [],
     })
-    const result = await thorClient.getBalance()
+    const result = await thorClient.getBalance(thorClient.getAddress(0))
     expect(result).toEqual([])
   })
 
@@ -190,7 +190,7 @@ describe('Client Test', () => {
     // Balance for the `thor147jegk6e9sum7w3svy3hy4qme4h6dqdkgxhda5`
     // const address = thorClient.getAddress(0)
     // expect(address).toEqual('thor147jegk6e9sum7w3svy3hy4qme4h6dqdkgxhda5')
-    const balances = await thorClient.getBalance(0 /*'thor147jegk6e9sum7w3svy3hy4qme4h6dqdkgxhda5'*/)
+    const balances = await thorClient.getBalance('thor147jegk6e9sum7w3svy3hy4qme4h6dqdkgxhda5')
     expect(balances.length).toEqual(1)
     expect(balances[0].asset).toEqual(AssetRune)
     expect(balances[0].amount.amount().isEqualTo(baseAmount(100).amount())).toBeTruthy()

--- a/packages/xchain-thorchain/__tests__/client.test.ts
+++ b/packages/xchain-thorchain/__tests__/client.test.ts
@@ -188,9 +188,6 @@ describe('Client Test', () => {
       ],
     })
 
-    // Balance for the `thor147jegk6e9sum7w3svy3hy4qme4h6dqdkgxhda5`
-    // const address = thorClient.getAddress(0)
-    // expect(address).toEqual('thor147jegk6e9sum7w3svy3hy4qme4h6dqdkgxhda5')
     const balances = await thorMainClient.getBalance('thor147jegk6e9sum7w3svy3hy4qme4h6dqdkgxhda5')
     expect(balances.length).toEqual(1)
     expect(balances[0].asset).toEqual(AssetRune)

--- a/packages/xchain-thorchain/__tests__/client.test.ts
+++ b/packages/xchain-thorchain/__tests__/client.test.ts
@@ -61,8 +61,10 @@ const assertTxHashGet = (url: string, hash: string, result: TxResponse): void =>
 describe('Client Test', () => {
   let thorClient: Client
   const phrase = 'rural bright ball negative already grass good grant nation screen model pizza'
-  const mainnet_address = 'thor19kacmmyuf2ysyvq3t9nrl9495l5cvktjs0yfws'
-  const testnet_address = 'tthor19kacmmyuf2ysyvq3t9nrl9495l5cvktj5c4eh4'
+  const mainnet_address_path0 = 'thor19kacmmyuf2ysyvq3t9nrl9495l5cvktjs0yfws'
+  const mainnet_address_path1 = 'thor1hrf34g3lxwvpk7gjte0xvahf3txnq8ecgaf4nc'
+  const testnet_address_path0 = 'tthor19kacmmyuf2ysyvq3t9nrl9495l5cvktj5c4eh4'
+  const testnet_address_path1 = 'tthor1hrf34g3lxwvpk7gjte0xvahf3txnq8ecv2c92a'
 
   beforeEach(() => {
     thorClient = new Client({ phrase, network: 'testnet' })
@@ -75,11 +77,38 @@ describe('Client Test', () => {
   it('should start with empty wallet', async () => {
     const thorClientEmptyMain = new Client({ phrase, network: 'mainnet' })
     const addressMain = thorClientEmptyMain.getAddress()
-    expect(addressMain).toEqual(mainnet_address)
+    expect(addressMain).toEqual(mainnet_address_path0)
 
     const thorClientEmptyTest = new Client({ phrase, network: 'testnet' })
     const addressTest = thorClientEmptyTest.getAddress()
-    expect(addressTest).toEqual(testnet_address)
+    expect(addressTest).toEqual(testnet_address_path0)
+  })
+
+  it('should derive address accordingly to the user param', async () => {
+    const thorClientEmptyMain = new Client({ phrase, network: 'mainnet', derivationPath: "44'/931'/0'/0/0" })
+    const addressMain = thorClientEmptyMain.getAddress()
+    expect(addressMain).toEqual(mainnet_address_path0)
+
+    const viaSetPhraseAddr1 = thorClientEmptyMain.setPhrase(phrase, "44'/931'/0'/0/1")
+    expect(viaSetPhraseAddr1).toEqual(mainnet_address_path1)
+
+    const thorClientEmptyTest = new Client({ phrase, network: 'testnet', derivationPath: "44'/931'/0'/0/0" })
+    const addressTest = thorClientEmptyTest.getAddress()
+    expect(addressTest).toEqual(testnet_address_path0)
+
+    const viaSetPhraseAddr1Test = thorClientEmptyTest.setPhrase(phrase, "44'/931'/0'/0/1")
+    expect(viaSetPhraseAddr1Test).toEqual(testnet_address_path1)
+
+    const thorClientEmptyMain1 = new Client({ phrase, network: 'mainnet', derivationPath: "44'/931'/0'/0/1" })
+    const addressMain1 = thorClientEmptyMain1.getAddress()
+    expect(addressMain1).toEqual(mainnet_address_path1)
+
+
+    const thorClientEmptyTest1 = new Client({ phrase, network: 'testnet', derivationPath: "44'/931'/0'/0/1" })
+    const addressTest1 = thorClientEmptyTest1.getAddress()
+    expect(addressTest1).toEqual(testnet_address_path1)
+
+
   })
 
   it('throws an error passing an invalid phrase', async () => {
@@ -93,10 +122,10 @@ describe('Client Test', () => {
   })
 
   it('should have right address', async () => {
-    expect(thorClient.getAddress()).toEqual(testnet_address)
+    expect(thorClient.getAddress()).toEqual(testnet_address_path0)
 
     thorClient.setNetwork('mainnet')
-    expect(thorClient.getAddress()).toEqual(mainnet_address)
+    expect(thorClient.getAddress()).toEqual(mainnet_address_path0)
   })
 
   it('should allow to get the CosmosSDKClient', async () => {
@@ -109,7 +138,7 @@ describe('Client Test', () => {
     expect(client.getNetwork()).toEqual('testnet')
 
     const address = await client.getAddress()
-    expect(address).toEqual(testnet_address)
+    expect(address).toEqual(testnet_address_path0)
   })
 
   it('should init, should have right prefix', async () => {
@@ -139,7 +168,7 @@ describe('Client Test', () => {
   })
 
   it('has no balances', async () => {
-    mockAccountsBalance(thorClient.getClientUrl().node, testnet_address, {
+    mockAccountsBalance(thorClient.getClientUrl().node, testnet_address_path0, {
       height: 0,
       result: [],
     })
@@ -326,7 +355,7 @@ describe('Client Test', () => {
       logs: [],
     }
 
-    mockAccountsAddress(thorClient.getClientUrl().node, testnet_address, {
+    mockAccountsAddress(thorClient.getClientUrl().node, testnet_address_path0, {
       height: 0,
       result: {
         coins: [
@@ -339,7 +368,7 @@ describe('Client Test', () => {
         sequence: '0',
       },
     })
-    mockAccountsBalance(thorClient.getClientUrl().node, testnet_address, {
+    mockAccountsBalance(thorClient.getClientUrl().node, testnet_address_path0, {
       height: 0,
       result: [
         {
@@ -372,7 +401,7 @@ describe('Client Test', () => {
       logs: [],
     }
 
-    mockAccountsAddress(thorClient.getClientUrl().node, testnet_address, {
+    mockAccountsAddress(thorClient.getClientUrl().node, testnet_address_path0, {
       height: 0,
       result: {
         coins: [
@@ -385,7 +414,7 @@ describe('Client Test', () => {
         sequence: '0',
       },
     })
-    mockAccountsBalance(thorClient.getClientUrl().node, testnet_address, {
+    mockAccountsBalance(thorClient.getClientUrl().node, testnet_address_path0, {
       height: 0,
       result: [
         {

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-thorchain",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Custom Thorchain client and utilities used by XChainJS clients",
   "keywords": [
     "THORChain",
@@ -33,9 +33,9 @@
   },
   "devDependencies": {
     "@types/big.js": "^6.0.0",
-    "@xchainjs/xchain-client": "^0.8.0",
+    "@xchainjs/xchain-client": "^0.9.0",
     "@xchainjs/xchain-util": "^0.2.7",
-    "@xchainjs/xchain-cosmos": "^0.12.0",
+    "@xchainjs/xchain-cosmos": "^0.13.0",
     "@xchainjs/xchain-crypto": "^0.2.3",
     "axios": "^0.21.0",
     "cosmos-client": "^0.39.2",
@@ -46,9 +46,9 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@xchainjs/xchain-client": "^0.8.0",
+    "@xchainjs/xchain-client": "^0.9.0",
     "@xchainjs/xchain-util": "^0.2.7",
-    "@xchainjs/xchain-cosmos": "^0.12.0",
+    "@xchainjs/xchain-cosmos": "^0.13.0",
     "@xchainjs/xchain-crypto": "^0.2.3",
     "axios": "^0.21.0",
     "cosmos-client": "^0.39.2"

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-thorchain",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "description": "Custom Thorchain client and utilities used by XChainJS clients",
   "keywords": [
     "THORChain",

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-thorchain",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "Custom Thorchain client and utilities used by XChainJS clients",
   "keywords": [
     "THORChain",

--- a/packages/xchain-thorchain/src/client.ts
+++ b/packages/xchain-thorchain/src/client.ts
@@ -37,11 +37,10 @@ import {
   registerCodecs,
   getTxType,
   getDefaultExplorerUrl,
+  MAX_TX_COUNT,
+  MSG_DEPOSIT,
+  MSG_SEND,
 } from './util'
-
-const MSG_SEND = 'send'
-const MSG_DEPOSIT = 'deposit'
-const MAX_TX_COUNT = 100
 
 /**
  * Interface for custom Thorchain client
@@ -51,6 +50,7 @@ export interface ThorchainClient {
   getClientUrl(): NodeUrl
   setExplorerUrl(explorerUrl: ExplorerUrl): void
   getExplorerNodeUrl(node: Address): string
+  getCosmosClient(): CosmosSDKClient
 
   deposit(params: DepositParam): Promise<TxHash>
 }
@@ -222,6 +222,14 @@ class Client implements ThorchainClient, XChainClient {
   }
 
   /**
+   * Get cosmos client
+   * @returns {CosmosSDKClient} current cosmos client
+   */
+  getCosmosClient = (): CosmosSDKClient => {
+    return this.thorClient
+  }
+
+  /**
    * Get the chain id.
    *
    * @returns {string} The chain id based on the network.
@@ -363,7 +371,9 @@ class Client implements ThorchainClient, XChainClient {
    * @param {TxHistoryParams} params The options to get transaction history. (optional)
    * @returns {TxsPage} The transaction history.
    */
-  getTransactions = async (params?: TxHistoryParams): Promise<TxsPage> => {
+  getTransactions = async (
+    params?: TxHistoryParams & { filterFn?: (tx: RPCTxResult) => boolean },
+  ): Promise<TxsPage> => {
     const messageAction = undefined
     const address = (params && params.address) || this.getAddress()
     const offset = params?.offset || 0
@@ -405,10 +415,14 @@ class Client implements ThorchainClient, XChainClient {
           (acc, tx) => [...acc, ...(acc.length === 0 || acc[acc.length - 1].hash !== tx.hash ? [tx] : [])],
           [] as RPCTxResult[],
         )
-        .filter((tx) => {
-          const action = getTxType(tx.tx_result.data, 'base64')
-          return action === MSG_DEPOSIT || action === MSG_SEND
-        })
+        .filter(
+          params?.filterFn
+            ? params.filterFn
+            : (tx) => {
+                const action = getTxType(tx.tx_result.data, 'base64')
+                return action === MSG_DEPOSIT || action === MSG_SEND
+              },
+        )
         .filter((_, index) => index < MAX_TX_COUNT)
 
       const total = history.length

--- a/packages/xchain-thorchain/src/client.ts
+++ b/packages/xchain-thorchain/src/client.ts
@@ -96,7 +96,6 @@ class Client implements ThorchainClient, XChainClient {
       server: this.getClientUrl().node,
       chainId: this.getChainId(),
       prefix: getPrefix(this.network),
-      rootDerivationPaths: this.rootDerivationPaths,
     })
 
     if (phrase) this.setPhrase(phrase)
@@ -127,7 +126,6 @@ class Client implements ThorchainClient, XChainClient {
 
     this.network = network
     this.cosmosClient.updatePrefix(getPrefix(this.network))
-    this.cosmosClient.setNetwork(network)
   }
 
   /**
@@ -299,7 +297,8 @@ class Client implements ThorchainClient, XChainClient {
    * @throws {"Phrase not set"}
    * Throws an error if phrase has not been set before
    * */
-  private getPrivateKey = (index = 0): PrivKey => this.cosmosClient.getPrivKeyFromMnemonic(this.phrase, index)
+  private getPrivateKey = (index = 0): PrivKey =>
+    this.cosmosClient.getPrivKeyFromMnemonic(this.phrase, this.getFullDerivationPath(index))
 
   /**
    * Get the current address.
@@ -309,7 +308,7 @@ class Client implements ThorchainClient, XChainClient {
    * @throws {Error} Thrown if phrase has not been set before. A phrase is needed to create a wallet and to derive an address from it.
    */
   getAddress = (index = 0): string => {
-    const address = this.cosmosClient.getAddressFromMnemonic(this.phrase, index)
+    const address = this.cosmosClient.getAddressFromMnemonic(this.phrase, this.getFullDerivationPath(index))
     if (!address) {
       throw new Error('address not defined')
     }

--- a/packages/xchain-thorchain/src/client.ts
+++ b/packages/xchain-thorchain/src/client.ts
@@ -267,7 +267,7 @@ class Client implements ThorchainClient, XChainClient {
    * @throws {"Invalid phrase"}
    * Thrown if the given phase is invalid.
    */
-  setPhrase = (phrase: string): Address => {
+  setPhrase = (phrase: string, walletIndex = 0): Address => {
     if (this.phrase !== phrase) {
       if (!xchainCrypto.validatePhrase(phrase)) {
         throw new Error('Invalid phrase')
@@ -275,7 +275,7 @@ class Client implements ThorchainClient, XChainClient {
       this.phrase = phrase
     }
 
-    return this.getAddress()
+    return this.getAddress(walletIndex)
   }
 
   /**

--- a/packages/xchain-thorchain/src/types/client-types.ts
+++ b/packages/xchain-thorchain/src/types/client-types.ts
@@ -26,9 +26,5 @@ export type DepositParam = {
   memo: string
 }
 
-export type Retry = {
-  noRetry?: number
-}
-
 export const THORChain = 'THOR'
 export const AssetRune: Asset = { chain: THORChain, symbol: 'RUNE', ticker: 'RUNE' }

--- a/packages/xchain-thorchain/src/util.ts
+++ b/packages/xchain-thorchain/src/util.ts
@@ -8,6 +8,9 @@ import { StdTx } from 'cosmos-client/x/auth'
 
 export const DECIMAL = 8
 export const DEFAULT_GAS_VALUE = '2000000'
+export const MSG_SEND = 'send'
+export const MSG_DEPOSIT = 'deposit'
+export const MAX_TX_COUNT = 100
 
 /**
  * Get denomination from Asset


### PR DESCRIPTION
enabled all current chains  to support HD addresses.

## Interface changes

```
export interface XChainClient {

  // now expects a number, DEFAULTS TO 0 if none provided
  getAddress(index: number): Address  

  //address required 
  getBalance(address: Address, assets?: Asset[]): Promise<Balances>

}
```
```
export type TxParams = {
  //send from which wallet index 
  walletIndex?: number 
  asset?: Asset
  amount: BaseAmount
  recipient: Address
  memo?: string
```
```
export type XChainClientParams = {
  network?: Network
  phrase?: string

  // the derivation path to use when getting HD wallets by index
  rootDerivationPaths?: RootDerivationPaths
}
```
