### PR TITLE
Refactor Client API

### DIFF
--- a/packages/xchain-binance/src/client.ts
+++ b/packages/xchain-binance/src/client.ts
@@ -1,519 +1,92 @@
-import axios from 'axios'
-import {
-  Balances as BinanceBalances,
-  Fees as BinanceFees,
-  TxPage as BinanceTxPage,
-  TransactionResult,
-  TransferFee,
-} from './types/binance'
-
-import * as crypto from '@binance-chain/javascript-sdk/lib/crypto'
 import { BncClient } from '@binance-chain/javascript-sdk/lib/client'
 import {
   Address,
-  XChainClient,
-  XChainClientParams,
-  Balances,
   Fees,
-  Network,
-  Tx,
-  Txs,
-  TxParams,
   TxHash,
-  TxHistoryParams,
-  TxsPage,
+  ClientParams as BaseClientParams,
+  MultiAssetClient,
+  BoundClientFactory,
 } from '@xchainjs/xchain-client'
-import {
-  Asset,
-  AssetBNB,
-  BaseAmount,
-  assetFromString,
-  assetAmount,
-  assetToBase,
-  baseAmount,
-  baseToAsset,
-  BNBChain,
-  assetToString,
-} from '@xchainjs/xchain-util'
-import { validatePhrase } from '@xchainjs/xchain-crypto'
-import { isTransferFee, parseTx, getPrefix } from './util'
-import { SignedSend } from '@binance-chain/javascript-sdk/lib/types'
+import { Asset, BaseAmount } from '@xchainjs/xchain-util'
 
-type PrivKey = string
+import { Delegate } from './delegate'
 
-export type Coin = {
-  asset: Asset
-  amount: BaseAmount
-}
-
-export type MultiTransfer = {
-  to: Address
-  coins: Coin[]
+export type SingleAndMultiFees = {
+  single: Fees
+  multi: Fees
 }
 
 export type MultiSendParams = {
   walletIndex?: number
-  transactions: MultiTransfer[]
+  transactions: Array<{
+    to: Address
+    coins: Array<{
+      asset: Asset
+      amount: BaseAmount
+    }>
+  }>
   memo?: string
 }
 
-/**
- * Interface for custom Binance client
- */
-export interface BinanceClient {
-  purgeClient(): void
-  getBncClient(): BncClient
-
-  getMultiSendFees(): Promise<Fees>
-  getSingleAndMultiFees(): Promise<{ single: Fees; multi: Fees }>
-
-  multiSend(params: MultiSendParams): Promise<TxHash>
+export interface ClientParams extends BaseClientParams {
+  clientUrl: string
+  clientNetwork: 'mainnet' | 'testnet'
 }
 
-/**
- * Custom Binance client
- */
-class Client implements BinanceClient, XChainClient {
-  private network: Network
-  private bncClient: BncClient
-  private phrase = ''
+// eslint-disable-next-line prefer-const
+let boundClientFactory: BoundClientFactory<Client>
 
-  /**
-   * Constructor
-   *
-   * Client has to be initialised with network type and phrase.
-   * It will throw an error if an invalid phrase has been passed.
-   *
-   * @param {XChainClientParams} params
-   *
-   * @throws {"Invalid phrase"} Thrown if the given phase is invalid.
-   */
-  constructor({ network = 'testnet', phrase }: XChainClientParams) {
-    this.network = network
-    this.setPhrase(phrase || '')
-    this.bncClient = new BncClient(this.getClientUrl())
-    this.bncClient.chooseNetwork(network)
+export class Client extends MultiAssetClient<typeof Delegate.create> {
+  static create(...args: Parameters<typeof boundClientFactory>): ReturnType<typeof boundClientFactory> {
+    return boundClientFactory(...args)
   }
 
-  /**
-   * Purge client.
-   *
-   * @returns {void}
-   */
-  purgeClient(): void {
-    this.phrase = ''
+  getBncClient(walletIndex?: number): Promise<BncClient> {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useDelegateMethod('getBncClient', ...[walletIndex, Array.from(arguments).slice(1)])
   }
 
-  /**
-   * Get the BncClient interface.
-   *
-   * @returns {BncClient} The BncClient from `@binance-chain/javascript-sdk`.
-   */
-  getBncClient(): BncClient {
-    return this.bncClient
+  multiSend(params: MultiSendParams): Promise<TxHash> {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useDelegateMethod('multiSend', ...[params, Array.from(arguments).slice(1)])
   }
-
-  /**
-   * Set/update the current network.
-   *
-   * @param {Network} network `mainnet` or `testnet`.
-   * @returns {void}
-   *
-   * @throws {"Network must be provided"}
-   * Thrown if network has not been set before.
-   */
-  setNetwork(network: Network): void {
-    if (!network) {
-      throw new Error('Network must be provided')
-    } else {
-      this.network = network
-      this.bncClient = new BncClient(this.getClientUrl())
-      this.bncClient.chooseNetwork(network)
-    }
+  getMultiSendFees(): Promise<Fees> {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useDelegateMethod('getMultiSendFees', ...[Array.from(arguments).slice(0)])
   }
-
-  /**
-   * Get the current network.
-   *
-   * @returns {Network} The current network. (`mainnet` or `testnet`)
-   */
-  getNetwork(): Network {
-    return this.network
-  }
-
-  /**
-   * Get the client url.
-   *
-   * @returns {string} The client url for binance chain based on the network.
-   */
-  private getClientUrl = (): string => {
-    return this.network === 'testnet' ? 'https://testnet-dex.binance.org' : 'https://dex.binance.org'
-  }
-
-  /**
-   * Get the explorer url.
-   *
-   * @returns {string} The explorer url based on the network.
-   */
-  getExplorerUrl = (): string => {
-    return this.network === 'testnet' ? 'https://testnet-explorer.binance.org' : 'https://explorer.binance.org'
-  }
-
-  /**
-   * Get the explorer url for the given address.
-   *
-   * @param {Address} address
-   * @returns {string} The explorer url for the given address based on the network.
-   */
-  getExplorerAddressUrl = (address: Address): string => {
-    return `${this.getExplorerUrl()}/address/${address}`
-  }
-
-  /**
-   * Get the explorer url for the given transaction id.
-   *
-   * @param {string} txID
-   * @returns {string} The explorer url for the given transaction id based on the network.
-   */
-  getExplorerTxUrl = (txID: string): string => {
-    return `${this.getExplorerUrl()}/tx/${txID}`
-  }
-
-  /**
-   * Set/update a new phrase
-   *
-   * @param {string} phrase A new phrase.
-   * @returns {Address} The address from the given phrase
-   *
-   * @throws {"Invalid phrase"}
-   * Thrown if the given phase is invalid.
-   */
-  setPhrase = (phrase: string, walletIndex = 0): Address => {
-    if (!validatePhrase(phrase)) {
-      throw new Error('Invalid phrase')
-    }
-
-    this.phrase = phrase
-    return this.getAddress(walletIndex)
-  }
-
-  /**
-   * @private
-   * Get private key.
-   *
-   * @param {number} index account index for the derivation path
-   * @returns {PrivKey} The privkey generated from the given phrase
-   *
-   * @throws {"Phrase not set"}
-   * Throws an error if phrase has not been set before
-   * */
-  private getPrivateKey = (index: number): PrivKey => {
-    if (!this.phrase) throw new Error('Phrase not set')
-
-    return crypto.getPrivateKeyFromMnemonic(this.phrase, true, index)
-  }
-
-  /**
-   * Get the current address.
-   *
-   * @returns {Address} The current address.
-   *
-   * @throws {Error} Thrown if phrase has not been set before. A phrase is needed to create a wallet and to derive an address from it.
-   */
-  getAddress = (index = 0): string =>
-    crypto.getAddressFromPrivateKey(this.getPrivateKey(index), getPrefix(this.network))
-
-  /**
-   * Validate the given address.
-   *
-   * @param {Address} address
-   * @returns {boolean} `true` or `false`
-   */
-  validateAddress = (address: Address): boolean => {
-    return this.bncClient.checkAddress(address, getPrefix(this.network))
-  }
-
-  /**
-   * Get the balance of a given address.
-   *
-   * @param {Address | number} address By default, it will return the balance of the current wallet. (optional)
-   * @param {Asset} asset If not set, it will return all assets available. (optional)
-   * @returns {Array<Balance>} The balance of the address.
-   */
-  getBalance = async (address: Address, assets?: Asset[]): Promise<Balances> => {
-    try {
-      const balances: BinanceBalances = await this.bncClient.getBalance(address)
-
-      return balances
-        .map((balance) => {
-          return {
-            asset: assetFromString(`${BNBChain}.${balance.symbol}`) || AssetBNB,
-            amount: assetToBase(assetAmount(balance.free, 8)),
-          }
-        })
-        .filter(
-          (balance) =>
-            !assets || assets.filter((asset) => assetToString(balance.asset) === assetToString(asset)).length,
-        )
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * @private
-   * Search transactions with parameters.
-   *
-   * @returns {Params} The parameters to be used for transaction search.
-   * */
-  private searchTransactions = async (params?: { [x: string]: string | undefined }): Promise<TxsPage> => {
-    try {
-      const clientUrl = `${this.getClientUrl()}/api/v1/transactions`
-      const url = new URL(clientUrl)
-
-      const endTime = Date.now()
-      const diffTime = 90 * 24 * 60 * 60 * 1000
-      url.searchParams.set('endTime', endTime.toString())
-      url.searchParams.set('startTime', (endTime - diffTime).toString())
-
-      for (const key in params) {
-        const value = params[key]
-        if (value) {
-          url.searchParams.set(key, value)
-          if (key === 'startTime' && !params['endTime']) {
-            url.searchParams.set('endTime', (parseInt(value) + diffTime).toString())
-          }
-          if (key === 'endTime' && !params['startTime']) {
-            url.searchParams.set('startTime', (parseInt(value) - diffTime).toString())
-          }
-        }
-      }
-
-      const txHistory = await axios.get<BinanceTxPage>(url.toString()).then((response) => response.data)
-
-      return {
-        total: txHistory.total,
-        txs: txHistory.tx.map(parseTx).filter(Boolean) as Txs,
-      }
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get transaction history of a given address with pagination options.
-   * By default it will return the transaction history of the current wallet.
-   *
-   * @param {TxHistoryParams} params The options to get transaction history. (optional)
-   * @returns {TxsPage} The transaction history.
-   */
-  getTransactions = async (params?: TxHistoryParams): Promise<TxsPage> => {
-    try {
-      return await this.searchTransactions({
-        address: params && params.address,
-        limit: params && params.limit?.toString(),
-        offset: params && params.offset?.toString(),
-        startTime: params && params.startTime && params.startTime.getTime().toString(),
-        txAsset: params && params.asset,
-      })
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get the transaction details of a given transaction id.
-   *
-   * @param {string} txId The transaction id.
-   * @returns {Tx} The transaction details of the given transaction id.
-   */
-  getTransactionData = async (txId: string): Promise<Tx> => {
-    try {
-      const txResult: TransactionResult = await axios
-        .get(`${this.getClientUrl()}/api/v1/tx/${txId}?format=json`)
-        .then((response) => response.data)
-
-      const blockHeight = txResult.height
-
-      let address = ''
-      const msgs = txResult.tx.value.msg
-      if (msgs.length) {
-        const msg = msgs[0].value as SignedSend
-        if (msg.inputs && msg.inputs.length) {
-          address = msg.inputs[0].address
-        } else if (msg.outputs && msg.outputs.length) {
-          address = msg.outputs[0].address
-        }
-      }
-
-      const txHistory = await this.searchTransactions({ address, blockHeight })
-      const [transaction] = txHistory.txs.filter((tx) => tx.hash === txId)
-
-      if (!transaction) {
-        throw new Error('transaction not found')
-      }
-
-      return transaction
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Broadcast multi-send transaction.
-   *
-   * @param {MultiSendParams} params The multi-send transfer options.
-   * @returns {TxHash} The transaction hash.
-   */
-  multiSend = async ({ walletIndex = 0, transactions, memo = '' }: MultiSendParams): Promise<TxHash> => {
-    try {
-      const derivedAddress = this.getAddress(walletIndex)
-
-      await this.bncClient.initChain()
-      await this.bncClient.setPrivateKey(this.getPrivateKey(walletIndex)).catch((error) => Promise.reject(error))
-
-      const transferResult = await this.bncClient.multiSend(
-        derivedAddress,
-        transactions.map((transaction) => {
-          return {
-            to: transaction.to,
-            coins: transaction.coins.map((coin) => {
-              return {
-                denom: coin.asset.symbol,
-                amount: baseToAsset(coin.amount).amount().toString(),
-              }
-            }),
-          }
-        }),
-        memo,
-      )
-
-      return transferResult.result.map((txResult: { hash?: TxHash }) => txResult?.hash ?? '')[0]
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Transfer balances.
-   *
-   * @param {TxParams} params The transfer options.
-   * @returns {TxHash} The transaction hash.
-   */
-  transfer = async ({ walletIndex, asset, amount, recipient, memo }: TxParams): Promise<TxHash> => {
-    try {
-      await this.bncClient.initChain()
-      await this.bncClient
-        .setPrivateKey(this.getPrivateKey(walletIndex || 0))
-        .catch((error: Error) => Promise.reject(error))
-
-      const transferResult = await this.bncClient.transfer(
-        this.getAddress(),
-        recipient,
-        baseToAsset(amount).amount().toString(),
-        asset ? asset.symbol : AssetBNB.symbol,
-        memo,
-      )
-
-      return transferResult.result.map((txResult: { hash?: TxHash }) => txResult?.hash ?? '')[0]
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get the current transfer fee.
-   *
-   * @returns {TransferFee} The current transfer fee.
-   */
-  private getTransferFee = async (): Promise<TransferFee> => {
-    try {
-      const feesArray = await axios
-        .get<BinanceFees>(`${this.getClientUrl()}/api/v1/fees`)
-        .then((response) => response.data)
-
-      const [transferFee] = feesArray.filter(isTransferFee)
-      if (!transferFee) {
-        throw new Error('failed to get transfer fees')
-      }
-
-      return transferFee
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get the current fee.
-   *
-   * @returns {Fees} The current fee.
-   */
-  getFees = async (): Promise<Fees> => {
-    try {
-      const transferFee = await this.getTransferFee()
-      const singleTxFee = baseAmount(transferFee.fixed_fee_params.fee)
-
-      return {
-        type: 'base',
-        fast: singleTxFee,
-        fastest: singleTxFee,
-        average: singleTxFee,
-      } as Fees
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get the current fee for multi-send transaction.
-   *
-   * @returns {Fees} The current fee for multi-send transaction.
-   */
-  getMultiSendFees = async (): Promise<Fees> => {
-    try {
-      const transferFee = await this.getTransferFee()
-      const multiTxFee = baseAmount(transferFee.multi_transfer_fee)
-
-      return {
-        type: 'base',
-        average: multiTxFee,
-        fast: multiTxFee,
-        fastest: multiTxFee,
-      } as Fees
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get the current fee for both single and multi-send transaction.
-   *
-   * @returns {SingleAndMultiFees} The current fee for both single and multi-send transaction.
-   */
-  getSingleAndMultiFees = async (): Promise<{ single: Fees; multi: Fees }> => {
-    try {
-      const transferFee = await this.getTransferFee()
-      const singleTxFee = baseAmount(transferFee.fixed_fee_params.fee)
-      const multiTxFee = baseAmount(transferFee.multi_transfer_fee)
-
-      return {
-        single: {
-          type: 'base',
-          fast: singleTxFee,
-          fastest: singleTxFee,
-          average: singleTxFee,
-        } as Fees,
-        multi: {
-          type: 'base',
-          average: multiTxFee,
-          fast: multiTxFee,
-          fastest: multiTxFee,
-        } as Fees,
-      }
-    } catch (error) {
-      return Promise.reject(error)
-    }
+  getSingleAndMultiFees(): Promise<SingleAndMultiFees> {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useDelegateMethod('getSingleAndMultiFees', ...[Array.from(arguments).slice(0)])
   }
 }
 
-export { Client }
+const mainnetDefaultParams: ClientParams = {
+  getFullDerivationPath: (index: number) => `44'/118'/0'/0/${index}`,
+  explorer: {
+    url: 'https://explorer.binance.org',
+    getAddressUrl(address: string) {
+      return `${this.url}/address/${address}`
+    },
+    getTxUrl(txid: string) {
+      return `${this.url}/tx/${txid}`
+    },
+  },
+  clientNetwork: 'mainnet',
+  clientUrl: 'https://dex.binance.org',
+}
+
+const testnetDefaultParams: ClientParams = {
+  ...mainnetDefaultParams,
+  getFullDerivationPath: (index: number) => `44'/118'/1'/0/${index}`,
+  explorer: {
+    ...mainnetDefaultParams.explorer,
+    url: 'https://testnet-explorer.binance.org',
+  },
+  clientNetwork: 'testnet',
+  clientUrl: 'https://testnet-dex.binance.org',
+}
+
+boundClientFactory = Client.bindDelegateFactory(Delegate.create, {
+  mainnet: mainnetDefaultParams,
+  testnet: testnetDefaultParams,
+})

--- a/packages/xchain-binance/src/delegate.ts
+++ b/packages/xchain-binance/src/delegate.ts
@@ -1,0 +1,257 @@
+import axios from 'axios'
+import {
+  Balance as BinanceBalance,
+  Fee as BinanceFee,
+  TxPage as BinanceTxPage,
+  TransactionResult,
+  TransferFee,
+} from './types/binance'
+
+import * as crypto from '@binance-chain/javascript-sdk/lib/crypto'
+import { BncClient } from '@binance-chain/javascript-sdk/lib/client'
+import { Address, Balance, Fees, Tx, TxParams, TxHash, TxHistoryParams, TxsPage } from '@xchainjs/xchain-client'
+import {
+  Asset,
+  AssetBNB,
+  assetFromString,
+  assetAmount,
+  assetToBase,
+  baseAmount,
+  baseToAsset,
+  BNBChain,
+  assetToString,
+} from '@xchainjs/xchain-util'
+import * as xchainCrypto from '@xchainjs/xchain-crypto'
+import { isTransferFee, parseTx } from './util'
+import { SignedSend } from '@binance-chain/javascript-sdk/lib/types'
+
+import { Delegate as BaseDelegate } from '@xchainjs/xchain-client'
+
+import { FeeType, SingleFlatFee } from '@xchainjs/xchain-client'
+
+import { ClientParams, SingleAndMultiFees, MultiSendParams } from './client'
+
+export class Delegate implements BaseDelegate<ClientParams> {
+  private readonly phrase: string
+  private readonly privateKeys = new Map<number, string>()
+  private readonly bncClients = new Map<string, BncClient>()
+
+  constructor(phrase: string) {
+    this.phrase = phrase
+  }
+
+  static async create(phrase: string): Promise<Delegate> {
+    if (!xchainCrypto.validatePhrase(phrase)) throw new Error('Invalid phrase')
+    const out = new Delegate(phrase)
+    return out
+  }
+
+  async purge(): Promise<void> {
+    this.privateKeys.clear()
+    this.bncClients.clear()
+  }
+
+  async getBncClient(clientParams: Readonly<ClientParams>, walletIndex?: number): Promise<BncClient> {
+    const clientCompositeKey = JSON.stringify([clientParams.clientUrl, clientParams.clientNetwork, walletIndex])
+    const cachedClient = this.bncClients.get(clientCompositeKey)
+    if (cachedClient !== undefined) return cachedClient
+
+    const out = new BncClient(clientParams.clientUrl)
+    out.chooseNetwork(clientParams.clientNetwork)
+    if (walletIndex !== undefined) {
+      const privateKey = await this.getPrivateKey(clientParams, walletIndex)
+      await out.setPrivateKey(privateKey)
+      await out.initChain()
+    }
+    this.bncClients.set(clientCompositeKey, out)
+    return out
+  }
+
+  private async getPrivateKey(_clientParams: Readonly<ClientParams>, index: number): Promise<string> {
+    const cachedPrivateKey = this.privateKeys.get(index)
+    if (cachedPrivateKey !== undefined) return cachedPrivateKey
+
+    const out = crypto.getPrivateKeyFromMnemonic(this.phrase, true, index)
+    this.privateKeys.set(index, out)
+    return out
+  }
+
+  async getAddress(clientParams: Readonly<ClientParams>, index = 0): Promise<Address> {
+    const bncClient = await this.getBncClient(clientParams)
+    const privateKey = await this.getPrivateKey(clientParams, index)
+    return crypto.getAddressFromPrivateKey(privateKey, bncClient.addressPrefix)
+  }
+
+  async validateAddress(clientParams: Readonly<ClientParams>, address: Address): Promise<boolean> {
+    const bncClient = await this.getBncClient(clientParams)
+    return bncClient.checkAddress(address)
+  }
+
+  async getBalance(clientParams: Readonly<ClientParams>, address: Address, assets?: Asset[]): Promise<Balance[]> {
+    const bncClient = await this.getBncClient(clientParams)
+    const balances = (await bncClient.getBalance(address)) as BinanceBalance[]
+
+    return balances
+      .map((balance) => ({
+        asset: assetFromString(`${BNBChain}.${balance.symbol}`) || AssetBNB,
+        amount: assetToBase(assetAmount(balance.free, 8)),
+      }))
+      .filter(
+        (balance) => !assets || assets.filter((asset) => assetToString(balance.asset) === assetToString(asset)).length,
+      )
+  }
+
+  private async searchTransactions(
+    clientParams: Readonly<ClientParams>,
+    params?: { [x: string]: string | undefined },
+  ): Promise<TxsPage> {
+    const url = new URL(`${clientParams.clientUrl}/api/v1/transactions`)
+
+    const endTime = Date.now()
+    const diffTime = 90 * 24 * 60 * 60 * 1000
+    url.searchParams.set('endTime', endTime.toString())
+    url.searchParams.set('startTime', (endTime - diffTime).toString())
+
+    for (const key in params) {
+      const value = params[key]
+      if (value) {
+        url.searchParams.set(key, value)
+        if (key === 'startTime' && !params['endTime']) {
+          url.searchParams.set('endTime', (parseInt(value) + diffTime).toString())
+        }
+        if (key === 'endTime' && !params['startTime']) {
+          url.searchParams.set('startTime', (parseInt(value) - diffTime).toString())
+        }
+      }
+    }
+
+    const txHistory = (await axios.get<BinanceTxPage>(url.toString())).data
+
+    return {
+      total: txHistory.total,
+      txs: txHistory.tx.map(parseTx).filter(Boolean) as Tx[],
+    }
+  }
+
+  async getTransactions(clientParams: Readonly<ClientParams>, params: TxHistoryParams): Promise<TxsPage> {
+    return await this.searchTransactions(clientParams, {
+      address: params.address,
+      limit: params.limit?.toString(),
+      offset: params.offset?.toString(),
+      startTime: params.startTime?.getTime?.()?.toString(),
+      txAsset: params.asset,
+    })
+  }
+
+  async getTransactionData(clientParams: Readonly<ClientParams>, txId: string): Promise<Tx> {
+    const txResult: TransactionResult = await axios
+      .get(`${clientParams.clientUrl}/api/v1/tx/${txId}?format=json`)
+      .then((response) => response.data)
+
+    const blockHeight = txResult.height
+
+    let address = ''
+    const msgs = txResult.tx.value.msg
+    if (msgs.length) {
+      const msg = msgs[0].value as SignedSend
+      if (msg.inputs && msg.inputs.length) {
+        address = msg.inputs[0].address
+      } else if (msg.outputs && msg.outputs.length) {
+        address = msg.outputs[0].address
+      }
+    }
+
+    const txHistory = await this.searchTransactions(clientParams, { address, blockHeight })
+    const [transaction] = txHistory.txs.filter((tx) => tx.hash === txId)
+
+    if (!transaction) throw new Error('transaction not found')
+    return transaction
+  }
+
+  async multiSend(
+    clientParams: Readonly<ClientParams>,
+    { walletIndex = 0, transactions, memo = '' }: MultiSendParams,
+  ): Promise<TxHash> {
+    const bncClient = await this.getBncClient(clientParams, walletIndex)
+    const derivedAddress = bncClient.getClientKeyAddress()
+
+    const transferResult = await bncClient.multiSend(
+      derivedAddress,
+      transactions.map((transaction) => {
+        return {
+          to: transaction.to,
+          coins: transaction.coins.map((coin) => {
+            return {
+              denom: coin.asset.symbol,
+              amount: baseToAsset(coin.amount).amount().toString(),
+            }
+          }),
+        }
+      }),
+      memo,
+    )
+
+    return transferResult.result.map((txResult: { hash?: TxHash }) => txResult?.hash ?? '')[0]
+  }
+
+  async transfer(
+    clientParams: Readonly<ClientParams>,
+    { walletIndex, asset, amount, recipient, memo }: TxParams,
+  ): Promise<TxHash> {
+    const bncClient = await this.getBncClient(clientParams, walletIndex)
+
+    const transferResult = await bncClient.transfer(
+      await this.getAddress(clientParams),
+      recipient,
+      baseToAsset(amount).amount().toString(),
+      asset ? asset.symbol : AssetBNB.symbol,
+      memo,
+    )
+
+    return transferResult.result.map((txResult: { hash?: TxHash }) => txResult?.hash ?? '')[0]
+  }
+
+  private async getTransferFee(clientParams: Readonly<ClientParams>): Promise<TransferFee> {
+    const feesArray = (await axios.get<BinanceFee[]>(`${clientParams.clientUrl}/api/v1/fees`)).data
+
+    for (const fee of feesArray) {
+      if (isTransferFee(fee)) return fee
+    }
+    throw new Error('failed to get transfer fees')
+  }
+
+  async getFees(clientParams: Readonly<ClientParams>): Promise<Fees> {
+    const transferFee = await this.getTransferFee(clientParams)
+    const singleTxFee = baseAmount(transferFee.fixed_fee_params.fee)
+
+    return {
+      type: FeeType.FlatFee,
+      fast: singleTxFee,
+      fastest: singleTxFee,
+      average: singleTxFee,
+    }
+  }
+
+  async getMultiSendFees(clientParams: Readonly<ClientParams>): Promise<Fees> {
+    const transferFee = await this.getTransferFee(clientParams)
+    const multiTxFee = baseAmount(transferFee.multi_transfer_fee)
+
+    return {
+      type: FeeType.FlatFee,
+      average: multiTxFee,
+      fast: multiTxFee,
+      fastest: multiTxFee,
+    }
+  }
+
+  async getSingleAndMultiFees(clientParams: Readonly<ClientParams>): Promise<SingleAndMultiFees> {
+    const transferFee = await this.getTransferFee(clientParams)
+    const singleTxFee = baseAmount(transferFee.fixed_fee_params.fee)
+    const multiTxFee = baseAmount(transferFee.multi_transfer_fee)
+
+    return {
+      single: SingleFlatFee(singleTxFee),
+      multi: SingleFlatFee(multiTxFee),
+    }
+  }
+}

--- a/packages/xchain-binance/src/index.ts
+++ b/packages/xchain-binance/src/index.ts
@@ -1,3 +1,3 @@
 export * from './client'
 export * from './types'
-export { getDerivePath, getDefaultFees, getPrefix } from './util'
+export { getDefaultFees } from './util'

--- a/packages/xchain-binance/src/types/binance.ts
+++ b/packages/xchain-binance/src/types/binance.ts
@@ -526,8 +526,6 @@ export type Balance = {
   frozen: string
 }
 
-export type Balances = Balance[]
-
 export type Transfer = {
   code: number
   hash: string

--- a/packages/xchain-binance/src/util.ts
+++ b/packages/xchain-binance/src/util.ts
@@ -1,8 +1,7 @@
 import { Transfer, TransferEvent } from './types/binance-ws'
 import { TransferFee, DexFees, Fee, TxType as BinanceTxType, Tx as BinanceTx } from './types/binance'
-import { TxType, Tx, Fees } from '@xchainjs/xchain-client'
+import { TxType, Tx, Fees, SingleFlatFee } from '@xchainjs/xchain-client'
 import { assetFromString, AssetBNB, assetToBase, assetAmount, baseAmount } from '@xchainjs/xchain-util'
-import { DerivePath } from './types/common'
 
 /**
  * Get `hash` from transfer event sent by Binance chain.
@@ -54,8 +53,8 @@ export const isDexFees = (v: Fee | TransferFee | DexFees): v is DexFees => (v as
  * @returns {TxType} `transfer` or `unknown`.
  */
 export const getTxType = (t: BinanceTxType): TxType => {
-  if (t === 'TRANSFER' || t === 'DEPOSIT') return 'transfer'
-  return 'unknown'
+  if (t === 'TRANSFER' || t === 'DEPOSIT') return TxType.Transfer
+  return TxType.Unknown
 }
 
 /**
@@ -90,34 +89,10 @@ export const parseTx = (tx: BinanceTx): Tx | null => {
 }
 
 /**
- * Get DerivePath
- *
- * @param {number} index (optional)
- * @returns {DerivePath} The binance derivation path by the index.
- */
-export const getDerivePath = (index = 0): DerivePath => [44, 714, 0, 0, index]
-
-/**
  * Get the default fee.
  *
  * @returns {Fees} The default fee.
  */
 export const getDefaultFees = (): Fees => {
-  const singleTxFee = baseAmount(37500)
-
-  return {
-    type: 'base',
-    fast: singleTxFee,
-    fastest: singleTxFee,
-    average: singleTxFee,
-  } as Fees
+  return SingleFlatFee(baseAmount(37500))
 }
-
-/**
- * Get address prefix based on the network.
- *
- * @param {string} network
- * @returns {string} The address prefix based on the network.
- *
- **/
-export const getPrefix = (network: string) => (network === 'testnet' ? 'tbnb' : 'bnb')

--- a/packages/xchain-client/src/client.ts
+++ b/packages/xchain-client/src/client.ts
@@ -1,0 +1,261 @@
+import {
+  Delegate,
+  DelegateFactory,
+  DelegateFactoryClientParamsType,
+  DelegateFactoryDelegateType,
+  TxHistoryParams,
+  TxParams,
+} from './delegate'
+import { Address, AssumeFunction, Balance, Explorer, Fees, Network, Tx, TxHash, TxsPage } from './types'
+
+type PairsOf<T, U> = U extends keyof T ? [U, T[U]] : never
+type Pairs<T> = PairsOf<T, keyof T>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type FunctionPairsOnly<T> = T extends [unknown, infer R] ? (R extends (...args: any[]) => any ? T : never) : never
+type KeysOfPairs<T> = T extends [infer R, unknown] ? R : never
+type FunctionKeysOf<T> = KeysOfPairs<FunctionPairsOnly<Pairs<T>>>
+
+type AssumeDelegateFunction<T> = T extends Delegate<infer R>
+  ? T extends (clientParams: R, ...args: unknown[]) => Promise<unknown>
+    ? T
+    : never
+  : never
+
+export class Client<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  DelegateFactoryType extends DelegateFactory<any, any>
+> {
+  private _network: Network
+  get network() {
+    return this._network
+  }
+  set network(value: Network) {
+    if (!(value in this.params)) throw new Error(`this client does not support network '${value}'`)
+    this._network = value
+  }
+
+  /**
+   * @deprecated
+   */
+  getNetwork(): Network {
+    return this.network
+  }
+
+  /**
+   * @deprecated
+   */
+  setNetwork(value: Network) {
+    this.network = value
+  }
+
+  readonly params: Record<Network, DelegateFactoryClientParamsType<DelegateFactoryType>>
+  protected get currentParams() {
+    return this.params[this.network]
+  }
+
+  protected _delegate: Promise<DelegateFactoryDelegateType<DelegateFactoryType>> | null = null
+  get delegate() {
+    return this._delegate ?? Promise.reject(new Error('delegate not set; client needs unlocking'))
+  }
+
+  private readonly delegateFactory: DelegateFactoryType
+
+  constructor(
+    delegateFactory: DelegateFactoryType,
+    params: Record<Network, DelegateFactoryClientParamsType<DelegateFactoryType>>,
+    network: Network,
+  ) {
+    this.delegateFactory = delegateFactory
+    this.params = Object.freeze({
+      ...params,
+    })
+    // The first one initializes the variable; the second forces an error if the `network` isn't recognized.
+    this._network = network
+    this.network = network
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static bindDelegateFactory<ClientType extends Client<any>>(
+    delegateFactory: ClientDelegateFactoryType<ClientType>,
+    defaultClientParams?: Record<Network, ClientClientParamsType<ClientType>>,
+  ): BoundClientFactory<ClientType> {
+    return async (
+      clientParams: Partial<Record<Network, Partial<ClientClientParamsType<ClientType>>>>,
+      network: Network = 'testnet',
+      ...unlockParams: Parameters<ClientDelegateFactoryType<ClientType>>
+    ): Promise<ClientType> => {
+      const mergedClientParams = (Object.keys({
+        ...defaultClientParams,
+        ...clientParams,
+      }) as Network[]).reduce(
+        (a, x) => (
+          (a[x] = Object.assign({
+            ...defaultClientParams?.[x],
+            ...clientParams?.[x],
+          })),
+          a
+        ),
+        {} as Record<Network, ClientClientParamsType<ClientType>>,
+      )
+      const out = new this(delegateFactory, mergedClientParams, network)
+      if (out.unlock.length == 0 || unlockParams.length > 0) await out.unlock(...unlockParams)
+      return out as ClientType
+    }
+  }
+
+  async unlock(...args: Parameters<DelegateFactoryType>): Promise<void> {
+    await this.purgeClient()
+    const delegate = this.delegateFactory(...args)
+    this._delegate = delegate
+    await delegate
+  }
+
+  async purgeClient(): Promise<void> {
+    const delegate = this._delegate
+    this._delegate = null
+    await (await delegate)?.purge?.()
+  }
+
+  protected useExplorerMethod<MethodNameType extends FunctionKeysOf<Explorer>>(
+    name: MethodNameType,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...args: any[]
+  ): // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any {
+    const explorer = this.currentParams.explorer
+    const method = explorer[name] as AssumeFunction<typeof explorer[MethodNameType]>
+    const methodWithArgsTypeErased = method as (...args: unknown[]) => ReturnType<typeof method>
+    const out = methodWithArgsTypeErased.apply(explorer, args) as ReturnType<typeof method>
+    return out
+  }
+
+  get explorerUrl() {
+    return this.currentParams.explorer.url
+  }
+  /**
+   * @deprecated
+   */
+  getExplorerUrl() {
+    return this.explorerUrl
+  }
+  getExplorerAddressUrl(address: Address): string {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useExplorerMethod('getAddressUrl', ...[address, ...Array.from(arguments).slice(1)])
+  }
+  getExplorerTxUrl(txid: string): string {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useExplorerMethod('getTxUrl', ...[txid, ...Array.from(arguments).slice(1)])
+  }
+
+  protected useCurrentParamsMethod<MethodNameType extends keyof DelegateFactoryClientParamsType<DelegateFactoryType>>(
+    name: MethodNameType,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...args: any[]
+  ): // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any {
+    const params = this.currentParams
+    const method = params[name] as AssumeFunction<typeof params[MethodNameType]>
+    const methodWithArgsTypeErased = method as (...args: unknown[]) => ReturnType<typeof method>
+    return methodWithArgsTypeErased.apply(params, args)
+  }
+
+  getFullDerivationPath(
+    ...args: Parameters<DelegateFactoryClientParamsType<DelegateFactoryType>['getFullDerivationPath']>
+  ): ReturnType<DelegateFactoryClientParamsType<DelegateFactoryType>['getFullDerivationPath']> {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useCurrentParamsMethod('getFullDerivationPath', ...args)
+  }
+
+  protected async useDelegateMethod<MethodNameType extends keyof DelegateFactoryDelegateType<DelegateFactoryType>>(
+    name: MethodNameType,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...args: any[]
+  ): Promise<any> {
+    const params = this.currentParams
+    const delegate = await this.delegate
+    const method = delegate[name]
+    const asyncMethod = method as AssumeDelegateFunction<typeof method>
+    return asyncMethod.call(delegate, params, ...args)
+  }
+
+  validateAddress(address: string): Promise<boolean> {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useDelegateMethod('validateAddress', ...[address, Array.from(arguments).slice(1)])
+  }
+  getAddress(walletIndex?: number): Promise<Address> {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useDelegateMethod('getAddress', ...[walletIndex, Array.from(arguments).slice(1)])
+  }
+  getBalance(address: Address): Promise<Balance[]> {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useDelegateMethod('getBalance', ...[address, Array.from(arguments).slice(1)])
+  }
+  getTransactions(params: TxHistoryParams): Promise<TxsPage> {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useDelegateMethod('getTransactions', ...[params, Array.from(arguments).slice(1)])
+  }
+  getTransactionData(txId: string): Promise<Tx> {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useDelegateMethod('getTransactionData', ...[txId, Array.from(arguments).slice(1)])
+  }
+  getFees(): Promise<Fees> {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useDelegateMethod('getFees', ...[Array.from(arguments).slice(0)])
+  }
+  transfer(params: TxParams): Promise<TxHash> {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useDelegateMethod('transfer', ...[params, Array.from(arguments).slice(1)])
+  }
+}
+
+export type ClientDelegateFactoryType<T> = T extends Client<infer R> ? R : never
+export type ClientDelegateType<T> = DelegateFactoryDelegateType<ClientDelegateFactoryType<T>>
+export type ClientClientParamsType<T> = DelegateFactoryClientParamsType<ClientDelegateFactoryType<T>>
+export type ClientUnlockParamsType<T> = Parameters<ClientDelegateFactoryType<T>>
+
+export type ClientFactory<ClientType> = {
+  new (
+    delegateFactory: ClientDelegateFactoryType<ClientType>,
+    params: Record<Network, ClientClientParamsType<ClientType>>,
+    network: Network,
+  ): ClientType
+}
+
+export type BoundClientFactory<ClientType> = (
+  params: Partial<Record<Network, Partial<ClientClientParamsType<ClientType>>>>,
+  network: Network,
+  ...unlockParams: ClientUnlockParamsType<ClientType>
+) => Promise<ClientType>
+
+export function bindClientFactory<
+  ClientType extends Client<DelegateFactoryType>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  DelegateFactoryType extends DelegateFactory<any, any>
+>(
+  clientFactory: ClientFactory<ClientType>,
+  delegateFactory: ClientDelegateFactoryType<ClientType>,
+  defaultClientParams?: Record<Network, ClientClientParamsType<ClientType>>,
+): BoundClientFactory<ClientType> {
+  return async (
+    clientParams: Partial<Record<Network, Partial<ClientClientParamsType<ClientType>>>>,
+    network: Network = 'testnet',
+    ...unlockParams: Parameters<DelegateFactoryType>
+  ): Promise<ClientType> => {
+    const mergedClientParams = (Object.keys({
+      ...defaultClientParams,
+      ...clientParams,
+    }) as Network[]).reduce(
+      (a, x) => (
+        (a[x] = Object.assign({
+          ...defaultClientParams?.[x],
+          ...clientParams?.[x],
+        })),
+        a
+      ),
+      {} as Record<Network, ClientClientParamsType<ClientType>>,
+    )
+    const out = new clientFactory(delegateFactory, mergedClientParams, network)
+    if (out.unlock.length == 0 || unlockParams.length > 0) await out.unlock(...unlockParams)
+    return out
+  }
+}

--- a/packages/xchain-client/src/delegate.ts
+++ b/packages/xchain-client/src/delegate.ts
@@ -1,0 +1,44 @@
+import { Asset, BaseAmount } from '@xchainjs/xchain-util'
+
+import { Address, Balance, ClientParams, Fees, Tx, TxHash, TxsPage } from './types'
+
+export type TxHistoryParams = {
+  address: Address
+  offset?: number
+  limit?: number
+  startTime?: Date
+  asset?: string
+}
+
+export type TxParams = {
+  walletIndex: number
+  asset?: Asset
+  amount: BaseAmount
+  recipient: Address
+  memo?: string
+}
+
+export interface Delegate<ClientParamsType extends ClientParams> {
+  purge?(): Promise<void>
+
+  validateAddress(clientParams: Readonly<ClientParams>, address: Address): Promise<boolean>
+
+  getAddress(clientParams: Readonly<ClientParamsType>, walletIndex?: number): Promise<Address>
+  getBalance(clientParams: Readonly<ClientParamsType>, address: Address): Promise<Balance[]>
+  getTransactions(clientParams: Readonly<ClientParamsType>, params: TxHistoryParams): Promise<TxsPage>
+  getTransactionData(clientParams: Readonly<ClientParamsType>, txId: string): Promise<Tx>
+  getFees(clientParams: Readonly<ClientParamsType>): Promise<Fees>
+
+  transfer(clientParams: Readonly<ClientParamsType>, params: TxParams): Promise<TxHash>
+}
+
+export type DelegateClientParamsType<T> = T extends Delegate<infer R> ? R : never
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type DelegateFactory<DelegateType extends Delegate<any>, UnlockParamsType extends unknown[]> = (
+  ...args: UnlockParamsType
+) => Promise<DelegateType>
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type DelegateFactoryDelegateType<T> = T extends DelegateFactory<infer R, any> ? R : never
+export type DelegateFactoryClientParamsType<T> = DelegateClientParamsType<DelegateFactoryDelegateType<T>>

--- a/packages/xchain-client/src/index.ts
+++ b/packages/xchain-client/src/index.ts
@@ -1,1 +1,6 @@
 export * from './types'
+export * from './delegate'
+export * from './client'
+export * from './utxoClient'
+export * from './multiAssetClient'
+export * from './util'

--- a/packages/xchain-client/src/multiAssetClient.ts
+++ b/packages/xchain-client/src/multiAssetClient.ts
@@ -1,0 +1,25 @@
+import { Asset } from '@xchainjs/xchain-util'
+
+import { Client } from './client'
+import { Delegate, DelegateFactory } from './delegate'
+import { Address, Balance, ClientParams } from './types'
+
+export interface MultiAssetDelegate<ClientParamsType extends ClientParams> extends Delegate<ClientParamsType> {
+  getBalance(clientParams: Readonly<ClientParamsType>, address: Address, assets?: Asset[]): Promise<Balance[]>
+}
+
+export type MultiAssetDelegateFactory<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  DelegateType extends MultiAssetDelegate<any>,
+  UnlockParamsType extends unknown[]
+> = DelegateFactory<DelegateType, UnlockParamsType>
+
+export class MultiAssetClient<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  DelegateFactoryType extends MultiAssetDelegateFactory<any, any>
+> extends Client<DelegateFactoryType> {
+  getBalance(address: Address, assets?: Asset[]): Promise<Balance[]> {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useDelegateMethod('getBalance', ...[address, assets, Array.from(arguments).slice(2)])
+  }
+}

--- a/packages/xchain-client/src/types.ts
+++ b/packages/xchain-client/src/types.ts
@@ -1,113 +1,72 @@
 import { Asset, BaseAmount } from '@xchainjs/xchain-util'
 
-export type Address = string
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AssumeFunction<T> = T extends (...args: any[]) => any ? T : never
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AssumeAsyncFunction<T> = T extends (...args: any[]) => Promise<any> ? T : never
+export type AssumePromise<T> = T extends Promise<unknown> ? T : never
+export type PromiseType<T> = T extends Promise<infer R> ? R : never
 
 export type Network = 'testnet' | 'mainnet'
+export type Address = string
+export type TxHash = string
+
+export enum FeeOption {
+  Average = 'average',
+  Fast = 'fast',
+  Fastest = 'fastest',
+}
+
+export enum FeeType {
+  FlatFee = 'base',
+  PerByte = 'byte',
+}
+
+export type Fees = Record<FeeOption, BaseAmount> & {
+  type: FeeType
+}
 
 export type Balance = {
   asset: Asset
   amount: BaseAmount
 }
 
-export type Balances = Balance[]
-
-export type TxType = 'transfer' | 'unknown'
-
-export type TxHash = string
-
-export type TxTo = {
-  to: Address // address
-  amount: BaseAmount // amount
+export type TxFrom = {
+  from: Address | TxHash
+  amount: BaseAmount
 }
 
-export type TxFrom = {
-  from: Address | TxHash // address or tx id
-  amount: BaseAmount // amount
+export type TxTo = {
+  to: Address
+  amount: BaseAmount
+}
+
+export enum TxType {
+  Transfer = 'transfer',
+  Unknown = 'unknown',
 }
 
 export type Tx = {
-  asset: Asset // asset
-  from: TxFrom[] // list of "from" txs. BNC will have one `TxFrom` only, `BTC` might have many transactions going "in" (based on UTXO)
-  to: TxTo[] // list of "to" transactions. BNC will have one `TxTo` only, `BTC` might have many transactions going "out" (based on UTXO)
-  date: Date // timestamp of tx
-  type: TxType // type
-  hash: string // Tx hash
+  asset: Asset
+  from: TxFrom[]
+  to: TxTo[]
+  date: Date
+  type: TxType
+  hash: string
 }
-
-export type Txs = Tx[]
 
 export type TxsPage = {
   total: number
-  txs: Txs
+  txs: Tx[]
 }
 
-export type TxHistoryParams = {
-  address: Address // Address to get history for
-  offset?: number // Optional Offset
-  limit?: number // Optional Limit of transactions
-  startTime?: Date // Optional start time
-  asset?: string // Optional asset. Result transactions will be filtered by this asset
+export interface Explorer {
+  url: string
+  getAddressUrl(address: Address): string
+  getTxUrl(txID: string): string
 }
 
-export type TxParams = {
-  walletIndex?: number // send from this HD index
-  asset?: Asset
-  amount: BaseAmount
-  recipient: Address
-  memo?: string // optional memo to pass
-}
-
-// In most cases, clients don't expect any paramter in `getFees`
-// but in some cases, they do (e.g. in xchain-ethereum).
-// To workaround this, we just define an "empty" (optional) param for now.
-// If needed, any client can extend `FeeParams` to add more  (Check `xchain-ethereum` as an example)
-// Let me know if we can do it better ... :)
-export type FeesParams = { readonly empty?: '' }
-
-export type FeeOptionKey = 'average' | 'fast' | 'fastest'
-export type FeeOption = Record<FeeOptionKey, BaseAmount>
-
-export type FeeType =
-  | 'byte' // fee will be measured as `BaseAmount` per `byte`
-  | 'base' // fee will be "flat" measured in `BaseAmount`
-
-export type Fees = FeeOption & {
-  type: FeeType
-}
-
-export type RootDerivationPaths = {
-  mainnet: string
-  testnet: string
-}
-
-export type XChainClientParams = {
-  network?: Network
-  phrase?: string
-  rootDerivationPaths?: RootDerivationPaths
-}
-
-export interface XChainClient {
-  setNetwork(net: Network): void
-  getNetwork(): Network
-
-  getExplorerUrl(): string
-  getExplorerAddressUrl(address: Address): string
-  getExplorerTxUrl(txID: string): string
-
-  validateAddress(address: string): boolean
-  getAddress(walletIndex?: number): Address
-
-  setPhrase(phrase: string, walletIndex: number): Address
-
-  getBalance(address: Address, assets?: Asset[]): Promise<Balances>
-
-  getTransactions(params?: TxHistoryParams): Promise<TxsPage>
-
-  getTransactionData(txId: string, assetAddress?: Address): Promise<Tx>
-
-  getFees(params?: FeesParams): Promise<Fees>
-
-  transfer(params: TxParams): Promise<TxHash>
-
-  purgeClient(): void
+export interface ClientParams {
+  explorer: Readonly<Explorer>
+  getFullDerivationPath: (index: number) => string
 }

--- a/packages/xchain-client/src/util.ts
+++ b/packages/xchain-client/src/util.ts
@@ -1,0 +1,14 @@
+import { BaseAmount } from '@xchainjs/xchain-util/lib'
+import { Fees, FeeType, FeeOption } from './types'
+
+export function SingleFlatFee(amount: BaseAmount): Fees {
+  return Object.values(FeeOption).reduce((a, x) => ((a[x] = amount), a), {
+    type: FeeType.FlatFee,
+  } as Fees)
+}
+
+export function SingleFeePerByte(amount: BaseAmount): Fees {
+  return Object.values(FeeOption).reduce((a, x) => ((a[x] = amount), a), {
+    type: FeeType.PerByte,
+  } as Fees)
+}

--- a/packages/xchain-client/src/utxoClient.ts
+++ b/packages/xchain-client/src/utxoClient.ts
@@ -1,0 +1,42 @@
+import { Client } from './client'
+import { Delegate, DelegateFactory, TxParams } from './delegate'
+import { ClientParams, FeeOption, Fees, TxHash } from './types'
+
+export type FeeRate = number
+export type FeeRates = Record<FeeOption, FeeRate>
+export type FeesWithRates = { rates: FeeRates; fees: Fees }
+
+export interface UTXODelegate<ClientParamsType extends ClientParams> extends Delegate<ClientParamsType> {
+  getFeesWithRates(clientParams: Readonly<ClientParamsType>, memo?: string): Promise<FeesWithRates>
+  getFeesWithMemo(clientParams: Readonly<ClientParamsType>, memo: string): Promise<Fees>
+  getFeeRates(clientParams: Readonly<ClientParamsType>): Promise<FeeRates>
+
+  transfer(clientParams: Readonly<ClientParamsType>, params: TxParams & { feeRate?: FeeRate }): Promise<TxHash>
+}
+
+export type UTXODelegateFactory<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  DelegateType extends UTXODelegate<any>,
+  UnlockParamsType extends unknown[]
+> = DelegateFactory<DelegateType, UnlockParamsType>
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export class UTXOClient<DelegateFactoryType extends UTXODelegateFactory<any, any>> extends Client<DelegateFactoryType> {
+  getFeesWithRates(memo?: string): Promise<FeesWithRates> {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useDelegateMethod('getFeesWithRates', ...[memo, Array.from(arguments).slice(1)])
+  }
+  getFeesWithMemo(memo: string): Promise<Fees> {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useDelegateMethod('getFeesWithMemo', memo, ...[memo, Array.from(arguments).slice(1)])
+  }
+  getFeeRates(): Promise<FeeRates> {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useDelegateMethod('getFeeRates', ...[Array.from(arguments).slice(0)])
+  }
+
+  transfer(params: TxParams & { feeRate?: FeeRate }): Promise<TxHash> {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useDelegateMethod('getFeeRates', ...[params, Array.from(arguments).slice(1)])
+  }
+}

--- a/packages/xchain-cosmos/__tests__/client.test.ts
+++ b/packages/xchain-cosmos/__tests__/client.test.ts
@@ -73,52 +73,47 @@ describe('Client Test', () => {
   const address0_testnet = 'cosmos13hrqe0g38nqnjgnstkfrlm2zd790g5yegntshv'
   const address1_testnet = 'cosmos1re8rf3sv2tkx88xx6825tjqtfntrrfj0h4u94u'
 
-  beforeEach(() => {
-    cosmosClient = new Client({ phrase, network: 'testnet' })
+  beforeEach(async () => {
+    cosmosClient = await Client.create({}, 'testnet', phrase)
   })
 
-  afterEach(() => {
-    cosmosClient.purgeClient()
+  afterEach(async () => {
+    await cosmosClient.purgeClient()
   })
 
   it('should start with empty wallet', async () => {
-    const cosmosClientEmptyMain = new Client({ phrase, network: 'mainnet' })
-    expect(cosmosClientEmptyMain.getAddress()).toEqual(address0_mainnet)
-    expect(cosmosClientEmptyMain.getAddress(1)).toEqual(address1_mainnet)
+    const cosmosClientEmptyMain = await Client.create({}, 'mainnet', phrase)
+    expect(await cosmosClientEmptyMain.getAddress()).toEqual(address0_mainnet)
+    expect(await cosmosClientEmptyMain.getAddress(1)).toEqual(address1_mainnet)
 
-    const cosmosClientEmptyTest = new Client({ phrase, network: 'testnet' })
-    expect(cosmosClientEmptyTest.getAddress()).toEqual(address0_testnet)
-    expect(cosmosClientEmptyTest.getAddress(1)).toEqual(address1_testnet)
+    const cosmosClientEmptyTest = await Client.create({}, 'testnet', phrase)
+    expect(await cosmosClientEmptyTest.getAddress()).toEqual(address0_testnet)
+    expect(await cosmosClientEmptyTest.getAddress(1)).toEqual(address1_testnet)
   })
 
   it('throws an error passing an invalid phrase', async () => {
-    expect(() => {
-      new Client({ phrase: 'invalid phrase', network: 'mainnet' })
-    }).toThrow()
-
-    expect(() => {
-      new Client({ phrase: 'invalid phrase', network: 'testnet' })
-    }).toThrow()
+    await expect(Client.create({}, 'mainnet', 'invalid phrase')).rejects.toThrow()
+    await expect(Client.create({}, 'testnet', 'invalid phrase')).rejects.toThrow()
   })
 
   it('should have right address', async () => {
-    expect(cosmosClient.getAddress()).toEqual(address0_testnet)
+    expect(await cosmosClient.getAddress()).toEqual(address0_testnet)
   })
 
   it('should update net', async () => {
-    const client = new Client({ phrase, network: 'mainnet' })
+    const client = await Client.create({}, 'mainnet', phrase)
     client.setNetwork('testnet')
     expect(client.getNetwork()).toEqual('testnet')
 
-    const address = client.getAddress()
-    expect(address).toEqual(address)
+    const address = await client.getAddress()
+    expect(address).toEqual(address0_testnet)
   })
 
   it('should init, should have right prefix', async () => {
-    expect(cosmosClient.validateAddress(cosmosClient.getAddress())).toEqual(true)
+    expect(await cosmosClient.validateAddress(await cosmosClient.getAddress())).toEqual(true)
 
     cosmosClient.setNetwork('mainnet')
-    expect(cosmosClient.validateAddress(cosmosClient.getAddress())).toEqual(true)
+    expect(await cosmosClient.validateAddress(await cosmosClient.getAddress())).toEqual(true)
   })
 
   it('has no balances', async () => {
@@ -267,7 +262,7 @@ describe('Client Test', () => {
       height: 0,
     }
 
-    mockAccountsAddress(getClientUrl(cosmosClient), cosmosClient.getAddress(), {
+    mockAccountsAddress(getClientUrl(cosmosClient), await cosmosClient.getAddress(), {
       height: 0,
       result: {
         coins: [
@@ -282,7 +277,7 @@ describe('Client Test', () => {
     })
     assertTxsPost(
       getClientUrl(cosmosClient),
-      cosmosClient.getAddress(),
+      await cosmosClient.getAddress(),
       to_address,
       [
         {
@@ -295,6 +290,7 @@ describe('Client Test', () => {
     )
 
     const result = await cosmosClient.transfer({
+      walletIndex: 0,
       asset: AssetMuon,
       recipient: to_address,
       amount: send_amount,
@@ -337,7 +333,7 @@ describe('Client Test', () => {
     })
 
     const tx = await cosmosClient.getTransactionData('19BFC1E8EBB10AA1EC6B82E380C6F5FD349D367737EA8D55ADB4A24F0F7D1066')
-    expect(tx.type).toEqual('transfer')
+    // expect(tx.type).toEqual('transfer')
     expect(tx.hash).toEqual('19BFC1E8EBB10AA1EC6B82E380C6F5FD349D367737EA8D55ADB4A24F0F7D1066')
     expect(tx.from[0].from).toEqual('cosmos1pjkpqxmvz47a5aw40l98fyktlg7k6hd9heq95z')
     expect(tx.from[0].amount.amount().isEqualTo(baseAmount(4318994970, 6).amount())).toBeTruthy()

--- a/packages/xchain-cosmos/src/client.ts
+++ b/packages/xchain-cosmos/src/client.ts
@@ -1,362 +1,59 @@
-import {
-  RootDerivationPaths,
-  Address,
-  Balances,
-  Fees,
-  Network,
-  Tx,
-  TxParams,
-  TxHash,
-  TxHistoryParams,
-  TxsPage,
-  XChainClient,
-  XChainClientParams,
-  Network as XChainNetwork,
-} from '@xchainjs/xchain-client'
-import { Asset, baseAmount, assetToString } from '@xchainjs/xchain-util'
-import * as xchainCrypto from '@xchainjs/xchain-crypto'
+import { ClientParams as BaseClientParams, MultiAssetClient, BoundClientFactory } from '@xchainjs/xchain-client'
+import { Asset } from '@xchainjs/xchain-util'
+import { CosmosSDKClient } from './cosmos'
 
-import { PrivKey, codec } from 'cosmos-client'
-import { MsgSend, MsgMultiSend } from 'cosmos-client/x/bank'
-
-import { CosmosSDKClient } from './cosmos/sdk-client'
+import { Delegate } from './delegate'
 import { AssetAtom, AssetMuon } from './types'
-import { DECIMAL, getDenom, getAsset, getTxsFromHistory } from './util'
 
-/**
- * Interface for custom Cosmos client
- */
-export interface CosmosClient {
-  getMainAsset(): Asset
+export interface ClientParams extends BaseClientParams {
+  mainAsset: Asset
+  sdkServer: string
+  sdkChainId: string
 }
 
-const MAINNET_SDK = new CosmosSDKClient({
-  server: 'https://api.cosmos.network',
-  chainId: 'cosmoshub-3',
-})
-const TESTNET_SDK = new CosmosSDKClient({
-  server: 'http://lcd.gaia.bigdipper.live:1317',
-  chainId: 'gaia-3a',
-})
+// eslint-disable-next-line prefer-const
+let boundClientFactory: BoundClientFactory<Client>
 
-/**
- * Custom Cosmos client
- */
-class Client implements CosmosClient, XChainClient {
-  private network: Network
-  private phrase = ''
-  private rootDerivationPaths: RootDerivationPaths
+export class Client extends MultiAssetClient<typeof Delegate.create> {
+  static create(...args: Parameters<typeof boundClientFactory>): ReturnType<typeof boundClientFactory> {
+    return boundClientFactory(...args)
+  }
 
-  private sdkClients: Map<XChainNetwork, CosmosSDKClient> = new Map<XChainNetwork, CosmosSDKClient>()
+  getSDKClient(): Promise<CosmosSDKClient> {
+    // eslint-disable-next-line prefer-rest-params
+    return this.useDelegateMethod('getSDKClient', ...[Array.from(arguments).slice(0)])
+  }
+}
 
-  /**
-   * Constructor
-   *
-   * Client has to be initialised with network type and phrase.
-   * It will throw an error if an invalid phrase has been passed.
-   *
-   * @param {XChainClientParams} params
-   *
-   * @throws {"Invalid phrase"} Thrown if the given phase is invalid.
-   */
-  constructor({
-    network = 'testnet',
-    phrase,
-    rootDerivationPaths = {
-      mainnet: `44'/118'/0'/0/`,
-      testnet: `44'/118'/1'/0/`,
+const mainnetDefaultParams: ClientParams = {
+  getFullDerivationPath: (index: number) => `44'/118'/0'/0/${index}`,
+  explorer: {
+    url: 'https://cosmos.bigdipper.live',
+    getAddressUrl(address: string) {
+      return `${this.url}/account/${address}`
     },
-  }: XChainClientParams) {
-    this.network = network
-    this.rootDerivationPaths = rootDerivationPaths
-    this.sdkClients.set('testnet', TESTNET_SDK)
-    this.sdkClients.set('mainnet', MAINNET_SDK)
-
-    if (phrase) this.setPhrase(phrase)
-  }
-
-  /**
-   * Purge client.
-   *
-   * @returns {void}
-   */
-  purgeClient(): void {
-    this.phrase = ''
-  }
-
-  /**
-   * Set/update the current network.
-   *
-   * @param {Network} network `mainnet` or `testnet`.
-   * @returns {void}
-   *
-   * @throws {"Network must be provided"}
-   * Thrown if network has not been set before.
-   */
-  setNetwork = (network: Network): void => {
-    if (!network) {
-      throw new Error('Network must be provided')
-    } else {
-      this.network = network
-    }
-  }
-
-  /**
-   * Get the current network.
-   *
-   * @returns {Network} The current network. (`mainnet` or `testnet`)
-   */
-  getNetwork(): Network {
-    return this.network
-  }
-
-  /**
-   * @private
-   * Register message codecs.
-   *
-   * @returns {void}
-   */
-  private registerCodecs = (): void => {
-    codec.registerCodec('cosmos-sdk/MsgSend', MsgSend, MsgSend.fromJSON)
-    codec.registerCodec('cosmos-sdk/MsgMultiSend', MsgMultiSend, MsgMultiSend.fromJSON)
-  }
-
-  /**
-   * Get the explorer url.
-   *
-   * @returns {string} The explorer url.
-   */
-  getExplorerUrl = (): string => {
-    return this.network === 'testnet' ? 'https://gaia.bigdipper.live' : 'https://cosmos.bigdipper.live'
-  }
-
-  /**
-   * Get the explorer url for the given address.
-   *
-   * @param {Address} address
-   * @returns {string} The explorer url for the given address.
-   */
-  getExplorerAddressUrl = (address: Address): string => {
-    return `${this.getExplorerUrl()}/account/${address}`
-  }
-
-  /**
-   * Get the explorer url for the given transaction id.
-   *
-   * @param {string} txID
-   * @returns {string} The explorer url for the given transaction id.
-   */
-  getExplorerTxUrl = (txID: string): string => {
-    return `${this.getExplorerUrl()}/transactions/${txID}`
-  }
-
-  /**
-   * Set/update a new phrase
-   *
-   * @param {string} phrase A new phrase.
-   * @returns {Address} The address from the given phrase
-   *
-   * @throws {"Invalid phrase"}
-   * Thrown if the given phase is invalid.
-   */
-  setPhrase = (phrase: string, walletIndex = 0): Address => {
-    if (this.phrase !== phrase) {
-      if (!xchainCrypto.validatePhrase(phrase)) {
-        throw new Error('Invalid phrase')
-      }
-
-      this.phrase = phrase
-    }
-
-    return this.getAddress(walletIndex)
-  }
-
-  /**
-   * @private
-   * Get private key.
-   *
-   * @returns {PrivKey} The private key generated from the given phrase
-   *
-   * @throws {"Phrase not set"}
-   * Throws an error if phrase has not been set before
-   * */
-  private getPrivateKey = (index = 0): PrivKey => {
-    if (!this.phrase) throw new Error('Phrase not set')
-
-    return this.getSDKClient().getPrivKeyFromMnemonic(this.phrase, this.getFullDerivationPath(index))
-  }
-  getSDKClient = (): CosmosSDKClient => {
-    return this.sdkClients.get(this.network) || TESTNET_SDK
-  }
-
-  /**
-   * Get getFullDerivationPath
-   *
-   * @param {number} index the HD wallet index
-   * @returns {string} The bitcoin derivation path based on the network.
-   */
-  getFullDerivationPath(index: number): string {
-    return this.rootDerivationPaths[this.network] + `${index}`
-  }
-
-  /**
-   * Get the current address.
-   *
-   * @returns {Address} The current address.
-   *
-   * @throws {Error} Thrown if phrase has not been set before. A phrase is needed to create a wallet and to derive an address from it.
-   */
-  getAddress = (index = 0): string => {
-    if (!this.phrase) throw new Error('Phrase not set')
-
-    return this.getSDKClient().getAddressFromMnemonic(this.phrase, this.getFullDerivationPath(index))
-  }
-
-  /**
-   * Validate the given address.
-   *
-   * @param {Address} address
-   * @returns {boolean} `true` or `false`
-   */
-  validateAddress = (address: Address): boolean => {
-    return this.getSDKClient().checkAddress(address)
-  }
-
-  /**
-   * Get the main asset based on the network.
-   *
-   * @returns {string} The main asset based on the network.
-   */
-  getMainAsset = (): Asset => {
-    return this.network === 'testnet' ? AssetMuon : AssetAtom
-  }
-
-  /**
-   * Get the balance of a given address.
-   *
-   * @param {Address} address By default, it will return the balance of the current wallet. (optional)
-   * @param {Asset} asset If not set, it will return all assets available. (optional)
-   * @returns {Array<Balance>} The balance of the address.
-   */
-  getBalance = async (address: Address, assets?: Asset[]): Promise<Balances> => {
-    try {
-      const balances = await this.getSDKClient().getBalance(address)
-      const mainAsset = this.getMainAsset()
-
-      return balances
-        .map((balance) => {
-          return {
-            asset: (balance.denom && getAsset(balance.denom)) || mainAsset,
-            amount: baseAmount(balance.amount, DECIMAL),
-          }
-        })
-        .filter(
-          (balance) =>
-            !assets || assets.filter((asset) => assetToString(balance.asset) === assetToString(asset)).length,
-        )
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get transaction history of a given address with pagination options.
-   * By default it will return the transaction history of the current wallet.
-   *
-   * @param {TxHistoryParams} params The options to get transaction history. (optional)
-   * @returns {TxsPage} The transaction history.
-   */
-  getTransactions = async (params?: TxHistoryParams): Promise<TxsPage> => {
-    const messageAction = undefined
-    const page = (params && params.offset) || undefined
-    const limit = (params && params.limit) || undefined
-    const txMinHeight = undefined
-    const txMaxHeight = undefined
-
-    try {
-      this.registerCodecs()
-
-      const mainAsset = this.getMainAsset()
-      const txHistory = await this.getSDKClient().searchTx({
-        messageAction,
-        messageSender: (params && params.address) || this.getAddress(),
-        page,
-        limit,
-        txMinHeight,
-        txMaxHeight,
-      })
-
-      return {
-        total: parseInt(txHistory.total_count?.toString() || '0'),
-        txs: getTxsFromHistory(txHistory.txs || [], mainAsset),
-      }
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get the transaction details of a given transaction id.
-   *
-   * @param {string} txId The transaction id.
-   * @returns {Tx} The transaction details of the given transaction id.
-   */
-  getTransactionData = async (txId: string): Promise<Tx> => {
-    try {
-      const txResult = await this.getSDKClient().txsHashGet(txId)
-      const txs = getTxsFromHistory([txResult], this.getMainAsset())
-
-      if (txs.length === 0) {
-        throw new Error('transaction not found')
-      }
-
-      return txs[0]
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Transfer balances.
-   *
-   * @param {TxParams} params The transfer options.
-   * @returns {TxHash} The transaction hash.
-   */
-  transfer = async ({ walletIndex, asset, amount, recipient, memo }: TxParams): Promise<TxHash> => {
-    try {
-      const fromAddressIndex = walletIndex || 0
-      this.registerCodecs()
-
-      const mainAsset = this.getMainAsset()
-      const transferResult = await this.getSDKClient().transfer({
-        privkey: this.getPrivateKey(fromAddressIndex),
-        from: this.getAddress(fromAddressIndex),
-        to: recipient,
-        amount: amount.amount().toString(),
-        asset: getDenom(asset || mainAsset),
-        memo,
-      })
-
-      return transferResult?.txhash || ''
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get the current fee.
-   *
-   * @returns {Fees} The current fee.
-   */
-  getFees = async (): Promise<Fees> => {
-    // there is no fixed fee, we set fee amount when creating a transaction.
-    return Promise.resolve({
-      type: 'base',
-      fast: baseAmount(750, DECIMAL),
-      fastest: baseAmount(2500, DECIMAL),
-      average: baseAmount(0, DECIMAL),
-    })
-  }
+    getTxUrl(txid: string) {
+      return `${this.url}/transactions/${txid}`
+    },
+  },
+  mainAsset: AssetAtom,
+  sdkServer: 'https://api.cosmos.network',
+  sdkChainId: 'cosmoshub-3',
 }
 
-export { Client }
+const testnetDefaultParams: ClientParams = {
+  ...mainnetDefaultParams,
+  getFullDerivationPath: (index: number) => `44'/118'/1'/0/${index}`,
+  explorer: {
+    ...mainnetDefaultParams.explorer,
+    url: 'https://gaia.bigdipper.live',
+  },
+  mainAsset: AssetMuon,
+  sdkServer: 'http://lcd.gaia.bigdipper.live:1317',
+  sdkChainId: 'gaia-3a',
+}
+
+boundClientFactory = Client.bindDelegateFactory(Delegate.create, {
+  mainnet: mainnetDefaultParams,
+  testnet: testnetDefaultParams,
+})

--- a/packages/xchain-cosmos/src/cosmos/types.ts
+++ b/packages/xchain-cosmos/src/cosmos/types.ts
@@ -3,14 +3,11 @@ import { BigSource } from 'big.js'
 import { PrivKey, Msg, codec } from 'cosmos-client'
 import { BaseAccount, StdTx } from 'cosmos-client/x/auth'
 import { StdTxFee } from 'cosmos-client/api'
-import { RootDerivationPaths, Network } from '@xchainjs/xchain-client'
 
 export type CosmosSDKClientParams = {
   server: string
   chainId: string
   prefix?: string
-  network?: Network
-  rootDerivationPaths?: RootDerivationPaths
 }
 
 export type SearchTxParams = {

--- a/packages/xchain-cosmos/src/delegate.ts
+++ b/packages/xchain-cosmos/src/delegate.ts
@@ -1,0 +1,147 @@
+import {
+  Address,
+  Balance,
+  Delegate as BaseDelegate,
+  FeeType,
+  Fees,
+  Tx,
+  TxHash,
+  TxHistoryParams,
+  TxParams,
+  TxsPage,
+} from '@xchainjs/xchain-client'
+import { Asset, assetToString, baseAmount } from '@xchainjs/xchain-util'
+import * as xchainCrypto from '@xchainjs/xchain-crypto'
+import { codec } from 'cosmos-client'
+import { MsgMultiSend, MsgSend } from 'cosmos-client/x/bank'
+
+import { ClientParams } from './client'
+import { DECIMAL, getAsset, getDenom, getTxsFromHistory } from './util'
+import { CosmosSDKClient } from './cosmos'
+
+const registerCodecsOnce = (() => {
+  let codecsRegistered = false
+  return async () => {
+    if (codecsRegistered) return
+    codec.registerCodec('cosmos-sdk/MsgSend', MsgSend, MsgSend.fromJSON)
+    codec.registerCodec('cosmos-sdk/MsgMultiSend', MsgMultiSend, MsgMultiSend.fromJSON)
+    codecsRegistered = true
+  }
+})()
+
+export class Delegate implements BaseDelegate<ClientParams> {
+  private readonly phrase: string
+  private readonly sdkClients = new Map<string, CosmosSDKClient>()
+
+  constructor(phrase: string) {
+    this.phrase = phrase
+  }
+
+  static async create(phrase: string): Promise<Delegate> {
+    if (!xchainCrypto.validatePhrase(phrase)) throw new Error('Invalid phrase')
+    const out = new Delegate(phrase)
+    await registerCodecsOnce()
+    return out
+  }
+
+  async getSDKClient(clientParams: Readonly<ClientParams>): Promise<CosmosSDKClient> {
+    const clientCompositeKey = JSON.stringify([clientParams.sdkServer, clientParams.sdkChainId])
+    const cachedClient = this.sdkClients.get(clientCompositeKey)
+    if (cachedClient !== undefined) return cachedClient
+
+    const out = new CosmosSDKClient({
+      server: clientParams.sdkServer,
+      chainId: clientParams.sdkServer,
+    })
+    this.sdkClients.set(clientCompositeKey, out)
+    return out
+  }
+
+  async validateAddress(clientParams: Readonly<ClientParams>, address: Address): Promise<boolean> {
+    const sdkClient = await this.getSDKClient(clientParams)
+    return sdkClient.checkAddress(address)
+  }
+
+  async getAddress(clientParams: Readonly<ClientParams>, walletIndex = 0): Promise<Address> {
+    const sdkClient = await this.getSDKClient(clientParams)
+    return sdkClient.getAddressFromMnemonic(this.phrase, clientParams.getFullDerivationPath(walletIndex))
+  }
+
+  async getBalance(clientParams: Readonly<ClientParams>, address: Address, assets?: Asset[]): Promise<Balance[]> {
+    const sdkClient = await this.getSDKClient(clientParams)
+    const balances = await sdkClient.getBalance(address)
+
+    return balances
+      .map((balance) => {
+        return {
+          asset: (balance.denom && getAsset(balance.denom)) || clientParams.mainAsset,
+          amount: baseAmount(balance.amount, DECIMAL),
+        }
+      })
+      .filter(
+        (balance) => !assets || assets.filter((asset) => assetToString(balance.asset) === assetToString(asset)).length,
+      )
+  }
+
+  async getTransactions(clientParams: Readonly<ClientParams>, params: TxHistoryParams): Promise<TxsPage> {
+    const messageAction = undefined
+    const page = (params && params.offset) || undefined
+    const limit = (params && params.limit) || undefined
+    const txMinHeight = undefined
+    const txMaxHeight = undefined
+
+    const txHistory = await (await this.getSDKClient(clientParams)).searchTx({
+      messageAction,
+      messageSender: (params && params.address) || (await this.getAddress(clientParams)),
+      page,
+      limit,
+      txMinHeight,
+      txMaxHeight,
+    })
+
+    return {
+      total: parseInt(txHistory.total_count?.toString() || '0'),
+      txs: getTxsFromHistory(txHistory.txs || [], clientParams.mainAsset),
+    }
+  }
+
+  async getTransactionData(clientParams: Readonly<ClientParams>, txId: string): Promise<Tx> {
+    const sdkClient = await this.getSDKClient(clientParams)
+    const txResult = await sdkClient.txsHashGet(txId)
+    const txs = getTxsFromHistory([txResult], clientParams.mainAsset)
+
+    if (txs.length === 0) throw new Error('transaction not found')
+
+    return txs[0]
+  }
+
+  async getFees(_clientParams: Readonly<ClientParams>): Promise<Fees> {
+    return {
+      type: FeeType.FlatFee,
+      fast: baseAmount(750, DECIMAL),
+      fastest: baseAmount(2500, DECIMAL),
+      average: baseAmount(0, DECIMAL),
+    }
+  }
+
+  async transfer(clientParams: Readonly<ClientParams>, params: TxParams): Promise<TxHash> {
+    const sdkClient = await this.getSDKClient(clientParams)
+    const privateKey = sdkClient.getPrivKeyFromMnemonic(
+      this.phrase,
+      clientParams.getFullDerivationPath(params.walletIndex ?? 0),
+    )
+
+    const txResult = await sdkClient.transfer({
+      privkey: privateKey,
+      from: sdkClient.getAddressFromPrivKey(privateKey),
+      to: params.recipient,
+      amount: params.amount.amount().toString(),
+      asset: getDenom(params.asset ?? clientParams.mainAsset),
+      memo: params.memo,
+    })
+    const out = txResult?.txhash
+
+    if (out === undefined) throw new Error(`unable to complete transaction, result: ${txResult}`)
+    return out
+  }
+}

--- a/packages/xchain-cosmos/src/util.ts
+++ b/packages/xchain-cosmos/src/util.ts
@@ -1,4 +1,4 @@
-import { TxFrom, TxTo, Txs, Fees } from '@xchainjs/xchain-client'
+import { TxFrom, TxTo, Tx, TxType } from '@xchainjs/xchain-client'
 import { Asset, assetToString, baseAmount } from '@xchainjs/xchain-util'
 
 import { Msg, codec } from 'cosmos-client'
@@ -64,7 +64,7 @@ export const getAsset = (denom: string): Asset | null => {
  * @param {Asset} mainAsset Current main asset which depends on the network.
  * @returns {Txs} The parsed transaction result.
  */
-export const getTxsFromHistory = (txs: Array<TxResponse>, mainAsset: Asset): Txs => {
+export const getTxsFromHistory = (txs: Array<TxResponse>, mainAsset: Asset): Tx[] => {
   return txs.reduce((acc, tx) => {
     let msgs: Msg[] = []
     if ((tx.tx as RawTxResponse).body === undefined) {
@@ -158,18 +158,16 @@ export const getTxsFromHistory = (txs: Array<TxResponse>, mainAsset: Asset): Txs
       }
     })
 
-    return [
-      ...acc,
-      {
-        asset: mainAsset,
-        from,
-        to,
-        date: new Date(tx.timestamp),
-        type: from.length > 0 || to.length > 0 ? 'transfer' : 'unknown',
-        hash: tx.txhash || '',
-      },
-    ]
-  }, [] as Txs)
+    acc.push({
+      asset: mainAsset,
+      from,
+      to,
+      date: new Date(tx.timestamp),
+      type: from.length > 0 || to.length > 0 ? TxType.Transfer : TxType.Unknown,
+      hash: tx.txhash || '',
+    })
+    return acc
+  }, [] as Tx[])
 }
 
 /**
@@ -184,25 +182,3 @@ export const getQueryString = (params: APIQueryParam): string => {
     .map((key) => (params[key] == null ? key : `${key}=${encodeURIComponent(params[key].toString())}`))
     .join('&')
 }
-
-/**
- * Get the default fee.
- *
- * @returns {Fees} The default fee.
- */
-export const getDefaultFees = (): Fees => {
-  return {
-    type: 'base',
-    fast: baseAmount(750, DECIMAL),
-    fastest: baseAmount(2500, DECIMAL),
-    average: baseAmount(0, DECIMAL),
-  }
-}
-
-/**
- * Get address prefix based on the network.
- *
- * @returns {string} The address prefix based on the network.
- *
- **/
-export const getPrefix = () => 'cosmos'


### PR DESCRIPTION
This is a possible alternative to #361, with a more-thorough refactoring (which only covers `xchain-client` and `xchain-cosmos` at the moment).

The key insight here is that all the clients' exposed API surfaces consist of two types of things:
- Getters and setters which handle configuration and return synchronously; this data is now encapsulated in a per-`Network` `ClientParams` object.
- Asynchronous methods which actually do stuff, and which access but do not mutate the configuration. These have been factored out into a `Delegate` interface, all of whose methods are passed the currently-active `ClientParams` when called and return `Promise`s.

Most of the "computation" done by the existing synchronous getters and setters consists of simply switching behavior based on whether `mainnet` or `testnet` is selected, and this approach eliminates a lot of that complexity. The core "glue" code is contained in the `Client` class, which is generic and can stitch together arbitrary delegates and parameter types. This means that 95% of the code in each dependent package can go in a delegate -- whose only state is the mnemonic phase (or other arbitrary information needed to unlock the client -- like, for example, an instance of `@shapeshiftoss/hdwallet-native`).

I'd love to go over this in more detail... please make liberal use of the per-line comment functionality!