### PR TITLE
Fix duplicated memo output

### DIFF
--- a/packages/xchain-litecoin/CHANGELOG.md
+++ b/packages/xchain-litecoin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v.0.6.4 (2021-05-31)
 
+- fix adding duplicated memo output in the `Utils.buildTx()`
+  
+# v.0.6.4 (2021-05-31)
+
 - refactor utils.buildTx() to include the memo for calculating inputs with accumulate() but re-adds it into outputs using `psbt.addOutput` to avoid dust attack error
 
 # v.0.6.3 (2021-05-31)

--- a/packages/xchain-litecoin/CHANGELOG.md
+++ b/packages/xchain-litecoin/CHANGELOG.md
@@ -1,7 +1,7 @@
-# v.0.6.4 (2021-05-31)
+# v.0.6.5 (2021-06-02)
 
 - fix adding duplicated memo output in the `Utils.buildTx()`
-  
+
 # v.0.6.4 (2021-05-31)
 
 - refactor utils.buildTx() to include the memo for calculating inputs with accumulate() but re-adds it into outputs using `psbt.addOutput` to avoid dust attack error

--- a/packages/xchain-litecoin/package.json
+++ b/packages/xchain-litecoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-litecoin",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Custom Litecoin client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",

--- a/packages/xchain-litecoin/src/utils.ts
+++ b/packages/xchain-litecoin/src/utils.ts
@@ -231,11 +231,6 @@ export const buildTx = async ({
       }
     })
 
-    // if memo exists, add memo output
-    if (compiledMemo) {
-      psbt.addOutput({ script: compiledMemo, value: 0 }) // Add OP_RETURN {script, value}
-    }
-
     return { psbt, utxos }
   } catch (e) {
     return Promise.reject(e)


### PR DESCRIPTION
## Changelog

### v.0.6.4 (2021-05-31)

- fix adding duplicated memo output in the `Utils.buildTx()`