### PR TITLE
export client params types which are used in constructor

### DIFF
--- a/packages/xchain-bitcoin/src/client.ts
+++ b/packages/xchain-bitcoin/src/client.ts
@@ -28,7 +28,7 @@ interface BitcoinClient {
   getFeeRates(): Promise<FeeRates>
 }
 
-type BitcoinClientParams = XChainClientParams & {
+export type BitcoinClientParams = XChainClientParams & {
   sochainUrl?: string
   blockstreamUrl?: string
 }

--- a/packages/xchain-bitcoincash/src/client.ts
+++ b/packages/xchain-bitcoincash/src/client.ts
@@ -31,7 +31,7 @@ interface BitcoinCashClient {
   getFeeRates(): Promise<FeeRates>
 }
 
-type BitcoinCashClientParams = XChainClientParams & {
+export type BitcoinCashClientParams = XChainClientParams & {
   haskoinUrl?: ClientUrl
   nodeUrl?: ClientUrl
   nodeAuth?: NodeAuth

--- a/packages/xchain-ethereum/src/client.ts
+++ b/packages/xchain-ethereum/src/client.ts
@@ -84,7 +84,7 @@ export interface EthereumClient {
   ): Promise<TransactionResponse>
 }
 
-export type ClientParams = XChainClientParams & {
+export type EthereumClientParams = XChainClientParams & {
   ethplorerUrl?: string
   ethplorerApiKey?: string
   explorerUrl?: ExplorerUrl
@@ -108,7 +108,7 @@ export default class Client implements XChainClient, EthereumClient {
 
   /**
    * Constructor
-   * @param {ClientParams} params
+   * @param {EthereumClientParams} params
    */
   constructor({
     network = 'testnet',
@@ -122,7 +122,7 @@ export default class Client implements XChainClient, EthereumClient {
     },
     etherscanApiKey,
     infuraCreds,
-  }: ClientParams) {
+  }: EthereumClientParams) {
     this.rootDerivationPaths = rootDerivationPaths
     this.network = xchainNetworkToEths(network)
     this.setPhrase(phrase)

--- a/packages/xchain-ethereum/src/client.ts
+++ b/packages/xchain-ethereum/src/client.ts
@@ -84,7 +84,7 @@ export interface EthereumClient {
   ): Promise<TransactionResponse>
 }
 
-type ClientParams = XChainClientParams & {
+export type ClientParams = XChainClientParams & {
   ethplorerUrl?: string
   ethplorerApiKey?: string
   explorerUrl?: ExplorerUrl

--- a/packages/xchain-litecoin/src/client.ts
+++ b/packages/xchain-litecoin/src/client.ts
@@ -30,7 +30,7 @@ interface LitecoinClient {
   getFeeRates(): Promise<FeeRates>
 }
 
-type LitecoinClientParams = XChainClientParams & {
+export type LitecoinClientParams = XChainClientParams & {
   sochainUrl?: string
   nodeUrl?: string
   nodeAuth?: NodeAuth | null


### PR DESCRIPTION
The ClientParams types which are used in the constructor of the client are now also exported. Then I can use the type also when I'm initializing the clients.