### PR TITLE
refactored utils.buildTx() in BCH,LTC,BTC

### DIFF
--- a/packages/xchain-bitcoin/CHANGELOG.md
+++ b/packages/xchain-bitcoin/CHANGELOG.md
@@ -1,8 +1,11 @@
+# v.0.15.3 (2021-05-31)
+
+- refactor utils.buildTx() to include the memo for calculating inputs with accumulate() but re-adds it into outputs using `psbt.addOutput` to avoid dust attack error
+
 # v.0.15.2 (2021-05-31)
 
-### Breaking change
 - don't add memo output to `coinselect/accumulative`
-- add memo output by using `psbt.addOutput` 
+- add memo output by using `psbt.addOutput`
 
 # v.0.15.0 (2021-05-28)
 

--- a/packages/xchain-bitcoin/package.json
+++ b/packages/xchain-bitcoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-bitcoin",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Custom Bitcoin client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",

--- a/packages/xchain-bitcoincash/CHANGELOG.md
+++ b/packages/xchain-bitcoincash/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v.0.11.4 (2021-05-31)
+
+- refactor utils.buildTx() to include the memo for calculating inputs with accumulate() but re-adds it into outputs using `psbt.addOutput` to avoid dust attack error
+
 # v.0.11.3 (2021-05-31)
 
 ### Breaking Change

--- a/packages/xchain-bitcoincash/package.json
+++ b/packages/xchain-bitcoincash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-bitcoincash",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Custom bitcoincash client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",

--- a/packages/xchain-bitcoincash/src/utils.ts
+++ b/packages/xchain-bitcoincash/src/utils.ts
@@ -263,11 +263,16 @@ export const buildTx = async ({
     const compiledMemo = memo ? compileMemo(memo) : null
 
     const targetOutputs = []
-    // output to recipient
+    //1. output to recipient
     targetOutputs.push({
       address: recipient,
       value: amount.amount().toNumber(),
     })
+    //2. add output memo to targets (optional)
+    if (compiledMemo) {
+      targetOutputs.push({ script: compiledMemo, value: 0 })
+    }
+
     const { inputs, outputs } = accumulative(utxos, targetOutputs, feeRateWhole)
 
     // .inputs and .outputs will be undefined if no solution was found
@@ -285,22 +290,17 @@ export const buildTx = async ({
     // Outputs
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     outputs.forEach((output: any) => {
-      let out = undefined
       if (output.script) {
-        out = compiledMemo
+        transactionBuilder.addOutput(compiledMemo, 0) // Add OP_RETURN {script, value}
       } else if (!output.address) {
         //an empty address means this is the  change address
-        out = bitcash.address.toOutputScript(toLegacyAddress(sender), bchNetwork(network))
+        const out = bitcash.address.toOutputScript(toLegacyAddress(sender), bchNetwork(network))
+        transactionBuilder.addOutput(out, output.value)
       } else if (output.address) {
-        out = bitcash.address.toOutputScript(toLegacyAddress(output.address), bchNetwork(network))
+        const out = bitcash.address.toOutputScript(toLegacyAddress(output.address), bchNetwork(network))
+        transactionBuilder.addOutput(out, output.value)
       }
-      transactionBuilder.addOutput(out, output.value)
     })
-
-    // add output for memo
-    if (compiledMemo) {
-      transactionBuilder.addOutput(compiledMemo, 0) // Add OP_RETURN {script, value}
-    }
 
     return {
       builder: transactionBuilder,

--- a/packages/xchain-litecoin/CHANGELOG.md
+++ b/packages/xchain-litecoin/CHANGELOG.md
@@ -1,8 +1,13 @@
+# v.0.6.4 (2021-05-31)
+
+- refactor utils.buildTx() to include the memo for calculating inputs with accumulate() but re-adds it into outputs using `psbt.addOutput` to avoid dust attack error
+
 # v.0.6.3 (2021-05-31)
 
 ### Breaking change
+
 - don't add memo output to `coinselect/accumulative`
-- add memo output by using `psbt.addOutput` 
+- add memo output by using `psbt.addOutput`
 
 # v.0.6.1 (2021-05-30)
 

--- a/packages/xchain-litecoin/package.json
+++ b/packages/xchain-litecoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-litecoin",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Custom Litecoin client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",


### PR DESCRIPTION
this is a followup to fix #336, where we leave the memo in the ouputs to make sure accumulate includes enough inputs to cover the tx costs if a memo is included. we then re-add the memo using psbt.addOutput() to avoid the tx to be flagged with dust error. 