### PR TITLE
[xchain-thorchain] Double `fee.gas` to `20m`

### DIFF
--- a/packages/xchain-thorchain/CHANGELOG.md
+++ b/packages/xchain-thorchain/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.16.1 (2021-06-14)
+
+### Fix
+
+- Double `fee.gas to `20000000` (twenty million) to avoid failing withdraw transactions
+
 # v.0.16.0 (2021-06-08)
 
 ### Breaking change

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-thorchain",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Custom Thorchain client and utilities used by XChainJS clients",
   "keywords": [
     "THORChain",

--- a/packages/xchain-thorchain/src/client.ts
+++ b/packages/xchain-thorchain/src/client.ts
@@ -528,7 +528,7 @@ class Client implements ThorchainClient, XChainClient {
       const accAddress = AccAddress.fromBech32(signer)
       const fee = unsignedStdTx.fee
       // max. gas
-      fee.gas = '10000000'
+      fee.gas = '20000000'
 
       return this.cosmosClient
         .signAndBroadcast(unsignedStdTx, privateKey, accAddress)


### PR DESCRIPTION
to avoid failing withdraw transactions + bump `v0.16.1`


Related issue https://github.com/thorchain/asgardex-electron/issues/1541