### PR TITLE
ETH: fix getTransactions filtering boundaries

### DIFF
--- a/packages/xchain-ethereum/CHANGELOG.md
+++ b/packages/xchain-ethereum/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - fixed `getTransactions`'s transactions filtering to match correct pagintaion's boundings
 
+### Update
+
+- updated `xchain-client` package version
+
 # v.0.21.0 (2021-05-27)
 
 ### Fix

--- a/packages/xchain-ethereum/CHANGELOG.md
+++ b/packages/xchain-ethereum/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.21.2 (2021-06-02)
+
+### Fix
+
+- fixed `getTransactions`'s transactions filtering to match correct pagintaion's boundings
+
 # v.0.21.0 (2021-05-27)
 
 ### Fix

--- a/packages/xchain-ethereum/package.json
+++ b/packages/xchain-ethereum/package.json
@@ -34,14 +34,14 @@
     "access": "public"
   },
   "devDependencies": {
-    "@xchainjs/xchain-client": "^0.9.1",
+    "@xchainjs/xchain-client": "^0.9.2",
     "@xchainjs/xchain-crypto": "^0.2.4",
     "@xchainjs/xchain-util": "^0.2.8",
     "axios": "^0.21.0",
     "ethers": "^5.1.0"
   },
   "peerDependencies": {
-    "@xchainjs/xchain-client": "^0.9.0",
+    "@xchainjs/xchain-client": "^0.9.2",
     "@xchainjs/xchain-crypto": "^0.2.3",
     "@xchainjs/xchain-util": "^0.2.7",
     "axios": "^0.21.0",

--- a/packages/xchain-ethereum/package.json
+++ b/packages/xchain-ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-ethereum",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Ethereum client for XChainJS",
   "keywords": [
     "XChain",

--- a/packages/xchain-ethereum/src/client.ts
+++ b/packages/xchain-ethereum/src/client.ts
@@ -418,8 +418,8 @@ export default class Client implements XChainClient, EthereumClient {
    */
   getTransactions = async (params?: TxHistoryParams): Promise<TxsPage> => {
     try {
-      const page = params?.offset || 0
-      const offset = params?.limit || 10
+      const offset = params?.offset || 0
+      const limit = params?.limit || 10
       const assetAddress = params?.asset
 
       const maxCount = 10000
@@ -448,7 +448,7 @@ export default class Client implements XChainClient, EthereumClient {
 
       return {
         total: transations.length,
-        txs: transations.filter((_, index) => index >= page * offset && index < (page + 1) * offset),
+        txs: transations.filter((_, index) => index >= offset && index < offset + limit),
       }
     } catch (error) {
       return Promise.reject(error)


### PR DESCRIPTION
- fixed `getTransactions` method
- bumped `v0.21.2`

works well with local `yarn link` for ASGDX project (related to https://github.com/thorchain/asgardex-electron/issues/1487)

https://user-images.githubusercontent.com/67793194/120477149-1d6acc00-c3b4-11eb-9afe-9cd1a571113a.mov

closes #343 
