### PR TITLE
Fix bitcoincash transaction prefixed address

### DIFF
--- a/packages/xchain-bitcoincash/CHANGELOG.md
+++ b/packages/xchain-bitcoincash/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v.0.10.1 (2021-05-24)
+
+- Fixed missed addresses' stripping out for `parseTransaction`
+
 # v.0.10.0 (2021-05-21)
 
 ### Breaking change

--- a/packages/xchain-bitcoincash/__tests__/client.test.ts
+++ b/packages/xchain-bitcoincash/__tests__/client.test.ts
@@ -172,11 +172,11 @@ describe('BCHClient Test', () => {
     )
     expect(txData.hash).toEqual('0d5764c89d3fbf8bea9b329ad5e0ddb6047e72313c0f7b54dcb14f4d242da64b')
     expect(txData.from.length).toEqual(1)
-    expect(txData.from[0].from).toEqual('bchtest:qzyrvsm6z4ucrhaq4zza3wylre7mavvldgr67jrxt4')
+    expect(txData.from[0].from).toEqual('qzyrvsm6z4ucrhaq4zza3wylre7mavvldgr67jrxt4')
     expect(txData.from[0].amount.amount().isEqualTo(baseAmount(4008203, 8).amount())).toBeTruthy()
 
     expect(txData.to.length).toEqual(1)
-    expect(txData.to[0].to).toEqual('bchtest:qq235k7k9y5cwf3s2vfpxwgu8c5497sxnsdnxv6upc')
+    expect(txData.to[0].to).toEqual('qq235k7k9y5cwf3s2vfpxwgu8c5497sxnsdnxv6upc')
     expect(txData.to[0].amount.amount().isEqualTo(baseAmount(4005704, 8).amount())).toBeTruthy()
   })
 
@@ -250,10 +250,10 @@ describe('BCHClient Test', () => {
     expect(txs.total).toEqual(1345)
     expect(txs.txs[0].hash).toEqual('0d5764c89d3fbf8bea9b329ad5e0ddb6047e72313c0f7b54dcb14f4d242da64b')
     expect(txs.txs[0].from.length).toEqual(1)
-    expect(txs.txs[0].from[0].from).toEqual('bchtest:qzyrvsm6z4ucrhaq4zza3wylre7mavvldgr67jrxt4')
+    expect(txs.txs[0].from[0].from).toEqual('qzyrvsm6z4ucrhaq4zza3wylre7mavvldgr67jrxt4')
     expect(txs.txs[0].from[0].amount.amount().isEqualTo(baseAmount(4008203, 8).amount())).toBeTruthy()
     expect(txs.txs[0].to.length).toEqual(1)
-    expect(txs.txs[0].to[0].to).toEqual('bchtest:qq235k7k9y5cwf3s2vfpxwgu8c5497sxnsdnxv6upc')
+    expect(txs.txs[0].to[0].to).toEqual('qq235k7k9y5cwf3s2vfpxwgu8c5497sxnsdnxv6upc')
     expect(txs.txs[0].to[0].amount.amount().isEqualTo(baseAmount(4005704, 8).amount())).toBeTruthy()
   })
 

--- a/packages/xchain-bitcoincash/package.json
+++ b/packages/xchain-bitcoincash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-bitcoincash",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Custom bitcoincash client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",

--- a/packages/xchain-bitcoincash/src/utils.ts
+++ b/packages/xchain-bitcoincash/src/utils.ts
@@ -14,6 +14,8 @@ import {
   GetChangeParams,
   UTXOs,
   UTXO,
+  TransactionInput,
+  TransactionOutput,
 } from './types'
 import { getAccount, getRawTransaction, getUnspentTransactions } from './haskoin-api'
 import { Network as BCHNetwork, TransactionBuilder } from './types/bitcoincashjs-types'
@@ -188,20 +190,22 @@ export const parseTransaction = (tx: Transaction): Tx => {
   return {
     asset: AssetBCH,
     from: tx.inputs
-      .filter((input) => !!input.address)
+      // For correct type inference `Array.prototype.filter` needs manual type guard to be defined
+      .filter((input): input is Omit<TransactionInput, 'address'> & { address: string } => !!input.address)
       .map(
         (input) =>
           ({
-            from: input.address ? stripPrefix(input.address) : input.address,
+            from: stripPrefix(input.address),
             amount: baseAmount(input.value, BCH_DECIMAL),
           } as TxFrom),
       ),
     to: tx.outputs
-      .filter((output) => !!output.address)
+      // For correct type inference `Array.prototype.filter` needs manual type guard to be defined
+      .filter((output): output is Omit<TransactionOutput, 'address'> & { address: string } => !!output.address)
       .map(
         (output) =>
           ({
-            to: output.address ? stripPrefix(output.address) : output.address,
+            to: stripPrefix(output.address),
             amount: baseAmount(output.value, BCH_DECIMAL),
           } as TxTo),
       ),

--- a/packages/xchain-bitcoincash/src/utils.ts
+++ b/packages/xchain-bitcoincash/src/utils.ts
@@ -192,7 +192,7 @@ export const parseTransaction = (tx: Transaction): Tx => {
       .map(
         (input) =>
           ({
-            from: input.address,
+            from: input.address ? stripPrefix(input.address) : input.address,
             amount: baseAmount(input.value, BCH_DECIMAL),
           } as TxFrom),
       ),
@@ -201,7 +201,7 @@ export const parseTransaction = (tx: Transaction): Tx => {
       .map(
         (output) =>
           ({
-            to: output.address,
+            to: output.address ? stripPrefix(output.address) : output.address,
             amount: baseAmount(output.value, BCH_DECIMAL),
           } as TxTo),
       ),


### PR DESCRIPTION
- `utils:parseTransaction` added stripping prefixes to the address mapper
- bump version to `v0.10.1`