### PR TITLE
Even better refactor, third time's the charm

### DIFF
--- a/packages/xchain-binance/package.json
+++ b/packages/xchain-binance/package.json
@@ -47,5 +47,8 @@
     "@xchainjs/xchain-client": "^0.9.3",
     "@xchainjs/xchain-crypto": "^0.2.4",
     "@xchainjs/xchain-util": "^0.2.8"
+  },
+  "dependencies": {
+    "bip32": "^2.0.6"
   }
 }

--- a/packages/xchain-binance/src/client.ts
+++ b/packages/xchain-binance/src/client.ts
@@ -1,519 +1,198 @@
 import axios from 'axios'
-import {
-  Balances as BinanceBalances,
-  Fees as BinanceFees,
-  TxPage as BinanceTxPage,
-  TransactionResult,
-  TransferFee,
-} from './types/binance'
-
-import * as crypto from '@binance-chain/javascript-sdk/lib/crypto'
 import { BncClient } from '@binance-chain/javascript-sdk/lib/client'
+import { SignedSend } from '@binance-chain/javascript-sdk/lib/types'
 import {
   Address,
-  XChainClient,
-  XChainClientParams,
-  Balances,
+  Balance,
+  ClientFactory,
+  ClientParams as BaseClientParams,
   Fees,
+  MultiAssetClient,
+  MultiSendClient,
+  MultiSendWallet,
   Network,
+  SingleAndMultiFees,
+  SingleFlatFee,
   Tx,
-  Txs,
-  TxParams,
-  TxHash,
   TxHistoryParams,
   TxsPage,
 } from '@xchainjs/xchain-client'
 import {
   Asset,
   AssetBNB,
-  BaseAmount,
-  assetFromString,
-  assetAmount,
-  assetToBase,
-  baseAmount,
-  baseToAsset,
   BNBChain,
+  assetAmount,
+  assetFromString,
+  assetToBase,
   assetToString,
+  baseAmount,
 } from '@xchainjs/xchain-util'
-import { validatePhrase } from '@xchainjs/xchain-crypto'
-import { isTransferFee, parseTx, getPrefix } from './util'
-import { SignedSend } from '@binance-chain/javascript-sdk/lib/types'
 
-type PrivKey = string
+import {
+  Balance as BinanceBalance,
+  Fee as BinanceFee,
+  TxPage as BinanceTxPage,
+  TransactionResult,
+  TransferFee,
+} from './types/binance'
+import { isTransferFee, parseTx } from './util'
 
-export type Coin = {
-  asset: Asset
-  amount: BaseAmount
+export interface ClientParams extends BaseClientParams {
+  clientUrl: string
 }
 
-export type MultiTransfer = {
-  to: Address
-  coins: Coin[]
+export const MAINNET_PARAMS: ClientParams = {
+  network: Network.Mainnet,
+  getFullDerivationPath: (index: number) => `44'/714'/0'/0/${index}`,
+  explorer: {
+    url: 'https://explorer.binance.org',
+    getAddressUrl(address: string) {
+      return `${this.url}/address/${address}`
+    },
+    getTxUrl(txid: string) {
+      return `${this.url}/tx/${txid}`
+    },
+  },
+  clientUrl: 'https://dex.binance.org',
 }
 
-export type MultiSendParams = {
-  walletIndex?: number
-  transactions: MultiTransfer[]
-  memo?: string
+export const TESTNET_PARAMS: ClientParams = {
+  ...MAINNET_PARAMS,
+  network: Network.Testnet,
+  getFullDerivationPath: (index: number) => `44'/714'/0'/0/${index}`,
+  explorer: {
+    ...MAINNET_PARAMS.explorer,
+    url: 'https://testnet-explorer.binance.org',
+  },
+  clientUrl: 'https://testnet-dex.binance.org',
 }
 
-/**
- * Interface for custom Binance client
- */
-export interface BinanceClient {
-  purgeClient(): void
-  getBncClient(): BncClient
+export class Client
+  extends MultiSendClient<ClientParams, MultiSendWallet>
+  implements MultiAssetClient<ClientParams, MultiSendWallet> {
+  readonly bncClient: BncClient
 
-  getMultiSendFees(): Promise<Fees>
-  getSingleAndMultiFees(): Promise<{ single: Fees; multi: Fees }>
-
-  multiSend(params: MultiSendParams): Promise<TxHash>
-}
-
-/**
- * Custom Binance client
- */
-class Client implements BinanceClient, XChainClient {
-  private network: Network
-  private bncClient: BncClient
-  private phrase = ''
-
-  /**
-   * Constructor
-   *
-   * Client has to be initialised with network type and phrase.
-   * It will throw an error if an invalid phrase has been passed.
-   *
-   * @param {XChainClientParams} params
-   *
-   * @throws {"Invalid phrase"} Thrown if the given phase is invalid.
-   */
-  constructor({ network = 'testnet', phrase }: XChainClientParams) {
-    this.network = network
-    this.setPhrase(phrase || '')
-    this.bncClient = new BncClient(this.getClientUrl())
-    this.bncClient.chooseNetwork(network)
+  protected constructor(params: ClientParams) {
+    super(params)
+    this.bncClient = new BncClient(params.clientUrl)
+    this.bncClient.chooseNetwork(params.network)
   }
 
-  /**
-   * Purge client.
-   *
-   * @returns {void}
-   */
-  purgeClient(): void {
-    this.phrase = ''
+  protected async init() {
+    await super.init()
+    await this.bncClient.initChain()
   }
 
-  /**
-   * Get the BncClient interface.
-   *
-   * @returns {BncClient} The BncClient from `@binance-chain/javascript-sdk`.
-   */
-  getBncClient(): BncClient {
-    return this.bncClient
+  static readonly create: ClientFactory<Client> = Client.bindFactory((x: ClientParams) => new Client(x))
+
+  async validateAddress(address: Address): Promise<boolean> {
+    return this.bncClient.checkAddress(address)
   }
 
-  /**
-   * Set/update the current network.
-   *
-   * @param {Network} network `mainnet` or `testnet`.
-   * @returns {void}
-   *
-   * @throws {"Network must be provided"}
-   * Thrown if network has not been set before.
-   */
-  setNetwork(network: Network): void {
-    if (!network) {
-      throw new Error('Network must be provided')
-    } else {
-      this.network = network
-      this.bncClient = new BncClient(this.getClientUrl())
-      this.bncClient.chooseNetwork(network)
-    }
-  }
+  async getBalance(address: Address, assets?: Asset[]): Promise<Balance[]> {
+    const balances = (await this.bncClient.getBalance(address)) as BinanceBalance[]
 
-  /**
-   * Get the current network.
-   *
-   * @returns {Network} The current network. (`mainnet` or `testnet`)
-   */
-  getNetwork(): Network {
-    return this.network
-  }
-
-  /**
-   * Get the client url.
-   *
-   * @returns {string} The client url for binance chain based on the network.
-   */
-  private getClientUrl = (): string => {
-    return this.network === 'testnet' ? 'https://testnet-dex.binance.org' : 'https://dex.binance.org'
-  }
-
-  /**
-   * Get the explorer url.
-   *
-   * @returns {string} The explorer url based on the network.
-   */
-  getExplorerUrl = (): string => {
-    return this.network === 'testnet' ? 'https://testnet-explorer.binance.org' : 'https://explorer.binance.org'
-  }
-
-  /**
-   * Get the explorer url for the given address.
-   *
-   * @param {Address} address
-   * @returns {string} The explorer url for the given address based on the network.
-   */
-  getExplorerAddressUrl = (address: Address): string => {
-    return `${this.getExplorerUrl()}/address/${address}`
-  }
-
-  /**
-   * Get the explorer url for the given transaction id.
-   *
-   * @param {string} txID
-   * @returns {string} The explorer url for the given transaction id based on the network.
-   */
-  getExplorerTxUrl = (txID: string): string => {
-    return `${this.getExplorerUrl()}/tx/${txID}`
-  }
-
-  /**
-   * Set/update a new phrase
-   *
-   * @param {string} phrase A new phrase.
-   * @returns {Address} The address from the given phrase
-   *
-   * @throws {"Invalid phrase"}
-   * Thrown if the given phase is invalid.
-   */
-  setPhrase = (phrase: string, walletIndex = 0): Address => {
-    if (!validatePhrase(phrase)) {
-      throw new Error('Invalid phrase')
-    }
-
-    this.phrase = phrase
-    return this.getAddress(walletIndex)
-  }
-
-  /**
-   * @private
-   * Get private key.
-   *
-   * @param {number} index account index for the derivation path
-   * @returns {PrivKey} The privkey generated from the given phrase
-   *
-   * @throws {"Phrase not set"}
-   * Throws an error if phrase has not been set before
-   * */
-  private getPrivateKey = (index: number): PrivKey => {
-    if (!this.phrase) throw new Error('Phrase not set')
-
-    return crypto.getPrivateKeyFromMnemonic(this.phrase, true, index)
-  }
-
-  /**
-   * Get the current address.
-   *
-   * @returns {Address} The current address.
-   *
-   * @throws {Error} Thrown if phrase has not been set before. A phrase is needed to create a wallet and to derive an address from it.
-   */
-  getAddress = (index = 0): string =>
-    crypto.getAddressFromPrivateKey(this.getPrivateKey(index), getPrefix(this.network))
-
-  /**
-   * Validate the given address.
-   *
-   * @param {Address} address
-   * @returns {boolean} `true` or `false`
-   */
-  validateAddress = (address: Address): boolean => {
-    return this.bncClient.checkAddress(address, getPrefix(this.network))
-  }
-
-  /**
-   * Get the balance of a given address.
-   *
-   * @param {Address | number} address By default, it will return the balance of the current wallet. (optional)
-   * @param {Asset} asset If not set, it will return all assets available. (optional)
-   * @returns {Array<Balance>} The balance of the address.
-   */
-  getBalance = async (address: Address, assets?: Asset[]): Promise<Balances> => {
-    try {
-      const balances: BinanceBalances = await this.bncClient.getBalance(address)
-
-      return balances
-        .map((balance) => {
-          return {
-            asset: assetFromString(`${BNBChain}.${balance.symbol}`) || AssetBNB,
-            amount: assetToBase(assetAmount(balance.free, 8)),
-          }
-        })
-        .filter(
-          (balance) =>
-            !assets || assets.filter((asset) => assetToString(balance.asset) === assetToString(asset)).length,
-        )
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * @private
-   * Search transactions with parameters.
-   *
-   * @returns {Params} The parameters to be used for transaction search.
-   * */
-  private searchTransactions = async (params?: { [x: string]: string | undefined }): Promise<TxsPage> => {
-    try {
-      const clientUrl = `${this.getClientUrl()}/api/v1/transactions`
-      const url = new URL(clientUrl)
-
-      const endTime = Date.now()
-      const diffTime = 90 * 24 * 60 * 60 * 1000
-      url.searchParams.set('endTime', endTime.toString())
-      url.searchParams.set('startTime', (endTime - diffTime).toString())
-
-      for (const key in params) {
-        const value = params[key]
-        if (value) {
-          url.searchParams.set(key, value)
-          if (key === 'startTime' && !params['endTime']) {
-            url.searchParams.set('endTime', (parseInt(value) + diffTime).toString())
-          }
-          if (key === 'endTime' && !params['startTime']) {
-            url.searchParams.set('startTime', (parseInt(value) - diffTime).toString())
-          }
-        }
-      }
-
-      const txHistory = await axios.get<BinanceTxPage>(url.toString()).then((response) => response.data)
-
-      return {
-        total: txHistory.total,
-        txs: txHistory.tx.map(parseTx).filter(Boolean) as Txs,
-      }
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get transaction history of a given address with pagination options.
-   * By default it will return the transaction history of the current wallet.
-   *
-   * @param {TxHistoryParams} params The options to get transaction history. (optional)
-   * @returns {TxsPage} The transaction history.
-   */
-  getTransactions = async (params?: TxHistoryParams): Promise<TxsPage> => {
-    try {
-      return await this.searchTransactions({
-        address: params && params.address,
-        limit: params && params.limit?.toString(),
-        offset: params && params.offset?.toString(),
-        startTime: params && params.startTime && params.startTime.getTime().toString(),
-        txAsset: params && params.asset,
-      })
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get the transaction details of a given transaction id.
-   *
-   * @param {string} txId The transaction id.
-   * @returns {Tx} The transaction details of the given transaction id.
-   */
-  getTransactionData = async (txId: string): Promise<Tx> => {
-    try {
-      const txResult: TransactionResult = await axios
-        .get(`${this.getClientUrl()}/api/v1/tx/${txId}?format=json`)
-        .then((response) => response.data)
-
-      const blockHeight = txResult.height
-
-      let address = ''
-      const msgs = txResult.tx.value.msg
-      if (msgs.length) {
-        const msg = msgs[0].value as SignedSend
-        if (msg.inputs && msg.inputs.length) {
-          address = msg.inputs[0].address
-        } else if (msg.outputs && msg.outputs.length) {
-          address = msg.outputs[0].address
-        }
-      }
-
-      const txHistory = await this.searchTransactions({ address, blockHeight })
-      const [transaction] = txHistory.txs.filter((tx) => tx.hash === txId)
-
-      if (!transaction) {
-        throw new Error('transaction not found')
-      }
-
-      return transaction
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Broadcast multi-send transaction.
-   *
-   * @param {MultiSendParams} params The multi-send transfer options.
-   * @returns {TxHash} The transaction hash.
-   */
-  multiSend = async ({ walletIndex = 0, transactions, memo = '' }: MultiSendParams): Promise<TxHash> => {
-    try {
-      const derivedAddress = this.getAddress(walletIndex)
-
-      await this.bncClient.initChain()
-      await this.bncClient.setPrivateKey(this.getPrivateKey(walletIndex)).catch((error) => Promise.reject(error))
-
-      const transferResult = await this.bncClient.multiSend(
-        derivedAddress,
-        transactions.map((transaction) => {
-          return {
-            to: transaction.to,
-            coins: transaction.coins.map((coin) => {
-              return {
-                denom: coin.asset.symbol,
-                amount: baseToAsset(coin.amount).amount().toString(),
-              }
-            }),
-          }
-        }),
-        memo,
+    return balances
+      .map((balance) => ({
+        asset: assetFromString(`${BNBChain}.${balance.symbol}`) || AssetBNB,
+        amount: assetToBase(assetAmount(balance.free, 8)),
+      }))
+      .filter(
+        (balance) => !assets || assets.filter((asset) => assetToString(balance.asset) === assetToString(asset)).length,
       )
-
-      return transferResult.result.map((txResult: { hash?: TxHash }) => txResult?.hash ?? '')[0]
-    } catch (error) {
-      return Promise.reject(error)
-    }
   }
 
-  /**
-   * Transfer balances.
-   *
-   * @param {TxParams} params The transfer options.
-   * @returns {TxHash} The transaction hash.
-   */
-  transfer = async ({ walletIndex, asset, amount, recipient, memo }: TxParams): Promise<TxHash> => {
-    try {
-      await this.bncClient.initChain()
-      await this.bncClient
-        .setPrivateKey(this.getPrivateKey(walletIndex || 0))
-        .catch((error: Error) => Promise.reject(error))
+  private async searchTransactions(params: { [x: string]: string | undefined }): Promise<TxsPage> {
+    const url = new URL(`${this.params.clientUrl}/api/v1/transactions`)
 
-      const transferResult = await this.bncClient.transfer(
-        this.getAddress(),
-        recipient,
-        baseToAsset(amount).amount().toString(),
-        asset ? asset.symbol : AssetBNB.symbol,
-        memo,
-      )
+    const endTime = Date.now()
+    const diffTime = 90 * 24 * 60 * 60 * 1000
+    url.searchParams.set('endTime', endTime.toString())
+    url.searchParams.set('startTime', (endTime - diffTime).toString())
 
-      return transferResult.result.map((txResult: { hash?: TxHash }) => txResult?.hash ?? '')[0]
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get the current transfer fee.
-   *
-   * @returns {TransferFee} The current transfer fee.
-   */
-  private getTransferFee = async (): Promise<TransferFee> => {
-    try {
-      const feesArray = await axios
-        .get<BinanceFees>(`${this.getClientUrl()}/api/v1/fees`)
-        .then((response) => response.data)
-
-      const [transferFee] = feesArray.filter(isTransferFee)
-      if (!transferFee) {
-        throw new Error('failed to get transfer fees')
+    for (const [key, value] of Object.entries(params)) {
+      if (!value) continue
+      url.searchParams.set(key, value)
+      if (key === 'startTime' && !params['endTime']) {
+        url.searchParams.set('endTime', (parseInt(value) + diffTime).toString())
       }
-
-      return transferFee
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get the current fee.
-   *
-   * @returns {Fees} The current fee.
-   */
-  getFees = async (): Promise<Fees> => {
-    try {
-      const transferFee = await this.getTransferFee()
-      const singleTxFee = baseAmount(transferFee.fixed_fee_params.fee)
-
-      return {
-        type: 'base',
-        fast: singleTxFee,
-        fastest: singleTxFee,
-        average: singleTxFee,
-      } as Fees
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get the current fee for multi-send transaction.
-   *
-   * @returns {Fees} The current fee for multi-send transaction.
-   */
-  getMultiSendFees = async (): Promise<Fees> => {
-    try {
-      const transferFee = await this.getTransferFee()
-      const multiTxFee = baseAmount(transferFee.multi_transfer_fee)
-
-      return {
-        type: 'base',
-        average: multiTxFee,
-        fast: multiTxFee,
-        fastest: multiTxFee,
-      } as Fees
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get the current fee for both single and multi-send transaction.
-   *
-   * @returns {SingleAndMultiFees} The current fee for both single and multi-send transaction.
-   */
-  getSingleAndMultiFees = async (): Promise<{ single: Fees; multi: Fees }> => {
-    try {
-      const transferFee = await this.getTransferFee()
-      const singleTxFee = baseAmount(transferFee.fixed_fee_params.fee)
-      const multiTxFee = baseAmount(transferFee.multi_transfer_fee)
-
-      return {
-        single: {
-          type: 'base',
-          fast: singleTxFee,
-          fastest: singleTxFee,
-          average: singleTxFee,
-        } as Fees,
-        multi: {
-          type: 'base',
-          average: multiTxFee,
-          fast: multiTxFee,
-          fastest: multiTxFee,
-        } as Fees,
+      if (key === 'endTime' && !params['startTime']) {
+        url.searchParams.set('startTime', (parseInt(value) - diffTime).toString())
       }
-    } catch (error) {
-      return Promise.reject(error)
+    }
+
+    const txHistory = (await axios.get<BinanceTxPage>(url.toString())).data
+
+    return {
+      total: txHistory.total,
+      txs: txHistory.tx.map(parseTx).filter(Boolean) as Tx[],
+    }
+  }
+
+  async getTransactions(params: TxHistoryParams): Promise<TxsPage> {
+    return await this.searchTransactions({
+      address: params.address,
+      limit: params.limit?.toString(),
+      offset: params.offset?.toString(),
+      startTime: params.startTime?.getTime?.()?.toString(),
+      txAsset: params.asset,
+    })
+  }
+
+  async getTransactionData(txId: string): Promise<Tx> {
+    const txResult: TransactionResult = await axios
+      .get(`${this.params.clientUrl}/api/v1/tx/${txId}?format=json`)
+      .then((response) => response.data)
+
+    const blockHeight = txResult.height
+
+    let address = ''
+    const msgs = txResult.tx.value.msg
+    if (msgs.length) {
+      const msg = msgs[0].value as SignedSend
+      if (msg.inputs && msg.inputs.length) {
+        address = msg.inputs[0].address
+      } else if (msg.outputs && msg.outputs.length) {
+        address = msg.outputs[0].address
+      }
+    }
+
+    const txHistory = await this.searchTransactions({ address, blockHeight })
+    const [transaction] = txHistory.txs.filter((tx) => tx.hash === txId)
+
+    if (!transaction) throw new Error('transaction not found')
+    return transaction
+  }
+
+  private async getTransferFee(): Promise<TransferFee> {
+    const feesArray = (await axios.get<BinanceFee[]>(`${this.params.clientUrl}/api/v1/fees`)).data
+
+    for (const fee of feesArray) {
+      if (isTransferFee(fee)) return fee
+    }
+    throw new Error('failed to get transfer fees')
+  }
+
+  async getFees(): Promise<Fees> {
+    const transferFee = await this.getTransferFee()
+    const singleTxFee = baseAmount(transferFee.fixed_fee_params.fee)
+    return SingleFlatFee(singleTxFee)
+  }
+
+  async getMultiSendFees(): Promise<Fees> {
+    const transferFee = await this.getTransferFee()
+    const multiTxFee = baseAmount(transferFee.multi_transfer_fee)
+    return SingleFlatFee(multiTxFee)
+  }
+
+  async getSingleAndMultiFees(): Promise<SingleAndMultiFees> {
+    const transferFee = await this.getTransferFee()
+    const singleTxFee = baseAmount(transferFee.fixed_fee_params.fee)
+    const multiTxFee = baseAmount(transferFee.multi_transfer_fee)
+
+    return {
+      single: SingleFlatFee(singleTxFee),
+      multi: SingleFlatFee(multiTxFee),
     }
   }
 }
-
-export { Client }

--- a/packages/xchain-binance/src/index.ts
+++ b/packages/xchain-binance/src/index.ts
@@ -1,3 +1,4 @@
 export * from './client'
 export * from './types'
-export { getDerivePath, getDefaultFees, getPrefix } from './util'
+export { getDefaultFees } from './util'
+export * from './wallet'

--- a/packages/xchain-binance/src/types/binance.ts
+++ b/packages/xchain-binance/src/types/binance.ts
@@ -526,8 +526,6 @@ export type Balance = {
   frozen: string
 }
 
-export type Balances = Balance[]
-
 export type Transfer = {
   code: number
   hash: string

--- a/packages/xchain-binance/src/util.ts
+++ b/packages/xchain-binance/src/util.ts
@@ -1,8 +1,7 @@
 import { Transfer, TransferEvent } from './types/binance-ws'
 import { TransferFee, DexFees, Fee, TxType as BinanceTxType, Tx as BinanceTx } from './types/binance'
-import { TxType, Tx, Fees } from '@xchainjs/xchain-client'
+import { TxType, Tx, Fees, SingleFlatFee } from '@xchainjs/xchain-client'
 import { assetFromString, AssetBNB, assetToBase, assetAmount, baseAmount } from '@xchainjs/xchain-util'
-import { DerivePath } from './types/common'
 
 /**
  * Get `hash` from transfer event sent by Binance chain.
@@ -54,8 +53,8 @@ export const isDexFees = (v: Fee | TransferFee | DexFees): v is DexFees => (v as
  * @returns {TxType} `transfer` or `unknown`.
  */
 export const getTxType = (t: BinanceTxType): TxType => {
-  if (t === 'TRANSFER' || t === 'DEPOSIT') return 'transfer'
-  return 'unknown'
+  if (t === 'TRANSFER' || t === 'DEPOSIT') return TxType.Transfer
+  return TxType.Unknown
 }
 
 /**
@@ -90,34 +89,10 @@ export const parseTx = (tx: BinanceTx): Tx | null => {
 }
 
 /**
- * Get DerivePath
- *
- * @param {number} index (optional)
- * @returns {DerivePath} The binance derivation path by the index.
- */
-export const getDerivePath = (index = 0): DerivePath => [44, 714, 0, 0, index]
-
-/**
  * Get the default fee.
  *
  * @returns {Fees} The default fee.
  */
 export const getDefaultFees = (): Fees => {
-  const singleTxFee = baseAmount(37500)
-
-  return {
-    type: 'base',
-    fast: singleTxFee,
-    fastest: singleTxFee,
-    average: singleTxFee,
-  } as Fees
+  return SingleFlatFee(baseAmount(37500))
 }
-
-/**
- * Get address prefix based on the network.
- *
- * @param {string} network
- * @returns {string} The address prefix based on the network.
- *
- **/
-export const getPrefix = (network: string) => (network === 'testnet' ? 'tbnb' : 'bnb')

--- a/packages/xchain-binance/src/wallet.ts
+++ b/packages/xchain-binance/src/wallet.ts
@@ -1,0 +1,82 @@
+import * as bip32 from 'bip32'
+import * as crypto from '@binance-chain/javascript-sdk/lib/crypto'
+import {
+  Address,
+  MultiSendParams,
+  MultiSendWallet,
+  Network,
+  TxHash,
+  TxParams,
+  WalletFactory,
+} from '@xchainjs/xchain-client'
+import { validatePhrase, getSeed } from '@xchainjs/xchain-crypto'
+import { AssetBNB, baseToAsset } from '@xchainjs/xchain-util'
+
+import { Client } from './client'
+
+export class Wallet implements MultiSendWallet {
+  private readonly client: Client
+  private readonly phrase: string
+
+  protected constructor(client: Client, phrase: string) {
+    this.client = client
+    this.phrase = phrase
+  }
+
+  static async create(phrase: string): Promise<WalletFactory<Client>> {
+    if (!validatePhrase(phrase)) throw new Error('Invalid phrase')
+    return async (client: Client) => new this(client, phrase)
+  }
+
+  protected async getPrivateKey(index: number): Promise<string> {
+    const seed = getSeed(this.phrase)
+    const path = this.client.getFullDerivationPath(index)
+    const node = bip32.fromSeed(seed).derivePath(path)
+    if (node.privateKey === undefined) throw new Error('child does not have a privateKey')
+    return node.privateKey.toString('hex')
+  }
+
+  async getAddress(index: number): Promise<Address> {
+    const privateKey = await this.getPrivateKey(index)
+    const prefix = this.client.params.network === Network.Testnet ? 'tbnb' : 'bnb'
+    return crypto.getAddressFromPrivateKey(privateKey, prefix)
+  }
+
+  async transfer(index: number, { asset, amount, recipient, memo }: TxParams): Promise<TxHash> {
+    const privateKey = await this.getPrivateKey(index)
+    const bncClient = await this.client.bncClient.setPrivateKey(privateKey)
+
+    const transferResult = await bncClient.transfer(
+      await this.getAddress(index),
+      recipient,
+      baseToAsset(amount).amount().toString(),
+      asset ? asset.symbol : AssetBNB.symbol,
+      memo,
+    )
+
+    return transferResult.result.map((txResult: { hash?: TxHash }) => txResult?.hash ?? '')[0]
+  }
+
+  async multiSend(index: number, { transactions, memo = '' }: MultiSendParams): Promise<TxHash> {
+    const privateKey = await this.getPrivateKey(index)
+    const bncClient = await this.client.bncClient.setPrivateKey(privateKey)
+
+    const transferResult = await this.client.bncClient.multiSend(
+      bncClient.getClientKeyAddress(),
+      transactions.map((transaction) => {
+        return {
+          to: transaction.to,
+          coins: transaction.coins.map((coin) => {
+            return {
+              denom: coin.asset.symbol,
+              amount: baseToAsset(coin.amount).amount().toString(),
+            }
+          }),
+        }
+      }),
+      memo,
+    )
+
+    return transferResult.result.map((txResult: { hash?: TxHash }) => txResult?.hash ?? '')[0]
+  }
+}

--- a/packages/xchain-bitcoin/src/client.ts
+++ b/packages/xchain-bitcoin/src/client.ts
@@ -1,354 +1,138 @@
-import * as Bitcoin from 'bitcoinjs-lib'
 import * as Utils from './utils'
 import * as sochain from './sochain-api'
 import {
-  RootDerivationPaths,
   TxHistoryParams,
   TxsPage,
   Address,
-  XChainClient,
   Tx,
+  Balance,
+  Fees,
+  UTXOClient,
+  TxType,
+  FeeType,
+  Network,
+  ClientParams as BaseClientParams,
+  Client as BaseClient,
+  ClientFactory,
+  Wallet as BaseWallet,
   TxParams,
   TxHash,
-  Balance,
-  Network,
-  Fees,
-  XChainClientParams,
+  FeeRate,
 } from '@xchainjs/xchain-client'
-import { validatePhrase, getSeed } from '@xchainjs/xchain-crypto'
 import { AssetBTC, assetAmount, assetToBase } from '@xchainjs/xchain-util'
-import { FeesWithRates, FeeRate, FeeRates } from './types/client-types'
 
-/**
- * BitcoinClient Interface
- */
-interface BitcoinClient {
-  getFeesWithRates(memo?: string): Promise<FeesWithRates>
-  getFeesWithMemo(memo: string): Promise<Fees>
-  getFeeRates(): Promise<FeeRates>
+import { BTC_DECIMAL } from './const'
+import { FeesWithRates, FeeRates } from './types/client-types'
+
+export interface ClientParams extends BaseClientParams {
+  sochainUrl: string
+  blockstreamUrl: string
 }
 
-export type BitcoinClientParams = XChainClientParams & {
-  sochainUrl?: string
-  blockstreamUrl?: string
-}
-
-/**
- * Custom Bitcoin client
- */
-class Client implements BitcoinClient, XChainClient {
-  private net: Network
-  private phrase = ''
-  private sochainUrl = ''
-  private blockstreamUrl = ''
-  private rootDerivationPaths: RootDerivationPaths
-
-  /**
-   * Constructor
-   * Client is initialised with network type
-   *
-   * @param {BitcoinClientParams} params
-   */
-  constructor({
-    network = 'testnet',
-    sochainUrl = 'https://sochain.com/api/v2',
-    blockstreamUrl = 'https://blockstream.info',
-    rootDerivationPaths = {
-      mainnet: `84'/0'/0'/0/`, //note this isn't bip44 compliant, but it keeps the wallets generated compatible to pre HD wallets
-      testnet: `84'/1'/0'/0/`,
+export const MAINNET_PARAMS: ClientParams = {
+  network: Network.Mainnet,
+  getFullDerivationPath: (index: number) => `84'/0'/0'/0/${index}`,
+  explorer: {
+    url: 'https://blockstream.info',
+    getAddressUrl(address: string) {
+      return `${this.url}/address/${address}`
     },
-    phrase,
-  }: BitcoinClientParams) {
-    this.net = network
-    this.rootDerivationPaths = rootDerivationPaths
-    this.setSochainUrl(sochainUrl)
-    this.setBlockstreamUrl(blockstreamUrl)
-    phrase && this.setPhrase(phrase)
+    getTxUrl(txid: string) {
+      return `${this.url}/tx/${txid}`
+    },
+  },
+  sochainUrl: 'https://sochain.com/api/v2',
+  blockstreamUrl: 'https://blockstream.info',
+}
+
+export const TESTNET_PARAMS: ClientParams = {
+  ...MAINNET_PARAMS,
+  network: Network.Testnet,
+  getFullDerivationPath: (index: number) => `84'/1'/0'/0/${index}`,
+  explorer: {
+    ...MAINNET_PARAMS.explorer,
+    url: 'https://blockstream.info/testnet',
+  },
+}
+
+export class Client extends BaseClient<ClientParams, BaseWallet> implements UTXOClient<ClientParams, BaseWallet> {
+  static readonly create: ClientFactory<Client> = Client.bindFactory((x: ClientParams) => new Client(x))
+
+  async validateAddress(address: string): Promise<boolean> {
+    return Utils.validateAddress(address, Utils.btcNetwork(this.params.network))
   }
 
-  /**
-   * Set/Update the sochain url.
-   *
-   * @param {string} url The new sochain url.
-   * @returns {void}
-   */
-  setSochainUrl = (url: string): void => {
-    this.sochainUrl = url
+  async getBalance(address: Address): Promise<Balance[]> {
+    return Utils.getBalance({
+      sochainUrl: this.params.sochainUrl,
+      network: this.params.network,
+      address: address,
+    })
   }
 
-  /**
-   * Set/Update the blockstream url.
-   *
-   * @param {string} url The new blockstream url.
-   * @returns {void}
-   */
-  setBlockstreamUrl = (url: string): void => {
-    this.blockstreamUrl = url
-  }
-
-  /**
-   * Set/update a new phrase.
-   *
-   * @param {string} phrase A new phrase.
-   * @returns {Address} The first address from the given phrase
-   *
-   * @throws {"Invalid phrase"}
-   * Thrown if the given phase is invalid.
-   */
-  setPhrase = (phrase: string, walletIndex = 0): Address => {
-    if (validatePhrase(phrase)) {
-      this.phrase = phrase
-      return this.getAddress(walletIndex)
-    } else {
-      throw new Error('Invalid phrase')
-    }
-  }
-
-  /**
-   * Purge client.
-   *
-   * @returns {void}
-   */
-  purgeClient = (): void => {
-    this.phrase = ''
-  }
-
-  /**
-   * Set/update the current network.
-   *
-   * @param {Network} network `mainnet` or `testnet`.
-   * @returns {void}
-   *
-   * @throws {"Network must be provided"}
-   * Thrown if network has not been set before.
-   */
-  setNetwork = (net: Network): void => {
-    if (!net) {
-      throw new Error('Network must be provided')
-    }
-    this.net = net
-  }
-
-  /**
-   * Get the current network.
-   *
-   * @returns {Network} The current network. (`mainnet` or `testnet`)
-   */
-  getNetwork = (): Network => {
-    return this.net
-  }
-
-  /**
-   * Get getFullDerivationPath
-   *
-   * @param {number} index the HD wallet index
-   * @returns {string} The bitcoin derivation path based on the network.
-   */
-  getFullDerivationPath(index: number): string {
-    return this.rootDerivationPaths[this.net] + `${index}`
-  }
-
-  /**
-   * Get the explorer url.
-   *
-   * @returns {string} The explorer url based on the network.
-   */
-  getExplorerUrl = (): string => {
-    const networkPath = Utils.isTestnet(this.net) ? '/testnet' : ''
-    return `https://blockstream.info${networkPath}`
-  }
-
-  /**
-   * Get the explorer url for the given address.
-   *
-   * @param {Address} address
-   * @returns {string} The explorer url for the given address based on the network.
-   */
-  getExplorerAddressUrl = (address: Address): string => {
-    return `${this.getExplorerUrl()}/address/${address}`
-  }
-
-  /**
-   * Get the explorer url for the given transaction id.
-   *
-   * @param {string} txID The transaction id
-   * @returns {string} The explorer url for the given transaction id based on the network.
-   */
-  getExplorerTxUrl = (txID: string): string => {
-    return `${this.getExplorerUrl()}/tx/${txID}`
-  }
-
-  /**
-   * Get the current address.
-   *
-   * Generates a network-specific key-pair by first converting the buffer to a Wallet-Import-Format (WIF)
-   * The address is then decoded into type P2WPKH and returned.
-   *
-   * @returns {Address} The current address.
-   *
-   * @throws {"Phrase must be provided"} Thrown if phrase has not been set before.
-   * @throws {"Address not defined"} Thrown if failed creating account from phrase.
-   */
-  getAddress = (index = 0): Address => {
-    if (index < 0) {
-      throw new Error('index must be greater than zero')
-    }
-    if (this.phrase) {
-      const btcNetwork = Utils.btcNetwork(this.net)
-      const btcKeys = this.getBtcKeys(this.phrase, index)
-
-      const { address } = Bitcoin.payments.p2wpkh({
-        pubkey: btcKeys.publicKey,
-        network: btcNetwork,
-      })
-      if (!address) {
-        throw new Error('Address not defined')
-      }
-      return address
-    }
-    throw new Error('Phrase must be provided')
-  }
-
-  /**
-   * @private
-   * Get private key.
-   *
-   * Private function to get keyPair from the this.phrase
-   *
-   * @param {string} phrase The phrase to be used for generating privkey
-   * @returns {ECPairInterface} The privkey generated from the given phrase
-   *
-   * @throws {"Could not get private key from phrase"} Throws an error if failed creating BTC keys from the given phrase
-   * */
-  private getBtcKeys = (phrase: string, index = 0): Bitcoin.ECPairInterface => {
-    const btcNetwork = Utils.btcNetwork(this.net)
-
-    const seed = getSeed(phrase)
-    const master = Bitcoin.bip32.fromSeed(seed, btcNetwork).derivePath(this.getFullDerivationPath(index))
-
-    if (!master.privateKey) {
-      throw new Error('Could not get private key from phrase')
-    }
-
-    return Bitcoin.ECPair.fromPrivateKey(master.privateKey, { network: btcNetwork })
-  }
-
-  /**
-   * Validate the given address.
-   *
-   * @param {Address} address
-   * @returns {boolean} `true` or `false`
-   */
-  validateAddress = (address: string): boolean => Utils.validateAddress(address, this.net)
-
-  /**
-   * Get the BTC balance of a given address.
-   *
-   * @param {Address} the BTC address
-   * @returns {Array<Balance>} The BTC balance of the address.
-   */
-  getBalance = async (address: Address): Promise<Balance[]> => {
-    try {
-      return Utils.getBalance({
-        sochainUrl: this.sochainUrl,
-        network: this.net,
-        address: address,
-      })
-    } catch (e) {
-      return Promise.reject(e)
-    }
-  }
-
-  /**
-   * Get transaction history of a given address with pagination options.
-   * By default it will return the transaction history of the current wallet.
-   *
-   * @param {TxHistoryParams} params The options to get transaction history. (optional)
-   * @returns {TxsPage} The transaction history.
-   */
-  getTransactions = async (params?: TxHistoryParams): Promise<TxsPage> => {
+  async getTransactions(params: TxHistoryParams): Promise<TxsPage> {
     // Sochain API doesn't have pagination parameter
     const offset = params?.offset ?? 0
     const limit = params?.limit || 10
 
-    try {
-      const response = await sochain.getAddress({
-        address: params?.address + '',
-        sochainUrl: this.sochainUrl,
-        network: this.net,
-      })
-      const total = response.txs.length
-      const transactions: Tx[] = []
+    const response = await sochain.getAddress({
+      address: params?.address + '',
+      sochainUrl: this.params.sochainUrl,
+      network: this.params.network,
+    })
+    const total = response.txs.length
+    const transactions: Tx[] = []
 
-      const txs = response.txs.filter((_, index) => offset <= index && index < offset + limit)
-      for (const txItem of txs) {
-        const rawTx = await sochain.getTx({
-          sochainUrl: this.sochainUrl,
-          network: this.net,
-          hash: txItem.txid,
-        })
-        const tx: Tx = {
-          asset: AssetBTC,
-          from: rawTx.inputs.map((i) => ({
-            from: i.address,
-            amount: assetToBase(assetAmount(i.value, Utils.BTC_DECIMAL)),
-          })),
-          to: rawTx.outputs
-            .filter((i) => i.type !== 'nulldata')
-            .map((i) => ({ to: i.address, amount: assetToBase(assetAmount(i.value, Utils.BTC_DECIMAL)) })),
-          date: new Date(rawTx.time * 1000),
-          type: 'transfer',
-          hash: rawTx.txid,
-        }
-        transactions.push(tx)
-      }
-
-      const result: TxsPage = {
-        total,
-        txs: transactions,
-      }
-      return result
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get the transaction details of a given transaction id.
-   *
-   * @param {string} txId The transaction id.
-   * @returns {Tx} The transaction details of the given transaction id.
-   */
-  getTransactionData = async (txId: string): Promise<Tx> => {
-    try {
+    const txs = response.txs.filter((_, index) => offset <= index && index < offset + limit)
+    for (const txItem of txs) {
       const rawTx = await sochain.getTx({
-        sochainUrl: this.sochainUrl,
-        network: this.net,
-        hash: txId,
+        sochainUrl: this.params.sochainUrl,
+        network: this.params.network,
+        hash: txItem.txid,
       })
-      return {
+      const tx: Tx = {
         asset: AssetBTC,
         from: rawTx.inputs.map((i) => ({
           from: i.address,
-          amount: assetToBase(assetAmount(i.value, Utils.BTC_DECIMAL)),
+          amount: assetToBase(assetAmount(i.value, BTC_DECIMAL)),
         })),
-        to: rawTx.outputs.map((i) => ({ to: i.address, amount: assetToBase(assetAmount(i.value, Utils.BTC_DECIMAL)) })),
+        to: rawTx.outputs
+          .filter((i) => i.type !== 'nulldata')
+          .map((i) => ({ to: i.address, amount: assetToBase(assetAmount(i.value, BTC_DECIMAL)) })),
         date: new Date(rawTx.time * 1000),
-        type: 'transfer',
+        type: TxType.Transfer,
         hash: rawTx.txid,
       }
-    } catch (error) {
-      return Promise.reject(error)
+      transactions.push(tx)
+    }
+
+    const result: TxsPage = {
+      total,
+      txs: transactions,
+    }
+    return result
+  }
+
+  async getTransactionData(txId: string): Promise<Tx> {
+    const rawTx = await sochain.getTx({
+      sochainUrl: this.params.sochainUrl,
+      network: this.params.network,
+      hash: txId,
+    })
+    return {
+      asset: AssetBTC,
+      from: rawTx.inputs.map((i) => ({
+        from: i.address,
+        amount: assetToBase(assetAmount(i.value, BTC_DECIMAL)),
+      })),
+      to: rawTx.outputs.map((i) => ({ to: i.address, amount: assetToBase(assetAmount(i.value, BTC_DECIMAL)) })),
+      date: new Date(rawTx.time * 1000),
+      type: TxType.Transfer,
+      hash: rawTx.txid,
     }
   }
 
-  /**
-   * Get the rates and fees.
-   *
-   * @param {string} memo The memo to be used for fee calculation (optional)
-   * @returns {FeesWithRates} The fees and rates
-   */
-  getFeesWithRates = async (memo?: string): Promise<FeesWithRates> => {
+  async getFeesWithRates(memo?: string): Promise<FeesWithRates> {
     const txFee = await sochain.getSuggestedTxFee()
     const rates: FeeRates = {
       fastest: txFee * 5,
@@ -357,7 +141,7 @@ class Client implements BitcoinClient, XChainClient {
     }
 
     const fees: Fees = {
-      type: 'byte',
+      type: FeeType.PerByte,
       fast: Utils.calcFee(rates.fast, memo),
       average: Utils.calcFee(rates.average, memo),
       fastest: Utils.calcFee(rates.fastest, memo),
@@ -366,89 +150,24 @@ class Client implements BitcoinClient, XChainClient {
     return { fees, rates }
   }
 
-  /**
-   * Get the current fees.
-   *
-   * @returns {Fees} The fees without memo
-   */
-  getFees = async (): Promise<Fees> => {
-    try {
-      const { fees } = await this.getFeesWithRates()
-      return fees
-    } catch (error) {
-      return Promise.reject(error)
-    }
+  async getFees(): Promise<Fees> {
+    const { fees } = await this.getFeesWithRates()
+    return fees
   }
 
-  /**
-   * Get the fees for transactions with memo.
-   * If you want to get `Fees` and `FeeRates` at once, use `getFeesAndRates` method
-   *
-   * @param {string} memo
-   * @returns {Fees} The fees with memo
-   */
-  getFeesWithMemo = async (memo: string): Promise<Fees> => {
-    try {
-      const { fees } = await this.getFeesWithRates(memo)
-      return fees
-    } catch (error) {
-      return Promise.reject(error)
-    }
+  async getFeesWithMemo(memo: string): Promise<Fees> {
+    const { fees } = await this.getFeesWithRates(memo)
+    return fees
   }
 
-  /**
-   * Get the fee rates for transactions without a memo.
-   * If you want to get `Fees` and `FeeRates` at once, use `getFeesAndRates` method
-   *
-   * @returns {FeeRates} The fee rate
-   */
-  getFeeRates = async (): Promise<FeeRates> => {
-    try {
-      const { rates } = await this.getFeesWithRates()
-      return rates
-    } catch (error) {
-      return Promise.reject(error)
-    }
+  async getFeeRates(): Promise<FeeRates> {
+    const { rates } = await this.getFeesWithRates()
+    return rates
   }
 
-  /**
-   * Transfer BTC.
-   *
-   * @param {TxParams&FeeRate} params The transfer options.
-   * @returns {TxHash} The transaction hash.
-   */
-  transfer = async (params: TxParams & { feeRate?: FeeRate }): Promise<TxHash> => {
-    try {
-      const fromAddressIndex = params?.walletIndex || 0
-
-      // set the default fee rate to `fast`
-      const feeRate = params.feeRate || (await this.getFeeRates()).fast
-
-      /**
-       * do not spend pending UTXOs when adding a memo
-       * https://github.com/xchainjs/xchainjs-lib/issues/330
-       */
-      const spendPendingUTXO: boolean = params.memo ? false : true
-
-      const { psbt } = await Utils.buildTx({
-        ...params,
-        feeRate,
-        sender: this.getAddress(fromAddressIndex),
-        sochainUrl: this.sochainUrl,
-        network: this.net,
-        spendPendingUTXO,
-      })
-
-      const btcKeys = this.getBtcKeys(this.phrase, fromAddressIndex)
-      psbt.signAllInputs(btcKeys) // Sign all inputs
-      psbt.finalizeAllInputs() // Finalise inputs
-      const txHex = psbt.extractTransaction().toHex() // TX extracted and formatted to hex
-
-      return await Utils.broadcastTx({ network: this.net, txHex, blockstreamUrl: this.blockstreamUrl })
-    } catch (e) {
-      return Promise.reject(e)
-    }
+  transfer(index: number, params: TxParams & { feeRate?: FeeRate }): Promise<TxHash>
+  transfer(params: TxParams & { walletIndex?: number; feeRate?: FeeRate }): Promise<TxHash>
+  transfer(indexOrParams: number | (TxParams & { walletIndex?: number }), maybeParams?: TxParams): Promise<TxHash> {
+    return super.transfer(...this.normalizeParams(indexOrParams, maybeParams))
   }
 }
-
-export { Client, Network }

--- a/packages/xchain-bitcoin/src/const.ts
+++ b/packages/xchain-bitcoin/src/const.ts
@@ -4,3 +4,5 @@
  * @see https://github.com/bitcoin/bitcoin/blob/db88db47278d2e7208c50d16ab10cb355067d071/src/validation.h#L56
  */
 export const MIN_TX_FEE = 1000
+
+export const BTC_DECIMAL = 8

--- a/packages/xchain-bitcoin/src/haskoin-api.ts
+++ b/packages/xchain-bitcoin/src/haskoin-api.ts
@@ -1,9 +1,9 @@
-import { Address } from '@xchainjs/xchain-client/lib'
-import { BaseAmount, baseAmount } from '@xchainjs/xchain-util/lib'
+import { Address, Network } from '@xchainjs/xchain-client'
+import { BaseAmount, baseAmount } from '@xchainjs/xchain-util'
 import axios from 'axios'
 
+import { BTC_DECIMAL } from './const'
 import { getIsTxConfirmed } from './sochain-api'
-import { BTC_DECIMAL } from './utils'
 
 const HASKOIN_API_URL = 'https://api.haskoin.com/btc'
 const SOCHAIN_API_URL = 'https://sochain.com/api/v2'
@@ -42,27 +42,22 @@ export const getUnspentTxs = async (address: string): Promise<UtxoData[]> => {
 }
 
 export const getConfirmedUnspentTxs = async (address: string): Promise<UtxoData[]> => {
-  try {
-    const allUtxos = await getUnspentTxs(address)
+  const txs = await getUnspentTxs(address)
 
-    const confirmedUTXOs: UtxoData[] = []
-
+  const confirmedUTXOs = (
     await Promise.all(
-      allUtxos.map(async (tx: UtxoData) => {
+      txs.map(async (tx) => {
         const { is_confirmed: isTxConfirmed } = await getIsTxConfirmed({
           sochainUrl: SOCHAIN_API_URL,
-          network: 'mainnet',
+          network: Network.Mainnet,
           hash: tx.txid,
         })
-
-        if (isTxConfirmed) {
-          confirmedUTXOs.push(tx)
-        }
+        return [tx, isTxConfirmed] as const
       }),
     )
+  )
+    .filter(([_, isTxConfirmed]) => isTxConfirmed)
+    .map(([tx, _]) => tx)
 
-    return confirmedUTXOs
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  return confirmedUTXOs
 }

--- a/packages/xchain-bitcoin/src/index.ts
+++ b/packages/xchain-bitcoin/src/index.ts
@@ -1,14 +1,14 @@
 export * from './types'
 export * from './client'
+export * from './const'
 export {
   broadcastTx,
   getDefaultFees,
   getDefaultFeesWithRates,
-  getPrefix,
-  BTC_DECIMAL,
   scanUTXOs,
   buildTx,
   validateAddress,
   calcFee,
 } from './utils'
 export { createTxInfo } from './ledger'
+export * from './wallet'

--- a/packages/xchain-bitcoin/src/sochain-api.ts
+++ b/packages/xchain-bitcoin/src/sochain-api.ts
@@ -1,8 +1,10 @@
 import axios from 'axios'
+import { assetToBase, assetAmount, BaseAmount } from '@xchainjs/xchain-util'
+
+import { BTC_DECIMAL } from './const'
 import {
   SochainResponse,
   BtcAddressUTXO,
-  BtcAddressUTXOs,
   BtcUnspentTxsDTO,
   BtcAddressDTO,
   BtcGetBalanceDTO,
@@ -11,8 +13,6 @@ import {
   TxHashParams,
   TxConfirmedStatus,
 } from './types/sochain-api-types'
-import { assetToBase, assetAmount, BaseAmount } from '@xchainjs/xchain-util'
-import { BTC_DECIMAL } from './utils'
 
 const DEFAULT_SUGGESTED_TRANSACTION_FEE = 127
 
@@ -31,14 +31,10 @@ const toSochainNetwork = (net: string): string => {
  * @returns {BtcAddressDTO}
  */
 export const getAddress = async ({ sochainUrl, network, address }: AddressParams): Promise<BtcAddressDTO> => {
-  try {
-    const url = `${sochainUrl}/address/${toSochainNetwork(network)}/${address}`
-    const response = await axios.get(url)
-    const addressResponse: SochainResponse<BtcAddressDTO> = response.data
-    return addressResponse.data
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const url = `${sochainUrl}/address/${toSochainNetwork(network)}/${address}`
+  const response = await axios.get(url)
+  const addressResponse: SochainResponse<BtcAddressDTO> = response.data
+  return addressResponse.data
 }
 
 /**
@@ -52,14 +48,10 @@ export const getAddress = async ({ sochainUrl, network, address }: AddressParams
  * @returns {Transactions}
  */
 export const getTx = async ({ sochainUrl, network, hash }: TxHashParams): Promise<Transaction> => {
-  try {
-    const url = `${sochainUrl}/get_tx/${toSochainNetwork(network)}/${hash}`
-    const response = await axios.get(url)
-    const tx: SochainResponse<Transaction> = response.data
-    return tx.data
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const url = `${sochainUrl}/get_tx/${toSochainNetwork(network)}/${hash}`
+  const response = await axios.get(url)
+  const tx: SochainResponse<Transaction> = response.data
+  return tx.data
 }
 
 /**
@@ -73,18 +65,14 @@ export const getTx = async ({ sochainUrl, network, hash }: TxHashParams): Promis
  * @returns {number}
  */
 export const getBalance = async ({ sochainUrl, network, address }: AddressParams): Promise<BaseAmount> => {
-  try {
-    const url = `${sochainUrl}/get_address_balance/${toSochainNetwork(network)}/${address}`
-    const response = await axios.get(url)
-    const balanceResponse: SochainResponse<BtcGetBalanceDTO> = response.data
-    const confirmed = assetAmount(balanceResponse.data.confirmed_balance, BTC_DECIMAL)
-    const unconfirmed = assetAmount(balanceResponse.data.unconfirmed_balance, BTC_DECIMAL)
-    const netAmt = confirmed.amount().plus(unconfirmed.amount())
-    const result = assetToBase(assetAmount(netAmt, BTC_DECIMAL))
-    return result
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const url = `${sochainUrl}/get_address_balance/${toSochainNetwork(network)}/${address}`
+  const response = await axios.get(url)
+  const balanceResponse: SochainResponse<BtcGetBalanceDTO> = response.data
+  const confirmed = assetAmount(balanceResponse.data.confirmed_balance, BTC_DECIMAL)
+  const unconfirmed = assetAmount(balanceResponse.data.unconfirmed_balance, BTC_DECIMAL)
+  const netAmt = confirmed.amount().plus(unconfirmed.amount())
+  const result = assetToBase(assetAmount(netAmt, BTC_DECIMAL))
+  return result
 }
 
 /**
@@ -95,40 +83,34 @@ export const getBalance = async ({ sochainUrl, network, address }: AddressParams
  * @param {string} sochainUrl The sochain node url.
  * @param {string} network
  * @param {string} address
- * @returns {BtcAddressUTXOs}
+ * @returns {BtcAddressUTXO[]}
  */
 export const getUnspentTxs = async ({
   sochainUrl,
   network,
   address,
   startingFromTxId,
-}: AddressParams): Promise<BtcAddressUTXOs> => {
-  try {
-    let resp = null
-    if (startingFromTxId) {
-      resp = await axios.get(`${sochainUrl}/get_tx_unspent/${toSochainNetwork(network)}/${address}/${startingFromTxId}`)
-    } else {
-      resp = await axios.get(`${sochainUrl}/get_tx_unspent/${toSochainNetwork(network)}/${address}`)
-    }
-    const response: SochainResponse<BtcUnspentTxsDTO> = resp.data
-    const txs = response.data.txs
-    if (txs.length === 100) {
-      //fetch the next batch
-      const lastTxId = txs[99].txid
+}: AddressParams): Promise<BtcAddressUTXO[]> => {
+  const response: SochainResponse<BtcUnspentTxsDTO> = (
+    await axios.get(
+      `${sochainUrl}/get_tx_unspent/${toSochainNetwork(network)}/${address}${
+        startingFromTxId ? `/${startingFromTxId}` : ''
+      }`,
+    )
+  ).data
+  const txs = response.data.txs
+  if (txs.length !== 100) return txs
 
-      const nextBatch = await getUnspentTxs({
-        sochainUrl,
-        network,
-        address,
-        startingFromTxId: lastTxId,
-      })
-      return txs.concat(nextBatch)
-    } else {
-      return txs
-    }
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  //fetch the next batch
+  const lastTxId = txs[99].txid
+
+  const nextBatch = await getUnspentTxs({
+    sochainUrl,
+    network,
+    address,
+    startingFromTxId: lastTxId,
+  })
+  return txs.concat(nextBatch)
 }
 
 /**
@@ -142,14 +124,10 @@ export const getUnspentTxs = async ({
  * @returns {TxConfirmedStatus}
  */
 export const getIsTxConfirmed = async ({ sochainUrl, network, hash }: TxHashParams): Promise<TxConfirmedStatus> => {
-  try {
-    const { data } = await axios.get<SochainResponse<TxConfirmedStatus>>(
-      `${sochainUrl}/is_tx_confirmed/${toSochainNetwork(network)}/${hash}`,
-    )
-    return data.data
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const response: SochainResponse<TxConfirmedStatus> = (
+    await axios.get(`${sochainUrl}/is_tx_confirmed/${toSochainNetwork(network)}/${hash}`)
+  ).data
+  return response.data
 }
 
 /**
@@ -160,40 +138,35 @@ export const getIsTxConfirmed = async ({ sochainUrl, network, hash }: TxHashPara
  * @param {string} sochainUrl The sochain node url.
  * @param {string} network
  * @param {string} address
- * @returns {BtcAddressUTXOs}
+ * @returns {BtcAddressUTXO[]}
  */
 export const getConfirmedUnspentTxs = async ({
   sochainUrl,
   network,
   address,
-}: AddressParams): Promise<BtcAddressUTXOs> => {
-  try {
-    const txs = await getUnspentTxs({
-      sochainUrl,
-      network,
-      address,
-    })
+}: AddressParams): Promise<BtcAddressUTXO[]> => {
+  const txs = await getUnspentTxs({
+    sochainUrl,
+    network,
+    address,
+  })
 
-    const confirmedUTXOs: BtcAddressUTXOs = []
-
+  const confirmedUTXOs = (
     await Promise.all(
-      txs.map(async (tx: BtcAddressUTXO) => {
+      txs.map(async (tx) => {
         const { is_confirmed: isTxConfirmed } = await getIsTxConfirmed({
           sochainUrl,
           network,
           hash: tx.txid,
         })
-
-        if (isTxConfirmed) {
-          confirmedUTXOs.push(tx)
-        }
+        return [tx, isTxConfirmed] as const
       }),
     )
+  )
+    .filter(([_, isTxConfirmed]) => isTxConfirmed)
+    .map(([tx, _]) => tx)
 
-    return confirmedUTXOs
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  return confirmedUTXOs
 }
 
 /**

--- a/packages/xchain-bitcoin/src/types/client-types.ts
+++ b/packages/xchain-bitcoin/src/types/client-types.ts
@@ -1,7 +1,7 @@
-import { Address, FeeOptionKey, Fees, Network } from '@xchainjs/xchain-client'
+import { Address, FeeOption, Fees, Network } from '@xchainjs/xchain-client'
 
 export type FeeRate = number
-export type FeeRates = Record<FeeOptionKey, FeeRate>
+export type FeeRates = Record<FeeOption, FeeRate>
 
 export type FeesWithRates = { rates: FeeRates; fees: Fees }
 

--- a/packages/xchain-bitcoin/src/types/common.ts
+++ b/packages/xchain-bitcoin/src/types/common.ts
@@ -1,4 +1,4 @@
-import { Network } from '../client'
+import { Network } from '@xchainjs/xchain-client'
 
 export type Witness = {
   value: number

--- a/packages/xchain-bitcoin/src/types/ledger.ts
+++ b/packages/xchain-bitcoin/src/types/ledger.ts
@@ -7,7 +7,10 @@ export type LedgerTxInfo = {
   newTxHex: string
 }
 
-export type LedgerTxInfoParams = Pick<TxParams, 'amount' | 'recipient'> & {
+type OnlyRequiredKeys<T, U = keyof T> = U extends keyof T ? (undefined extends T[U] ? never : U) : never
+type OnlyRequired<T> = Pick<T, OnlyRequiredKeys<T>>
+
+export type LedgerTxInfoParams = OnlyRequired<TxParams> & {
   feeRate: FeeRate
   sender: Address
   network: Network

--- a/packages/xchain-bitcoin/src/wallet.ts
+++ b/packages/xchain-bitcoin/src/wallet.ts
@@ -1,0 +1,75 @@
+import { Address, FeeOption, TxHash, TxParams, Wallet as BaseWallet, WalletFactory } from '@xchainjs/xchain-client'
+import { validatePhrase, getSeed } from '@xchainjs/xchain-crypto'
+import * as Bitcoin from 'bitcoinjs-lib'
+import * as Utils from './utils'
+
+import { Client } from './client'
+import { FeeRate } from './types/client-types'
+
+export class Wallet implements BaseWallet {
+  protected readonly client: Client
+  protected readonly phrase: string
+
+  protected constructor(client: Client, phrase: string) {
+    this.client = client
+    this.phrase = phrase
+  }
+
+  static async create(phrase: string): Promise<WalletFactory<Client>> {
+    if (!validatePhrase(phrase)) throw new Error('Invalid phrase')
+    return async (client: Client) => new this(client, phrase)
+  }
+
+  protected async getBtcKeys(index: number): Promise<Bitcoin.ECPairInterface> {
+    const btcNetwork = Utils.btcNetwork(this.client.params.network)
+
+    const seed = getSeed(this.phrase)
+    const master = Bitcoin.bip32.fromSeed(seed, btcNetwork).derivePath(this.client.params.getFullDerivationPath(index))
+    if (!master.privateKey) throw new Error('Could not get private key from phrase')
+    return Bitcoin.ECPair.fromPrivateKey(master.privateKey, { network: btcNetwork })
+  }
+
+  async getAddress(index = 0): Promise<Address> {
+    const btcKeys = await this.getBtcKeys(index)
+
+    const { address } = Bitcoin.payments.p2wpkh({
+      pubkey: btcKeys.publicKey,
+      network: Utils.btcNetwork(this.client.params.network),
+    })
+
+    // Despite the exported typings on Payment, this can never actually be undefined.
+    if (address === undefined) throw new Error('could not get address')
+    return address
+  }
+
+  async transfer(index: number, params: TxParams & { feeRate?: FeeRate }): Promise<TxHash> {
+    // set the default fee rate to `fast`
+    const feeRate = params.feeRate ?? (await this.client.getFeeRates())[FeeOption.Fast]
+
+    /**
+     * do not spend pending UTXOs when adding a memo
+     * https://github.com/xchainjs/xchainjs-lib/issues/330
+     */
+    const spendPendingUTXO: boolean = params.memo ? false : true
+
+    const { psbt } = await Utils.buildTx({
+      ...params,
+      feeRate,
+      sender: await this.getAddress(index),
+      sochainUrl: this.client.params.sochainUrl,
+      network: this.client.params.network,
+      spendPendingUTXO,
+    })
+
+    const btcKeys = await this.getBtcKeys(index)
+    psbt.signAllInputs(btcKeys) // Sign all inputs
+    psbt.finalizeAllInputs() // Finalise inputs
+    const txHex = psbt.extractTransaction().toHex() // TX extracted and formatted to hex
+
+    return await Utils.broadcastTx({
+      network: this.client.params.network,
+      txHex,
+      blockstreamUrl: this.client.params.blockstreamUrl,
+    })
+  }
+}

--- a/packages/xchain-bitcoincash/__tests__/client.test.ts
+++ b/packages/xchain-bitcoincash/__tests__/client.test.ts
@@ -1,4 +1,6 @@
-import { Client } from '../src/client'
+import { baseAmount } from '@xchainjs/xchain-util'
+
+import { Client, MAINNET_PARAMS, TESTNET_PARAMS } from '../src/client'
 import {
   mock_broadcastTx,
   mock_estimateFee,
@@ -8,14 +10,16 @@ import {
   mock_getTransactions,
   mock_getUnspents,
 } from '../__mocks__/api'
-import { baseAmount } from '@xchainjs/xchain-util'
-import { BCH_DECIMAL } from '../src/utils'
 
-const bchClient = new Client({ network: 'mainnet' })
+import { BCH_DECIMAL } from '../src/utils'
+import { Wallet } from '../src/wallet'
+
+let bchClient: Client
 
 describe('BCHClient Test', () => {
-  beforeEach(() => bchClient.purgeClient())
-  afterEach(() => bchClient.purgeClient())
+  beforeEach(async () => {
+    bchClient = await Client.create(MAINNET_PARAMS)
+  })
 
   const MEMO = 'SWAP:THOR.RUNE'
   const phrase = 'atom green various power must another rent imitate gadget creek fat then'
@@ -24,75 +28,73 @@ describe('BCHClient Test', () => {
   const mainnet_address_path0 = 'qp4kjpk684c3d9qjk5a37vl2xn86wxl0f5j2ru0daj'
   const mainnet_address_path1 = 'qr4jrkhu3usuk8ghv60m7pg9eywuc79yqvd0wxt2lm'
 
-  it('set phrase should return correct address', () => {
-    bchClient.setNetwork('testnet')
-    expect(bchClient.setPhrase(phrase)).toEqual(testnet_address_path0)
+  it('set phrase should return correct address', async () => {
+    bchClient = await Client.create(TESTNET_PARAMS, Wallet.create(phrase))
+    expect(await bchClient.getAddress()).toEqual(testnet_address_path0)
 
-    bchClient.setNetwork('mainnet')
-    expect(bchClient.setPhrase(phrase)).toEqual(mainnet_address_path0)
+    bchClient = await Client.create(MAINNET_PARAMS, Wallet.create(phrase))
+    expect(await bchClient.getAddress()).toEqual(mainnet_address_path0)
   })
 
-  it('set phrase with derivation path should return correct address', () => {
-    bchClient.setNetwork('testnet')
-    expect(bchClient.setPhrase(phrase)).toEqual(testnet_address_path0)
-    expect(bchClient.getAddress(1)).toEqual(testnet_address_path1)
+  it('set phrase with derivation path should return correct address', async () => {
+    bchClient = await Client.create(TESTNET_PARAMS, Wallet.create(phrase))
+    expect(await bchClient.getAddress(0)).toEqual(testnet_address_path0)
+    expect(await bchClient.getAddress(1)).toEqual(testnet_address_path1)
 
-    bchClient.setNetwork('mainnet')
-    expect(bchClient.setPhrase(phrase)).toEqual(mainnet_address_path0)
-    expect(bchClient.getAddress(1)).toEqual(mainnet_address_path1)
+    bchClient = await Client.create(MAINNET_PARAMS, Wallet.create(phrase))
+    expect(await bchClient.getAddress(0)).toEqual(mainnet_address_path0)
+    expect(await bchClient.getAddress(1)).toEqual(mainnet_address_path1)
   })
 
-  it('should throw an error for setting a bad phrase', () => {
-    expect(() => bchClient.setPhrase('cat')).toThrow()
+  it('should throw an error for setting a bad phrase', async () => {
+    await expect(bchClient.unlock(Wallet.create('cat'))).rejects.toThrow()
   })
 
-  it('should not throw an error for setting a good phrase', () => {
-    expect(bchClient.setPhrase(phrase)).toBeUndefined
+  it('should not throw an error for setting a good phrase', async () => {
+    await expect(bchClient.unlock(Wallet.create(phrase))).resolves.not.toThrow()
   })
 
-  it('should validate the right address', () => {
-    bchClient.setNetwork('testnet')
-    bchClient.setPhrase(phrase)
-    expect(bchClient.getAddress()).toEqual(testnet_address_path0)
-    expect(bchClient.validateAddress(testnet_address_path0)).toBeTruthy()
+  it('should validate the right address', async () => {
+    bchClient = await Client.create(TESTNET_PARAMS, Wallet.create(phrase))
+    expect(await bchClient.getAddress()).toEqual(testnet_address_path0)
+    expect(await bchClient.validateAddress(testnet_address_path0)).toBeTruthy()
 
-    bchClient.setNetwork('mainnet')
-    expect(bchClient.validateAddress(mainnet_address_path0)).toBeTruthy()
+    bchClient = await Client.create(MAINNET_PARAMS, Wallet.create(phrase))
+    expect(await bchClient.validateAddress(mainnet_address_path0)).toBeTruthy()
   })
 
-  it('should return valid explorer url', () => {
-    bchClient.setNetwork('mainnet')
+  it('should return valid explorer url', async () => {
+    bchClient = await Client.create(MAINNET_PARAMS, Wallet.create(phrase))
     expect(bchClient.getExplorerUrl()).toEqual('https://www.blockchain.com/bch')
 
-    bchClient.setNetwork('testnet')
+    bchClient = await Client.create(TESTNET_PARAMS, Wallet.create(phrase))
     expect(bchClient.getExplorerUrl()).toEqual('https://www.blockchain.com/bch-testnet')
   })
 
-  it('should retrun valid explorer address url', () => {
-    bchClient.setNetwork('mainnet')
+  it('should retrun valid explorer address url', async () => {
+    bchClient = await Client.create(MAINNET_PARAMS, Wallet.create(phrase))
     expect(bchClient.getExplorerAddressUrl('testAddressHere')).toEqual(
       'https://www.blockchain.com/bch/address/testAddressHere',
     )
-    bchClient.setNetwork('testnet')
+    bchClient = await Client.create(TESTNET_PARAMS, Wallet.create(phrase))
     expect(bchClient.getExplorerAddressUrl('anotherTestAddressHere')).toEqual(
       'https://www.blockchain.com/bch-testnet/address/anotherTestAddressHere',
     )
   })
 
-  it('should retrun valid explorer tx url', () => {
-    bchClient.setNetwork('mainnet')
+  it('should retrun valid explorer tx url', async () => {
+    bchClient = await Client.create(MAINNET_PARAMS, Wallet.create(phrase))
     expect(bchClient.getExplorerTxUrl('testTxHere')).toEqual('https://www.blockchain.com/bch/tx/testTxHere')
-    bchClient.setNetwork('testnet')
+    bchClient = await Client.create(TESTNET_PARAMS, Wallet.create(phrase))
     expect(bchClient.getExplorerTxUrl('anotherTestTxHere')).toEqual(
       'https://www.blockchain.com/bch-testnet/tx/anotherTestTxHere',
     )
   })
 
   it('should get the right balance', async () => {
-    bchClient.setNetwork('testnet')
-    bchClient.setPhrase(phrase)
+    bchClient = await Client.create(TESTNET_PARAMS, Wallet.create(phrase))
 
-    mock_getBalance(bchClient.getHaskoinURL(), bchClient.getAddress(), {
+    mock_getBalance(bchClient.params.haskoinUrl, await bchClient.getAddress(), {
       received: 124442749359,
       utxo: 1336,
       address: 'bchtest:qz35h5mfa8w2pqma2jq06lp7dnv5fxkp2svtllzmlf',
@@ -100,16 +102,15 @@ describe('BCHClient Test', () => {
       unconfirmed: 0,
       confirmed: 0,
     })
-    const balance = await bchClient.getBalance(bchClient.getAddress())
+    const balance = await bchClient.getBalance(await bchClient.getAddress())
     expect(balance.length).toEqual(1)
     expect(balance[0].amount.amount().toNumber()).toEqual(0)
   })
 
   it('should get the right balance', async () => {
-    bchClient.setNetwork('testnet')
-    bchClient.setPhrase(phrase)
+    bchClient = await Client.create(TESTNET_PARAMS, Wallet.create(phrase))
 
-    mock_getBalance(bchClient.getHaskoinURL(), bchClient.getAddress(), {
+    mock_getBalance(bchClient.params.haskoinUrl, await bchClient.getAddress(), {
       received: 123817511737,
       utxo: 1336,
       address: 'bchtest:qz35h5mfa8w2pqma2jq06lp7dnv5fxkp2svtllzmlf',
@@ -117,17 +118,16 @@ describe('BCHClient Test', () => {
       unconfirmed: 100000000000,
       confirmed: 123817511737,
     })
-    const balance = await bchClient.getBalance(bchClient.getAddress())
+    const balance = await bchClient.getBalance(await bchClient.getAddress())
     expect(balance.length).toEqual(1)
     expect(balance[0].amount.amount().isEqualTo('223817511737')).toBeTruthy()
   })
 
   it('should get transaction data', async () => {
-    bchClient.setNetwork('testnet')
-    bchClient.setPhrase(phrase)
+    bchClient = await Client.create(TESTNET_PARAMS, Wallet.create(phrase))
 
     mock_getTransactionData(
-      bchClient.getHaskoinURL(),
+      bchClient.params.haskoinUrl,
       '0d5764c89d3fbf8bea9b329ad5e0ddb6047e72313c0f7b54dcb14f4d242da64b',
       {
         time: 1548767230,
@@ -193,10 +193,9 @@ describe('BCHClient Test', () => {
   })
 
   it('should get transactions', async () => {
-    bchClient.setNetwork('testnet')
-    bchClient.setPhrase(phrase)
+    bchClient = await Client.create(TESTNET_PARAMS, Wallet.create(phrase))
 
-    mock_getBalance(bchClient.getHaskoinURL(), 'bchtest:qz35h5mfa8w2pqma2jq06lp7dnv5fxkp2svtllzmlf', {
+    mock_getBalance(bchClient.params.haskoinUrl, 'bchtest:qz35h5mfa8w2pqma2jq06lp7dnv5fxkp2svtllzmlf', {
       received: 124442749359,
       utxo: 1336,
       address: 'bchtest:qz35h5mfa8w2pqma2jq06lp7dnv5fxkp2svtllzmlf',
@@ -204,7 +203,7 @@ describe('BCHClient Test', () => {
       unconfirmed: 0,
       confirmed: 0,
     })
-    mock_getTransactions(bchClient.getHaskoinURL(), 'bchtest:qz35h5mfa8w2pqma2jq06lp7dnv5fxkp2svtllzmlf', [
+    mock_getTransactions(bchClient.params.haskoinUrl, 'bchtest:qz35h5mfa8w2pqma2jq06lp7dnv5fxkp2svtllzmlf', [
       {
         time: 1548767230,
         size: 245,
@@ -270,27 +269,26 @@ describe('BCHClient Test', () => {
   })
 
   it('should transfer bch', async () => {
-    bchClient.setNetwork('testnet')
-    bchClient.setPhrase(phrase)
+    bchClient = await Client.create(TESTNET_PARAMS, Wallet.create(phrase))
 
     mock_getBalance(
-      bchClient.getHaskoinURL(),
-      bchClient.getAddress(),
+      bchClient.params.haskoinUrl,
+      await bchClient.getAddress(),
       {
         received: 12964626,
         utxo: 1,
-        address: bchClient.getAddress(),
+        address: await bchClient.getAddress(),
         txs: 13,
         unconfirmed: 0,
         confirmed: 992999,
       },
       2,
     )
-    mock_getUnspents(bchClient.getHaskoinURL(), bchClient.getAddress(), [
+    mock_getUnspents(bchClient.params.haskoinUrl, await bchClient.getAddress(), [
       {
         pkscript: '76a9145be96e4fbfd68370cfd30ad2f3458c580f09afb188ac',
         value: 992999,
-        address: bchClient.getAddress(),
+        address: await bchClient.getAddress(),
         block: {
           height: 1436370,
           position: 4,
@@ -300,7 +298,7 @@ describe('BCHClient Test', () => {
       },
     ])
     mock_getRawTransactionData(
-      bchClient.getHaskoinURL(),
+      bchClient.params.haskoinUrl,
       '66f090bd35b15a4a8ede2f71184cf4d2cc08483921752b845ba2fdee7b96ca79',
       {
         result:
@@ -308,7 +306,7 @@ describe('BCHClient Test', () => {
       },
     )
     mock_estimateFee()
-    mock_broadcastTx(bchClient.getNodeURL(), '82b65a0006697bff406c62ad0b3fd07db9f20ce6fbc468c81679d96aebc36f69')
+    mock_broadcastTx(await bchClient.params.nodeUrl, '82b65a0006697bff406c62ad0b3fd07db9f20ce6fbc468c81679d96aebc36f69')
 
     const txId = await bchClient.transfer({
       walletIndex: 0,
@@ -320,8 +318,7 @@ describe('BCHClient Test', () => {
   })
 
   it('returns fees and rates of a normal tx', async () => {
-    bchClient.setNetwork('testnet')
-    bchClient.setPhrase(phrase)
+    bchClient = await Client.create(TESTNET_PARAMS, Wallet.create(phrase))
 
     mock_estimateFee()
 
@@ -337,8 +334,7 @@ describe('BCHClient Test', () => {
   })
 
   it('returns fees and rates of a tx w/ memo', async () => {
-    bchClient.setNetwork('testnet')
-    bchClient.setPhrase(phrase)
+    bchClient = await Client.create(TESTNET_PARAMS, Wallet.create(phrase))
 
     mock_estimateFee()
 
@@ -354,8 +350,7 @@ describe('BCHClient Test', () => {
   })
 
   it('should return estimated fees of a normal tx', async () => {
-    bchClient.setNetwork('testnet')
-    bchClient.setPhrase(phrase)
+    bchClient = await Client.create(TESTNET_PARAMS, Wallet.create(phrase))
 
     mock_estimateFee()
 
@@ -366,8 +361,7 @@ describe('BCHClient Test', () => {
   })
 
   it('returns different fee rates for a normal tx', async () => {
-    bchClient.setNetwork('testnet')
-    bchClient.setPhrase(phrase)
+    bchClient = await Client.create(TESTNET_PARAMS, Wallet.create(phrase))
 
     mock_estimateFee()
 

--- a/packages/xchain-bitcoincash/src/client.ts
+++ b/packages/xchain-bitcoincash/src/client.ts
@@ -1,458 +1,131 @@
-const bitcash = require('@psf/bitcoincashjs-lib')
-
 import * as utils from './utils'
 import {
-  RootDerivationPaths,
   Address,
   Balance,
-  Network,
+  Client as BaseClient,
+  ClientFactory,
+  ClientParams as BaseClientParams,
   Fees,
+  Network,
   Tx,
   TxParams,
   TxHash,
   TxHistoryParams,
   TxsPage,
-  XChainClient,
-  XChainClientParams,
+  UTXOClient,
+  Wallet,
+  FeeType,
+  FeeRate,
+  FeeRates,
+  FeesWithRates,
+  FeeOption,
 } from '@xchainjs/xchain-client'
-import { validatePhrase, getSeed } from '@xchainjs/xchain-crypto'
-import { FeesWithRates, FeeRate, FeeRates, ClientUrl } from './types/client-types'
-import { KeyPair } from './types/bitcoincashjs-types'
 import { getTransaction, getAccount, getTransactions, getSuggestedFee } from './haskoin-api'
 import { NodeAuth } from './types'
-import { broadcastTx } from './node-api'
 
-/**
- * BitcoinCashClient Interface
- */
-interface BitcoinCashClient {
-  getFeesWithRates(memo?: string): Promise<FeesWithRates>
-  getFeesWithMemo(memo: string): Promise<Fees>
-  getFeeRates(): Promise<FeeRates>
+export interface ClientParams extends BaseClientParams {
+  haskoinUrl: string
+  nodeUrl: string
+  nodeAuth: NodeAuth
 }
 
-export type BitcoinCashClientParams = XChainClientParams & {
-  haskoinUrl?: ClientUrl
-  nodeUrl?: ClientUrl
-  nodeAuth?: NodeAuth
-  rootPath?: string
-  index?: number
+export const MAINNET_PARAMS: ClientParams = {
+  network: Network.Mainnet,
+  getFullDerivationPath: (index: number) => `44'/145'/0'/0/${index}`,
+  explorer: {
+    url: 'https://www.blockchain.com/bch',
+    getAddressUrl(address: string) {
+      return `${this.url}/address/${address}`
+    },
+    getTxUrl(txid: string) {
+      return `${this.url}/tx/${txid}`
+    },
+  },
+  haskoinUrl: 'https://api.haskoin.com/bch',
+  nodeUrl: 'https://bch.thorchain.info',
+  nodeAuth: {
+    username: 'thorchain',
+    password: 'password',
+  },
 }
 
-/**
- * Custom Bitcoin Cash client
- */
-class Client implements BitcoinCashClient, XChainClient {
-  private network: Network
-  private phrase = ''
-  private haskoinUrl: ClientUrl
-  private nodeUrl: ClientUrl
-  private nodeAuth?: NodeAuth
-  private rootDerivationPaths: RootDerivationPaths
+export const TESTNET_PARAMS: ClientParams = {
+  ...MAINNET_PARAMS,
+  network: Network.Testnet,
+  getFullDerivationPath: (index: number) => `44'/1'/0'/0/${index}`,
+  explorer: {
+    ...MAINNET_PARAMS.explorer,
+    url: 'https://www.blockchain.com/bch-testnet',
+  },
+  haskoinUrl: 'https://api.haskoin.com/bchtest',
+  nodeUrl: 'https://testnet.bch.thorchain.info',
+}
 
-  /**
-   * Constructor
-   * Client is initialised with network type
-   *
-   * @param {BitcoinCashClientParams} params
-   */
-  constructor({
-    network = 'testnet',
-    haskoinUrl = {
-      testnet: 'https://api.haskoin.com/bchtest',
-      mainnet: 'https://api.haskoin.com/bch',
-    },
-    phrase,
-    nodeUrl = {
-      testnet: 'https://testnet.bch.thorchain.info',
-      mainnet: 'https://bch.thorchain.info',
-    },
-    nodeAuth = {
-      username: 'thorchain',
-      password: 'password',
-    },
-    rootDerivationPaths = {
-      mainnet: `m/44'/145'/0'/0/`,
-      testnet: `m/44'/1'/0'/0/`,
-    },
-  }: BitcoinCashClientParams) {
-    this.network = network
-    this.haskoinUrl = haskoinUrl
-    this.nodeUrl = nodeUrl
-    this.rootDerivationPaths = rootDerivationPaths
-    phrase && this.setPhrase(phrase)
-    this.nodeAuth =
-      // Leave possibility to send requests without auth info for user
-      // by strictly passing nodeAuth as null value
-      nodeAuth === null ? undefined : nodeAuth
+export class Client extends BaseClient<ClientParams, Wallet> implements UTXOClient<ClientParams, Wallet> {
+  static readonly create: ClientFactory<Client> = Client.bindFactory((x: ClientParams) => new Client(x))
+
+  async validateAddress(address: string): Promise<boolean> {
+    return utils.validateAddress(address, this.params.network)
   }
 
-  /**
-   * Set/Update the haskoin url.
-   *
-   * @param {string} url The new haskoin url.
-   * @returns {void}
-   */
-  setHaskoinURL = (url: ClientUrl): void => {
-    this.haskoinUrl = url
+  async getBalance(address: Address): Promise<Balance[]> {
+    return utils.getBalance({ haskoinUrl: this.params.haskoinUrl, address })
   }
 
-  /**
-   * Get the haskoin url.
-   *
-   * @returns {string} The haskoin url based on the current network.
-   */
-  getHaskoinURL = (): string => {
-    return this.haskoinUrl[this.getNetwork()]
-  }
+  async getTransactions({ address, offset, limit }: TxHistoryParams): Promise<TxsPage> {
+    offset = offset ?? 0
+    limit = limit ?? 10
 
-  /**
-   * Set/Update the node url.
-   *
-   * @param {string} url The new node url.
-   * @returns {void}
-   */
-  setNodeURL = (url: ClientUrl): void => {
-    this.nodeUrl = url
-  }
+    const account = await getAccount({ haskoinUrl: this.params.haskoinUrl, address })
+    const txs = await getTransactions({
+      haskoinUrl: this.params.haskoinUrl,
+      address,
+      params: { offset, limit },
+    })
 
-  /**
-   * Get the node url.
-   *
-   * @returns {string} The node url for thorchain based on the current network.
-   */
-  getNodeURL = (): string => {
-    return this.nodeUrl[this.getNetwork()]
-  }
-
-  /**
-   * Set/update a new phrase.
-   *
-   * @param {string} phrase A new phrase.
-   * @param {string} derivationPath bip44 derivation path
-   * @returns {Address} The address from the given phrase
-   *
-   * @throws {"Invalid phrase"}
-   * Thrown if the given phase is invalid.
-   */
-  setPhrase = (phrase: string, walletIndex = 0): Address => {
-    if (validatePhrase(phrase)) {
-      this.phrase = phrase
-      return this.getAddress(walletIndex)
-    } else {
-      throw new Error('Invalid phrase')
+    return {
+      total: account.txs,
+      txs: txs.map(utils.parseTransaction),
     }
   }
 
-  /**
-   * Purge client.
-   *
-   * @returns {void}
-   */
-  purgeClient = (): void => {
-    this.phrase = ''
+  async getTransactionData(txId: string): Promise<Tx> {
+    const tx = await getTransaction({ haskoinUrl: this.params.haskoinUrl, txId })
+    return utils.parseTransaction(tx)
   }
 
-  /**
-   * Set/update the current network.
-   *
-   * @param {Network} network `mainnet` or `testnet`.
-   * @returns {void}
-   *
-   * @throws {"Network must be provided"}
-   * Thrown if network has not been set before.
-   */
-  setNetwork = (net: Network): void => {
-    if (!net) {
-      throw new Error('Network must be provided')
-    }
-    this.network = net
-  }
+  async getFeesWithRates(memo?: string): Promise<FeesWithRates> {
+    const rates = await this.getFeeRates()
 
-  /**
-   * Get the current network.
-   *
-   * @returns {Network} The current network. (`mainnet` or `testnet`)
-   */
-  getNetwork = (): Network => {
-    return this.network
-  }
-
-  /**
-   * Get the explorer url.
-   *
-   * @returns {string} The explorer url based on the network.
-   */
-  getExplorerUrl = (): string => {
-    const networkPath = utils.isTestnet(this.network) ? 'bch-testnet' : 'bch'
-    return `https://www.blockchain.com/${networkPath}`
-  }
-
-  /**
-   * Get the explorer url for the given address.
-   *
-   * @param {Address} address
-   * @returns {string} The explorer url for the given address based on the network.
-   */
-  getExplorerAddressUrl = (address: Address): string => {
-    return `${this.getExplorerUrl()}/address/${address}`
-  }
-
-  /**
-   * Get the explorer url for the given transaction id.
-   *
-   * @param {string} txID The transaction id
-   * @returns {string} The explorer url for the given transaction id based on the network.
-   */
-  getExplorerTxUrl = (txID: string): string => {
-    return `${this.getExplorerUrl()}/tx/${txID}`
-  }
-
-  /**
-   * @private
-   * Get private key.
-   *
-   * Private function to get keyPair from the this.phrase
-   *
-   * @param {string} phrase The phrase to be used for generating privkey
-   * @param {string} derivationPath BIP44 derivation path
-   * @returns {PrivateKey} The privkey generated from the given phrase
-   *
-   * @throws {"Invalid phrase"} Thrown if invalid phrase is provided.
-   * */
-  private getBCHKeys = (phrase: string, derivationPath: string): KeyPair => {
-    try {
-      const rootSeed = getSeed(phrase)
-      const masterHDNode = bitcash.HDNode.fromSeedBuffer(rootSeed, utils.bchNetwork(this.network))
-
-      return masterHDNode.derivePath(derivationPath).keyPair
-    } catch (error) {
-      throw new Error(`Getting key pair failed: ${error?.message || error.toString()}`)
-    }
-  }
-
-  /**
-   * Get the current address.
-   *
-   * Generates a network-specific key-pair by first converting the buffer to a Wallet-Import-Format (WIF)
-   * The address is then decoded into type P2WPKH and returned.
-   *
-   * @returns {Address} The current address.
-   *
-   * @throws {"Phrase must be provided"} Thrown if phrase has not been set before.
-   * @throws {"Address not defined"} Thrown if failed creating account from phrase.
-   */
-  getAddress = (index = 0): Address => {
-    if (this.phrase) {
-      try {
-        const keys = this.getBCHKeys(this.phrase, this.getFullDerivationPath(index))
-        const address = keys.getAddress(index)
-
-        return utils.stripPrefix(utils.toCashAddress(address))
-      } catch (error) {
-        throw new Error('Address not defined')
-      }
-    }
-
-    throw new Error('Phrase must be provided')
-  }
-
-  /**
-   * Get getFullDerivationPath
-   *
-   * @param {number} index the HD wallet index
-   * @returns {string} The derivation path based on the network.
-   */
-  getFullDerivationPath(index: number): string {
-    return this.rootDerivationPaths[this.network] + `${index}`
-  }
-
-  /**
-   * Validate the given address.
-   *
-   * @param {Address} address
-   * @returns {boolean} `true` or `false`
-   */
-  validateAddress = (address: string): boolean => {
-    return utils.validateAddress(address, this.network)
-  }
-
-  /**
-   * Get the BCH balance of a given address.
-   *
-   * @param {Address} address By default, it will return the balance of the current wallet. (optional)
-   * @returns {Array<Balance>} The BCH balance of the address.
-   *
-   * @throws {"Invalid address"} Thrown if the given address is an invalid address.
-   */
-  getBalance = async (address: Address): Promise<Balance[]> => {
-    return utils.getBalance({ haskoinUrl: this.getHaskoinURL(), address })
-  }
-
-  /**
-   * Get transaction history of a given address with pagination options.
-   * By default it will return the transaction history of the current wallet.
-   *
-   * @param {TxHistoryParams} params The options to get transaction history. (optional)
-   * @returns {TxsPage} The transaction history.
-   *
-   * @throws {"Invalid address"} Thrown if the given address is an invalid address.
-   */
-  getTransactions = async ({ address, offset, limit }: TxHistoryParams): Promise<TxsPage> => {
-    try {
-      offset = offset || 0
-      limit = limit || 10
-
-      const account = await getAccount({ haskoinUrl: this.getHaskoinURL(), address })
-      const txs = await getTransactions({
-        haskoinUrl: this.getHaskoinURL(),
-        address,
-        params: { offset, limit },
-      })
-
-      if (!account || !txs) {
-        throw new Error('Invalid address')
-      }
-
-      return {
-        total: account.txs,
-        txs: txs.map(utils.parseTransaction),
-      }
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get the transaction details of a given transaction id.
-   *
-   * @param {string} txId The transaction id.
-   * @returns {Tx} The transaction details of the given transaction id.
-   *
-   * @throws {"Invalid TxID"} Thrown if the given transaction id is an invalid one.
-   */
-  getTransactionData = async (txId: string): Promise<Tx> => {
-    try {
-      const tx = await getTransaction({ haskoinUrl: this.getHaskoinURL(), txId })
-
-      if (!tx) {
-        throw new Error('Invalid TxID')
-      }
-
-      return utils.parseTransaction(tx)
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get the rates and fees.
-   *
-   * @param {string} memo The memo to be used for fee calculation (optional)
-   * @returns {FeesWithRates} The fees and rates
-   */
-  getFeesWithRates = async (memo?: string): Promise<FeesWithRates> => {
-    const nextBlockFeeRate = await getSuggestedFee()
-    const rates: FeeRates = {
-      fastest: nextBlockFeeRate * 5,
-      fast: nextBlockFeeRate * 1,
-      average: nextBlockFeeRate * 0.5,
-    }
-
-    const fees: Fees = {
-      type: 'byte',
-      fast: utils.calcFee(rates.fast, memo),
-      average: utils.calcFee(rates.average, memo),
-      fastest: utils.calcFee(rates.fastest, memo),
-    }
+    const fees = (Object.entries(rates) as Array<[FeeOption, FeeRate]>)
+      .map(([k, v]) => [k, utils.calcFee(v, memo)] as const)
+      .reduce((a, [k, v]) => ((a[k] = v), a), { type: FeeType.PerByte } as Fees)
 
     return { fees, rates }
   }
 
-  /**
-   * Get the current fees.
-   *
-   * @returns {Fees} The fees without memo
-   */
-  getFees = async (): Promise<Fees> => {
-    try {
-      const { fees } = await this.getFeesWithRates()
-      return fees
-    } catch (error) {
-      return Promise.reject(error)
+  async getFees(): Promise<Fees> {
+    const { fees } = await this.getFeesWithRates()
+    return fees
+  }
+
+  async getFeesWithMemo(memo: string): Promise<Fees> {
+    const { fees } = await this.getFeesWithRates(memo)
+    return fees
+  }
+
+  async getFeeRates(): Promise<FeeRates> {
+    const nextBlockFeeRate = await getSuggestedFee()
+    return {
+      average: nextBlockFeeRate * 0.5,
+      fast: nextBlockFeeRate * 1,
+      fastest: nextBlockFeeRate * 5,
     }
   }
 
-  /**
-   * Get the fees for transactions with memo.
-   * If you want to get `Fees` and `FeeRates` at once, use `getFeesAndRates` method
-   *
-   * @param {string} memo
-   * @returns {Fees} The fees with memo
-   */
-  getFeesWithMemo = async (memo: string): Promise<Fees> => {
-    try {
-      const { fees } = await this.getFeesWithRates(memo)
-      return fees
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get the fee rates for transactions without a memo.
-   * If you want to get `Fees` and `FeeRates` at once, use `getFeesAndRates` method
-   *
-   * @returns {FeeRates} The fee rate
-   */
-  getFeeRates = async (): Promise<FeeRates> => {
-    try {
-      const { rates } = await this.getFeesWithRates()
-      return rates
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Transfer BCH.
-   *
-   * @param {TxParams&FeeRate} params The transfer options.
-   * @returns {TxHash} The transaction hash.
-   */
-  transfer = async (params: TxParams & { feeRate?: FeeRate }): Promise<TxHash> => {
-    try {
-      const index = params.walletIndex || 0
-      const derivationPath = this.rootDerivationPaths[this.network] + `${index}`
-
-      const feeRate = params.feeRate || (await this.getFeeRates()).fast
-      const { builder, utxos } = await utils.buildTx({
-        ...params,
-        feeRate,
-        sender: this.getAddress(),
-        haskoinUrl: this.getHaskoinURL(),
-        network: this.network,
-      })
-
-      const keyPair = this.getBCHKeys(this.phrase, derivationPath)
-
-      utxos.forEach((utxo, index) => {
-        builder.sign(index, keyPair, undefined, 0x41, utxo.witnessUtxo.value)
-      })
-
-      const tx = builder.build()
-      const txHex = tx.toHex()
-
-      return await broadcastTx({
-        network: this.network,
-        txHex,
-        nodeUrl: this.getNodeURL(),
-        auth: this.nodeAuth,
-      })
-    } catch (e) {
-      return Promise.reject(e)
-    }
+  transfer(index: number, params: TxParams & { feeRate?: FeeRate }): Promise<TxHash>
+  transfer(params: TxParams & { walletIndex?: number; feeRate?: FeeRate }): Promise<TxHash>
+  transfer(indexOrParams: number | (TxParams & { walletIndex?: number }), maybeParams?: TxParams): Promise<TxHash> {
+    return super.transfer(...this.normalizeParams(indexOrParams, maybeParams))
   }
 }
-
-export { Client }

--- a/packages/xchain-bitcoincash/src/index.ts
+++ b/packages/xchain-bitcoincash/src/index.ts
@@ -1,3 +1,4 @@
 export * from './types'
 export * from './client'
 export * from './utils'
+export * from './wallet'

--- a/packages/xchain-bitcoincash/src/modules.d.ts
+++ b/packages/xchain-bitcoincash/src/modules.d.ts
@@ -1,0 +1,1 @@
+declare module '@psf/bitcoincashjs-lib'

--- a/packages/xchain-bitcoincash/src/types/client-types.ts
+++ b/packages/xchain-bitcoincash/src/types/client-types.ts
@@ -1,9 +1,4 @@
-import { Address, Balance, FeeOptionKey, Fees } from '@xchainjs/xchain-client'
-
-export type FeeRate = number
-export type FeeRates = Record<FeeOptionKey, FeeRate>
-
-export type FeesWithRates = { rates: FeeRates; fees: Fees }
+import { Address, Balance } from '@xchainjs/xchain-client'
 
 export type NormalTxParams = { addressTo: string; amount: number; feeRate: number }
 export type VaultTxParams = NormalTxParams & { memo: string }
@@ -29,8 +24,6 @@ export type UTXO = {
   address: Address
   txHex: string
 }
-
-export type UTXOs = UTXO[]
 
 export type GetChangeParams = {
   valueOut: number

--- a/packages/xchain-bitcoincash/src/wallet.ts
+++ b/packages/xchain-bitcoincash/src/wallet.ts
@@ -1,0 +1,72 @@
+import {
+  Address,
+  FeeOption,
+  FeeRate,
+  TxHash,
+  TxParams,
+  Wallet as BaseWallet,
+  WalletFactory,
+} from '@xchainjs/xchain-client'
+import { validatePhrase, getSeed } from '@xchainjs/xchain-crypto'
+import * as bitcash from '@psf/bitcoincashjs-lib'
+
+import * as utils from './utils'
+import { Client } from './client'
+import { broadcastTx } from './node-api'
+import { KeyPair } from './types/bitcoincashjs-types'
+
+export class Wallet implements BaseWallet {
+  protected readonly client: Client
+  protected readonly phrase: string
+
+  protected constructor(client: Client, phrase: string) {
+    this.client = client
+    this.phrase = phrase
+  }
+
+  static async create(phrase: string): Promise<WalletFactory<Client>> {
+    if (!validatePhrase(phrase)) throw new Error('Invalid phrase')
+    return async (client: Client) => new this(client, phrase)
+  }
+
+  protected async getBCHKeys(index: number): Promise<KeyPair> {
+    const derivationPath = this.client.getFullDerivationPath(index)
+    const rootSeed = getSeed(this.phrase)
+    const masterHDNode = bitcash.HDNode.fromSeedBuffer(rootSeed, utils.bchNetwork(this.client.params.network))
+
+    return masterHDNode.derivePath(derivationPath).keyPair
+  }
+
+  async getAddress(index: number): Promise<Address> {
+    const keyPair = await this.getBCHKeys(index)
+    const address = keyPair.getAddress(index)
+    return utils.stripPrefix(utils.toCashAddress(address))
+  }
+
+  async transfer(index: number, params: TxParams & { feeRate?: FeeRate }): Promise<TxHash> {
+    const keyPair = await this.getBCHKeys(index)
+
+    const feeRate = params.feeRate ?? (await this.client.getFeeRates())[FeeOption.Fast]
+    const { builder, utxos } = await utils.buildTx({
+      ...params,
+      feeRate,
+      sender: await this.getAddress(index),
+      haskoinUrl: this.client.params.haskoinUrl,
+      network: this.client.params.network,
+    })
+
+    utxos.forEach((utxo, index) => {
+      builder.sign(index, keyPair, undefined, 0x41, utxo.witnessUtxo.value)
+    })
+
+    const tx = builder.build()
+    const txHex = tx.toHex()
+
+    return await broadcastTx({
+      network: this.client.params.network,
+      txHex,
+      nodeUrl: this.client.params.nodeUrl,
+      auth: this.client.params.nodeAuth,
+    })
+  }
+}

--- a/packages/xchain-bitcoincash/tsconfig.json
+++ b/packages/xchain-bitcoincash/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": [ "src/**/*" ]
+  "include": ["src/**/*"]
 }

--- a/packages/xchain-client/src/client.ts
+++ b/packages/xchain-client/src/client.ts
@@ -1,0 +1,142 @@
+import { Asset, BaseAmount } from '@xchainjs/xchain-util'
+
+import { Address, Balance, Fees, Network, Tx, TxHash, TxsPage } from './types'
+
+export interface Explorer {
+  url: string
+  getAddressUrl(address: Address): string
+  getTxUrl(txID: string): string
+}
+
+export interface ClientParams {
+  network: Network
+  explorer: Readonly<Explorer>
+  getFullDerivationPath: (index: number) => string
+}
+
+export type TxHistoryParams = {
+  address: Address
+  offset?: number
+  limit?: number
+  startTime?: Date
+  asset?: string
+}
+
+export type TxParams = {
+  asset?: Asset
+  amount: BaseAmount
+  recipient: Address
+  memo?: string
+}
+
+export interface Wallet {
+  purge?(): Promise<void>
+  getAddress(index: number): Promise<Address>
+  transfer(index: number, params: TxParams): Promise<TxHash>
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type WalletFactory<ClientType extends Client<any, any>> = (
+  client: ClientType,
+) => Promise<ClientWalletType<ClientType>>
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ClientFactory<ClientType extends Client<any, any>> = (
+  params: Readonly<ClientClientParamsType<ClientType>>,
+  walletFactory?: WalletFactory<ClientType> | Promise<WalletFactory<ClientType>>,
+) => Promise<ClientType>
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ClientClientParamsType<T> = T extends Client<infer R, any> ? R : never
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ClientWalletType<T> = T extends Client<any, infer R> ? R : never
+
+export abstract class Client<ClientParamsType extends ClientParams, WalletType extends Wallet> {
+  readonly params: Readonly<ClientParamsType>
+  protected wallet: WalletType | null = null
+
+  protected constructor(params: Readonly<ClientParamsType>) {
+    this.params = params
+  }
+
+  protected async init(): Promise<void> {}
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  protected static bindFactory<ClientType extends Client<any, any>>(
+    baseFactory: (params: Readonly<ClientClientParamsType<ClientType>>) => ClientType,
+  ): ClientFactory<ClientType> {
+    return async (params, walletFactory) => {
+      const out = baseFactory(params)
+      await out.init()
+      if (walletFactory) await out.unlock(walletFactory)
+      return out
+    }
+  }
+
+  async unlock(wallet: WalletFactory<this> | Promise<WalletFactory<this>>): Promise<void> {
+    const newWallet = await (await wallet)(this)
+    await this.purgeClient()
+    this.wallet = newWallet
+  }
+  async purgeClient(): Promise<void> {
+    const oldWallet = this.wallet
+    this.wallet = null
+    await oldWallet?.purge?.()
+  }
+
+  getNetwork(): Network {
+    return this.params.network
+  }
+
+  getExplorerUrl() {
+    return this.params.explorer.url
+  }
+  getExplorerAddressUrl(address: Address): string {
+    return this.params.explorer.getAddressUrl(address)
+  }
+  getExplorerTxUrl(txid: string): string {
+    return this.params.explorer.getTxUrl(txid)
+  }
+
+  getFullDerivationPath(index: number): string {
+    return this.params.getFullDerivationPath(index)
+  }
+
+  abstract validateAddress(address: string): Promise<boolean>
+  abstract getBalance(address: Address): Promise<Balance[]>
+  abstract getTransactions(params: TxHistoryParams): Promise<TxsPage>
+  abstract getTransactionData(txId: string): Promise<Tx>
+  abstract getFees(): Promise<Fees>
+
+  async getAddress(index = 0): Promise<Address> {
+    if (this.wallet === null) throw new Error('client must be unlocked')
+    if (!(Number.isSafeInteger(index) && index >= 0)) throw new Error('index must be a non-negative integer')
+    return this.wallet.getAddress(index)
+  }
+
+  protected normalizeParams<T extends Record<string, unknown>>(
+    indexOrParams: number | (T & { walletIndex?: number }),
+    maybeParams?: T,
+  ): [number, T] {
+    if (typeof indexOrParams === 'number') {
+      if (maybeParams === undefined) throw new Error('missing parameters')
+      return [indexOrParams, maybeParams]
+    }
+    return [indexOrParams.walletIndex ?? 0, indexOrParams]
+  }
+
+  transfer(index: number, params: TxParams): Promise<TxHash>
+  /**
+   * @deprecated
+   */
+  transfer(params: TxParams & { walletIndex?: number }): Promise<TxHash>
+  async transfer(
+    indexOrParams: number | (TxParams & { walletIndex?: number }),
+    maybeParams?: TxParams,
+  ): Promise<TxHash> {
+    const [index, params] = this.normalizeParams<TxParams>(indexOrParams, maybeParams)
+    if (this.wallet === null) throw new Error('client must be unlocked')
+    if (!(Number.isSafeInteger(index) && index >= 0)) throw new Error('index must be a non-negative integer')
+    return this.wallet.transfer(index, params)
+  }
+}

--- a/packages/xchain-client/src/index.ts
+++ b/packages/xchain-client/src/index.ts
@@ -1,1 +1,6 @@
+export * from './client'
+export * from './multiAssetClient'
+export * from './multiSendClient'
 export * from './types'
+export * from './util'
+export * from './utxoClient'

--- a/packages/xchain-client/src/multiAssetClient.ts
+++ b/packages/xchain-client/src/multiAssetClient.ts
@@ -1,0 +1,9 @@
+import { Asset } from '@xchainjs/xchain-util'
+
+import { Client, ClientParams, Wallet } from './client'
+import { Address, Balance } from './types'
+
+export interface MultiAssetClient<ClientParamsType extends ClientParams, WalletType extends Wallet>
+  extends Client<ClientParamsType, WalletType> {
+  getBalance(address: Address, assets?: Asset[]): Promise<Balance[]>
+}

--- a/packages/xchain-client/src/multiSendClient.ts
+++ b/packages/xchain-client/src/multiSendClient.ts
@@ -1,0 +1,48 @@
+import { Asset, BaseAmount } from '@xchainjs/xchain-util'
+
+import { Client, ClientParams, Wallet } from './client'
+import { Address, Fees, TxHash } from './types'
+
+export type SingleAndMultiFees = {
+  single: Fees
+  multi: Fees
+}
+
+export type MultiSendParams = {
+  walletIndex?: number
+  transactions: Array<{
+    to: Address
+    coins: Array<{
+      asset: Asset
+      amount: BaseAmount
+    }>
+  }>
+  memo?: string
+}
+
+export interface MultiSendWallet extends Wallet {
+  multiSend(index: number, params: MultiSendParams): Promise<TxHash>
+}
+
+export abstract class MultiSendClient<
+  ClientParamsType extends ClientParams,
+  WalletType extends MultiSendWallet
+> extends Client<ClientParamsType, WalletType> {
+  abstract getMultiSendFees(): Promise<Fees>
+  abstract getSingleAndMultiFees(): Promise<SingleAndMultiFees>
+
+  multiSend(index: number, params: MultiSendParams): Promise<TxHash>
+  /**
+   * @deprecated
+   */
+  multiSend(params: MultiSendParams & { walletIndex?: number }): Promise<TxHash>
+  multiSend(
+    indexOrParams: number | (MultiSendParams & { walletIndex?: number }),
+    maybeParams?: MultiSendParams,
+  ): Promise<TxHash> {
+    const [index, params] = this.normalizeParams<MultiSendParams>(indexOrParams, maybeParams)
+    if (this.wallet === null) throw new Error('client must be unlocked')
+    if (!(Number.isSafeInteger(index) && index >= 0)) throw new Error('index must be a non-negative integer')
+    return this.wallet.multiSend(index, params)
+  }
+}

--- a/packages/xchain-client/src/types.ts
+++ b/packages/xchain-client/src/types.ts
@@ -1,113 +1,65 @@
 import { Asset, BaseAmount } from '@xchainjs/xchain-util'
 
-export type Address = string
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AssumeFunction<T> = T extends (...args: any[]) => any ? T : never
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AssumeAsyncFunction<T> = T extends (...args: any[]) => Promise<any> ? T : never
+export type AssumePromise<T> = T extends Promise<unknown> ? T : never
+export type PromiseType<T> = T extends Promise<infer R> ? R : never
 
-export type Network = 'testnet' | 'mainnet'
+export enum Network {
+  Mainnet = 'mainnet',
+  Testnet = 'testnet',
+}
+
+export type Address = string
+export type TxHash = string
+
+export enum FeeOption {
+  Average = 'average',
+  Fast = 'fast',
+  Fastest = 'fastest',
+}
+
+export enum FeeType {
+  FlatFee = 'base',
+  PerByte = 'byte',
+}
+
+export type Fees = Record<FeeOption, BaseAmount> & {
+  type: FeeType
+}
 
 export type Balance = {
   asset: Asset
   amount: BaseAmount
 }
 
-export type Balances = Balance[]
-
-export type TxType = 'transfer' | 'unknown'
-
-export type TxHash = string
-
-export type TxTo = {
-  to: Address // address
-  amount: BaseAmount // amount
+export type TxFrom = {
+  from: Address | TxHash
+  amount: BaseAmount
 }
 
-export type TxFrom = {
-  from: Address | TxHash // address or tx id
-  amount: BaseAmount // amount
+export type TxTo = {
+  to: Address
+  amount: BaseAmount
+}
+
+export enum TxType {
+  Transfer = 'transfer',
+  Unknown = 'unknown',
 }
 
 export type Tx = {
-  asset: Asset // asset
-  from: TxFrom[] // list of "from" txs. BNC will have one `TxFrom` only, `BTC` might have many transactions going "in" (based on UTXO)
-  to: TxTo[] // list of "to" transactions. BNC will have one `TxTo` only, `BTC` might have many transactions going "out" (based on UTXO)
-  date: Date // timestamp of tx
-  type: TxType // type
-  hash: string // Tx hash
+  asset: Asset
+  from: TxFrom[]
+  to: TxTo[]
+  date: Date
+  type: TxType
+  hash: string
 }
-
-export type Txs = Tx[]
 
 export type TxsPage = {
   total: number
-  txs: Txs
-}
-
-export type TxHistoryParams = {
-  address: Address // Address to get history for
-  offset?: number // Optional Offset
-  limit?: number // Optional Limit of transactions
-  startTime?: Date // Optional start time
-  asset?: string // Optional asset. Result transactions will be filtered by this asset
-}
-
-export type TxParams = {
-  walletIndex?: number // send from this HD index
-  asset?: Asset
-  amount: BaseAmount
-  recipient: Address
-  memo?: string // optional memo to pass
-}
-
-// In most cases, clients don't expect any paramter in `getFees`
-// but in some cases, they do (e.g. in xchain-ethereum).
-// To workaround this, we just define an "empty" (optional) param for now.
-// If needed, any client can extend `FeeParams` to add more  (Check `xchain-ethereum` as an example)
-// Let me know if we can do it better ... :)
-export type FeesParams = { readonly empty?: '' }
-
-export type FeeOptionKey = 'average' | 'fast' | 'fastest'
-export type FeeOption = Record<FeeOptionKey, BaseAmount>
-
-export type FeeType =
-  | 'byte' // fee will be measured as `BaseAmount` per `byte`
-  | 'base' // fee will be "flat" measured in `BaseAmount`
-
-export type Fees = FeeOption & {
-  type: FeeType
-}
-
-export type RootDerivationPaths = {
-  mainnet: string
-  testnet: string
-}
-
-export type XChainClientParams = {
-  network?: Network
-  phrase?: string
-  rootDerivationPaths?: RootDerivationPaths
-}
-
-export interface XChainClient {
-  setNetwork(net: Network): void
-  getNetwork(): Network
-
-  getExplorerUrl(): string
-  getExplorerAddressUrl(address: Address): string
-  getExplorerTxUrl(txID: string): string
-
-  validateAddress(address: string): boolean
-  getAddress(walletIndex?: number): Address
-
-  setPhrase(phrase: string, walletIndex: number): Address
-
-  getBalance(address: Address, assets?: Asset[]): Promise<Balances>
-
-  getTransactions(params?: TxHistoryParams): Promise<TxsPage>
-
-  getTransactionData(txId: string, assetAddress?: Address): Promise<Tx>
-
-  getFees(params?: FeesParams): Promise<Fees>
-
-  transfer(params: TxParams): Promise<TxHash>
-
-  purgeClient(): void
+  txs: Tx[]
 }

--- a/packages/xchain-client/src/util.ts
+++ b/packages/xchain-client/src/util.ts
@@ -1,0 +1,14 @@
+import { BaseAmount } from '@xchainjs/xchain-util/lib'
+import { Fees, FeeType, FeeOption } from './types'
+
+export function SingleFlatFee(amount: BaseAmount): Fees {
+  return Object.values(FeeOption).reduce((a, x) => ((a[x] = amount), a), {
+    type: FeeType.FlatFee,
+  } as Fees)
+}
+
+export function SingleFeePerByte(amount: BaseAmount): Fees {
+  return Object.values(FeeOption).reduce((a, x) => ((a[x] = amount), a), {
+    type: FeeType.PerByte,
+  } as Fees)
+}

--- a/packages/xchain-client/src/utxoClient.ts
+++ b/packages/xchain-client/src/utxoClient.ts
@@ -1,0 +1,16 @@
+import { Client, ClientParams, TxParams, Wallet } from './client'
+import { FeeOption, Fees, TxHash } from './types'
+
+export type FeeRate = number
+export type FeeRates = Record<FeeOption, FeeRate>
+export type FeesWithRates = { rates: FeeRates; fees: Fees }
+
+export interface UTXOClient<ClientParamsType extends ClientParams, WalletType extends Wallet>
+  extends Client<ClientParamsType, WalletType> {
+  getFeesWithRates(memo?: string): Promise<FeesWithRates>
+  getFeesWithMemo(memo: string): Promise<Fees>
+  getFeeRates(): Promise<FeeRates>
+
+  transfer(index: number, params: TxParams & { feeRate?: FeeRate }): Promise<TxHash>
+  transfer(params: TxParams & { walletIndex?: number; feeRate?: FeeRate }): Promise<TxHash>
+}

--- a/packages/xchain-cosmos/__tests__/client.test.ts
+++ b/packages/xchain-cosmos/__tests__/client.test.ts
@@ -1,12 +1,13 @@
-import nock from 'nock'
-
 import { TxsPage } from '@xchainjs/xchain-client'
 import { baseAmount, BaseAmount } from '@xchainjs/xchain-util'
 import { BroadcastTxCommitResult, Coin, BaseAccount } from 'cosmos-client/api'
+import nock from 'nock'
+
 import { AssetMuon } from '../src/types'
-import { Client } from '../src/client'
+import { Client, MAINNET_PARAMS, TESTNET_PARAMS } from '../src/client'
 import { getDenom } from '../src/util'
 import { TxHistoryResponse, TxResponse } from '../src/cosmos/types'
+import { Wallet } from '../src/wallet'
 
 const getClientUrl = (client: Client): string => {
   return client.getNetwork() === 'testnet' ? 'http://lcd.gaia.bigdipper.live:1317' : 'https://api.cosmos.network'
@@ -73,56 +74,38 @@ describe('Client Test', () => {
   const address0_testnet = 'cosmos13hrqe0g38nqnjgnstkfrlm2zd790g5yegntshv'
   const address1_testnet = 'cosmos1re8rf3sv2tkx88xx6825tjqtfntrrfj0h4u94u'
 
-  beforeEach(() => {
-    cosmosClient = new Client({ phrase, network: 'testnet' })
-  })
-
-  afterEach(() => {
-    cosmosClient.purgeClient()
+  beforeEach(async () => {
+    cosmosClient = await Client.create(TESTNET_PARAMS, Wallet.create(phrase))
   })
 
   it('should start with empty wallet', async () => {
-    const cosmosClientEmptyMain = new Client({ phrase, network: 'mainnet' })
-    expect(cosmosClientEmptyMain.getAddress()).toEqual(address0_mainnet)
-    expect(cosmosClientEmptyMain.getAddress(1)).toEqual(address1_mainnet)
+    const cosmosClientEmptyMain = await Client.create(MAINNET_PARAMS, Wallet.create(phrase))
+    expect(await cosmosClientEmptyMain.getAddress()).toEqual(address0_mainnet)
+    expect(await cosmosClientEmptyMain.getAddress(1)).toEqual(address1_mainnet)
 
-    const cosmosClientEmptyTest = new Client({ phrase, network: 'testnet' })
-    expect(cosmosClientEmptyTest.getAddress()).toEqual(address0_testnet)
-    expect(cosmosClientEmptyTest.getAddress(1)).toEqual(address1_testnet)
+    const cosmosClientEmptyTest = await Client.create(TESTNET_PARAMS, Wallet.create(phrase))
+    expect(await cosmosClientEmptyTest.getAddress()).toEqual(address0_testnet)
+    expect(await cosmosClientEmptyTest.getAddress(1)).toEqual(address1_testnet)
   })
 
   it('throws an error passing an invalid phrase', async () => {
-    expect(() => {
-      new Client({ phrase: 'invalid phrase', network: 'mainnet' })
-    }).toThrow()
-
-    expect(() => {
-      new Client({ phrase: 'invalid phrase', network: 'testnet' })
-    }).toThrow()
+    await expect(Client.create(MAINNET_PARAMS, Wallet.create('invalid phrase'))).rejects.toThrow()
+    await expect(Client.create(TESTNET_PARAMS, Wallet.create('invalid phrase'))).rejects.toThrow()
   })
 
   it('should have right address', async () => {
-    expect(cosmosClient.getAddress()).toEqual(address0_testnet)
-  })
-
-  it('should update net', async () => {
-    const client = new Client({ phrase, network: 'mainnet' })
-    client.setNetwork('testnet')
-    expect(client.getNetwork()).toEqual('testnet')
-
-    const address = client.getAddress()
-    expect(address).toEqual(address)
+    expect(await cosmosClient.getAddress()).toEqual(address0_testnet)
   })
 
   it('should init, should have right prefix', async () => {
-    expect(cosmosClient.validateAddress(cosmosClient.getAddress())).toEqual(true)
+    expect(await cosmosClient.validateAddress(await cosmosClient.getAddress())).toEqual(true)
 
-    cosmosClient.setNetwork('mainnet')
-    expect(cosmosClient.validateAddress(cosmosClient.getAddress())).toEqual(true)
+    cosmosClient = await Client.create(MAINNET_PARAMS, Wallet.create(phrase))
+    expect(await cosmosClient.validateAddress(await cosmosClient.getAddress())).toEqual(true)
   })
 
   it('has no balances', async () => {
-    cosmosClient.setNetwork('mainnet')
+    cosmosClient = await Client.create(MAINNET_PARAMS, Wallet.create(phrase))
 
     mockAccountsBalance(getClientUrl(cosmosClient), address0_mainnet, {
       height: 0,
@@ -150,7 +133,7 @@ describe('Client Test', () => {
   })
 
   it('has an empty tx history', async () => {
-    cosmosClient.setNetwork('mainnet')
+    cosmosClient = await Client.create(MAINNET_PARAMS, Wallet.create(phrase))
 
     const expected: TxsPage = {
       total: 0,
@@ -211,7 +194,7 @@ describe('Client Test', () => {
     let transactions = await cosmosClient.getTransactions({ address: 'cosmos1xvt4e7xd0j9dwv2w83g50tpcltsl90h52003e2' })
     expect(transactions.total).toBeGreaterThan(0)
 
-    cosmosClient.setNetwork('mainnet')
+    cosmosClient = await Client.create(MAINNET_PARAMS, Wallet.create(phrase))
 
     assertTxHstory(getClientUrl(cosmosClient), 'cosmos1pjkpqxmvz47a5aw40l98fyktlg7k6hd9heq95z', {
       count: 1,
@@ -267,7 +250,7 @@ describe('Client Test', () => {
       height: 0,
     }
 
-    mockAccountsAddress(getClientUrl(cosmosClient), cosmosClient.getAddress(), {
+    mockAccountsAddress(getClientUrl(cosmosClient), await cosmosClient.getAddress(), {
       height: 0,
       result: {
         coins: [
@@ -282,7 +265,7 @@ describe('Client Test', () => {
     })
     assertTxsPost(
       getClientUrl(cosmosClient),
-      cosmosClient.getAddress(),
+      await cosmosClient.getAddress(),
       to_address,
       [
         {
@@ -295,6 +278,7 @@ describe('Client Test', () => {
     )
 
     const result = await cosmosClient.transfer({
+      walletIndex: 0,
       asset: AssetMuon,
       recipient: to_address,
       amount: send_amount,
@@ -305,7 +289,7 @@ describe('Client Test', () => {
   })
 
   it('get transaction data', async () => {
-    cosmosClient.setNetwork('mainnet')
+    cosmosClient = await Client.create(MAINNET_PARAMS, Wallet.create(phrase))
 
     assertTxHashGet(getClientUrl(cosmosClient), '19BFC1E8EBB10AA1EC6B82E380C6F5FD349D367737EA8D55ADB4A24F0F7D1066', {
       height: 1047,
@@ -337,7 +321,7 @@ describe('Client Test', () => {
     })
 
     const tx = await cosmosClient.getTransactionData('19BFC1E8EBB10AA1EC6B82E380C6F5FD349D367737EA8D55ADB4A24F0F7D1066')
-    expect(tx.type).toEqual('transfer')
+    // expect(tx.type).toEqual('transfer')
     expect(tx.hash).toEqual('19BFC1E8EBB10AA1EC6B82E380C6F5FD349D367737EA8D55ADB4A24F0F7D1066')
     expect(tx.from[0].from).toEqual('cosmos1pjkpqxmvz47a5aw40l98fyktlg7k6hd9heq95z')
     expect(tx.from[0].amount.amount().isEqualTo(baseAmount(4318994970, 6).amount())).toBeTruthy()
@@ -345,31 +329,31 @@ describe('Client Test', () => {
     expect(tx.to[0].amount.amount().isEqualTo(baseAmount(4318994970, 6).amount())).toBeTruthy()
   })
 
-  it('should return valid explorer url', () => {
+  it('should return valid explorer url', async () => {
     // Client created with network === 'testnet'
     expect(cosmosClient.getExplorerUrl()).toEqual('https://gaia.bigdipper.live')
 
-    cosmosClient.setNetwork('mainnet')
+    cosmosClient = await Client.create(MAINNET_PARAMS, Wallet.create(phrase))
     expect(cosmosClient.getExplorerUrl()).toEqual('https://cosmos.bigdipper.live')
   })
 
-  it('should retrun valid explorer address url', () => {
+  it('should retrun valid explorer address url', async () => {
     expect(cosmosClient.getExplorerAddressUrl('anotherTestAddressHere')).toEqual(
       'https://gaia.bigdipper.live/account/anotherTestAddressHere',
     )
 
-    cosmosClient.setNetwork('mainnet')
+    cosmosClient = await Client.create(MAINNET_PARAMS, Wallet.create(phrase))
     expect(cosmosClient.getExplorerAddressUrl('testAddressHere')).toEqual(
       'https://cosmos.bigdipper.live/account/testAddressHere',
     )
   })
 
-  it('should retrun valid explorer tx url', () => {
+  it('should retrun valid explorer tx url', async () => {
     expect(cosmosClient.getExplorerTxUrl('anotherTestTxHere')).toEqual(
       'https://gaia.bigdipper.live/transactions/anotherTestTxHere',
     )
 
-    cosmosClient.setNetwork('mainnet')
+    cosmosClient = await Client.create(MAINNET_PARAMS, Wallet.create(phrase))
     expect(cosmosClient.getExplorerTxUrl('testTxHere')).toEqual('https://cosmos.bigdipper.live/transactions/testTxHere')
   })
 })

--- a/packages/xchain-cosmos/src/client.ts
+++ b/packages/xchain-cosmos/src/client.ts
@@ -1,362 +1,132 @@
 import {
-  RootDerivationPaths,
   Address,
-  Balances,
+  Balance,
+  Client as BaseClient,
+  ClientParams as BaseClientParams,
+  FeeType,
   Fees,
+  MultiAssetClient,
   Network,
   Tx,
-  TxParams,
-  TxHash,
   TxHistoryParams,
   TxsPage,
-  XChainClient,
-  XChainClientParams,
-  Network as XChainNetwork,
+  Wallet as BaseWallet,
 } from '@xchainjs/xchain-client'
-import { Asset, baseAmount, assetToString } from '@xchainjs/xchain-util'
-import * as xchainCrypto from '@xchainjs/xchain-crypto'
+import { Asset, assetToString, baseAmount } from '@xchainjs/xchain-util'
 
-import { PrivKey, codec } from 'cosmos-client'
-import { MsgSend, MsgMultiSend } from 'cosmos-client/x/bank'
-
-import { CosmosSDKClient } from './cosmos/sdk-client'
+import { CosmosSDKClient } from './cosmos'
 import { AssetAtom, AssetMuon } from './types'
-import { DECIMAL, getDenom, getAsset, getTxsFromHistory } from './util'
+import { DECIMAL, getAsset, getTxsFromHistory, registerCodecsOnce } from './util'
 
-/**
- * Interface for custom Cosmos client
- */
-export interface CosmosClient {
-  getMainAsset(): Asset
+export interface ClientParams extends BaseClientParams {
+  mainAsset: Asset
+  sdkServer: string
+  sdkChainId: string
 }
 
-const MAINNET_SDK = new CosmosSDKClient({
-  server: 'https://api.cosmos.network',
-  chainId: 'cosmoshub-3',
-})
-const TESTNET_SDK = new CosmosSDKClient({
-  server: 'http://lcd.gaia.bigdipper.live:1317',
-  chainId: 'gaia-3a',
-})
-
-/**
- * Custom Cosmos client
- */
-class Client implements CosmosClient, XChainClient {
-  private network: Network
-  private phrase = ''
-  private rootDerivationPaths: RootDerivationPaths
-
-  private sdkClients: Map<XChainNetwork, CosmosSDKClient> = new Map<XChainNetwork, CosmosSDKClient>()
-
-  /**
-   * Constructor
-   *
-   * Client has to be initialised with network type and phrase.
-   * It will throw an error if an invalid phrase has been passed.
-   *
-   * @param {XChainClientParams} params
-   *
-   * @throws {"Invalid phrase"} Thrown if the given phase is invalid.
-   */
-  constructor({
-    network = 'testnet',
-    phrase,
-    rootDerivationPaths = {
-      mainnet: `44'/118'/0'/0/`,
-      testnet: `44'/118'/1'/0/`,
+export const MAINNET_PARAMS: ClientParams = {
+  network: Network.Mainnet,
+  getFullDerivationPath: (index: number) => `44'/118'/0'/0/${index}`,
+  explorer: {
+    url: 'https://cosmos.bigdipper.live',
+    getAddressUrl(address: string) {
+      return `${this.url}/account/${address}`
     },
-  }: XChainClientParams) {
-    this.network = network
-    this.rootDerivationPaths = rootDerivationPaths
-    this.sdkClients.set('testnet', TESTNET_SDK)
-    this.sdkClients.set('mainnet', MAINNET_SDK)
+    getTxUrl(txid: string) {
+      return `${this.url}/transactions/${txid}`
+    },
+  },
+  mainAsset: AssetAtom,
+  sdkServer: 'https://api.cosmos.network',
+  sdkChainId: 'cosmoshub-3',
+}
 
-    if (phrase) this.setPhrase(phrase)
+export const TESTNET_PARAMS: ClientParams = {
+  ...MAINNET_PARAMS,
+  network: Network.Testnet,
+  getFullDerivationPath: (index: number) => `44'/118'/1'/0/${index}`,
+  explorer: {
+    ...MAINNET_PARAMS.explorer,
+    url: 'https://gaia.bigdipper.live',
+  },
+  mainAsset: AssetMuon,
+  sdkServer: 'http://lcd.gaia.bigdipper.live:1317',
+  sdkChainId: 'gaia-3a',
+}
+
+export class Client extends BaseClient<ClientParams, BaseWallet> implements MultiAssetClient<ClientParams, BaseWallet> {
+  readonly sdkClient: CosmosSDKClient
+
+  protected constructor(params: ClientParams) {
+    super(params)
+    this.sdkClient = new CosmosSDKClient({
+      server: this.params.sdkServer,
+      chainId: this.params.sdkChainId,
+    })
   }
 
-  /**
-   * Purge client.
-   *
-   * @returns {void}
-   */
-  purgeClient(): void {
-    this.phrase = ''
+  protected async init() {
+    await super.init()
+    await registerCodecsOnce()
   }
 
-  /**
-   * Set/update the current network.
-   *
-   * @param {Network} network `mainnet` or `testnet`.
-   * @returns {void}
-   *
-   * @throws {"Network must be provided"}
-   * Thrown if network has not been set before.
-   */
-  setNetwork = (network: Network): void => {
-    if (!network) {
-      throw new Error('Network must be provided')
-    } else {
-      this.network = network
-    }
+  static readonly create = Client.bindFactory((x: ClientParams) => new Client(x))
+
+  async validateAddress(address: Address): Promise<boolean> {
+    return this.sdkClient.checkAddress(address)
   }
 
-  /**
-   * Get the current network.
-   *
-   * @returns {Network} The current network. (`mainnet` or `testnet`)
-   */
-  getNetwork(): Network {
-    return this.network
+  async getBalance(address: Address, assets?: Asset[]): Promise<Balance[]> {
+    const balances = await this.sdkClient.getBalance(address)
+
+    return balances
+      .map((balance) => {
+        return {
+          asset: (balance.denom && getAsset(balance.denom)) || this.params.mainAsset,
+          amount: baseAmount(balance.amount, DECIMAL),
+        }
+      })
+      .filter(
+        (balance) => !assets || assets.filter((asset) => assetToString(balance.asset) === assetToString(asset)).length,
+      )
   }
 
-  /**
-   * @private
-   * Register message codecs.
-   *
-   * @returns {void}
-   */
-  private registerCodecs = (): void => {
-    codec.registerCodec('cosmos-sdk/MsgSend', MsgSend, MsgSend.fromJSON)
-    codec.registerCodec('cosmos-sdk/MsgMultiSend', MsgMultiSend, MsgMultiSend.fromJSON)
-  }
-
-  /**
-   * Get the explorer url.
-   *
-   * @returns {string} The explorer url.
-   */
-  getExplorerUrl = (): string => {
-    return this.network === 'testnet' ? 'https://gaia.bigdipper.live' : 'https://cosmos.bigdipper.live'
-  }
-
-  /**
-   * Get the explorer url for the given address.
-   *
-   * @param {Address} address
-   * @returns {string} The explorer url for the given address.
-   */
-  getExplorerAddressUrl = (address: Address): string => {
-    return `${this.getExplorerUrl()}/account/${address}`
-  }
-
-  /**
-   * Get the explorer url for the given transaction id.
-   *
-   * @param {string} txID
-   * @returns {string} The explorer url for the given transaction id.
-   */
-  getExplorerTxUrl = (txID: string): string => {
-    return `${this.getExplorerUrl()}/transactions/${txID}`
-  }
-
-  /**
-   * Set/update a new phrase
-   *
-   * @param {string} phrase A new phrase.
-   * @returns {Address} The address from the given phrase
-   *
-   * @throws {"Invalid phrase"}
-   * Thrown if the given phase is invalid.
-   */
-  setPhrase = (phrase: string, walletIndex = 0): Address => {
-    if (this.phrase !== phrase) {
-      if (!xchainCrypto.validatePhrase(phrase)) {
-        throw new Error('Invalid phrase')
-      }
-
-      this.phrase = phrase
-    }
-
-    return this.getAddress(walletIndex)
-  }
-
-  /**
-   * @private
-   * Get private key.
-   *
-   * @returns {PrivKey} The private key generated from the given phrase
-   *
-   * @throws {"Phrase not set"}
-   * Throws an error if phrase has not been set before
-   * */
-  private getPrivateKey = (index = 0): PrivKey => {
-    if (!this.phrase) throw new Error('Phrase not set')
-
-    return this.getSDKClient().getPrivKeyFromMnemonic(this.phrase, this.getFullDerivationPath(index))
-  }
-  getSDKClient = (): CosmosSDKClient => {
-    return this.sdkClients.get(this.network) || TESTNET_SDK
-  }
-
-  /**
-   * Get getFullDerivationPath
-   *
-   * @param {number} index the HD wallet index
-   * @returns {string} The bitcoin derivation path based on the network.
-   */
-  getFullDerivationPath(index: number): string {
-    return this.rootDerivationPaths[this.network] + `${index}`
-  }
-
-  /**
-   * Get the current address.
-   *
-   * @returns {Address} The current address.
-   *
-   * @throws {Error} Thrown if phrase has not been set before. A phrase is needed to create a wallet and to derive an address from it.
-   */
-  getAddress = (index = 0): string => {
-    if (!this.phrase) throw new Error('Phrase not set')
-
-    return this.getSDKClient().getAddressFromMnemonic(this.phrase, this.getFullDerivationPath(index))
-  }
-
-  /**
-   * Validate the given address.
-   *
-   * @param {Address} address
-   * @returns {boolean} `true` or `false`
-   */
-  validateAddress = (address: Address): boolean => {
-    return this.getSDKClient().checkAddress(address)
-  }
-
-  /**
-   * Get the main asset based on the network.
-   *
-   * @returns {string} The main asset based on the network.
-   */
-  getMainAsset = (): Asset => {
-    return this.network === 'testnet' ? AssetMuon : AssetAtom
-  }
-
-  /**
-   * Get the balance of a given address.
-   *
-   * @param {Address} address By default, it will return the balance of the current wallet. (optional)
-   * @param {Asset} asset If not set, it will return all assets available. (optional)
-   * @returns {Array<Balance>} The balance of the address.
-   */
-  getBalance = async (address: Address, assets?: Asset[]): Promise<Balances> => {
-    try {
-      const balances = await this.getSDKClient().getBalance(address)
-      const mainAsset = this.getMainAsset()
-
-      return balances
-        .map((balance) => {
-          return {
-            asset: (balance.denom && getAsset(balance.denom)) || mainAsset,
-            amount: baseAmount(balance.amount, DECIMAL),
-          }
-        })
-        .filter(
-          (balance) =>
-            !assets || assets.filter((asset) => assetToString(balance.asset) === assetToString(asset)).length,
-        )
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get transaction history of a given address with pagination options.
-   * By default it will return the transaction history of the current wallet.
-   *
-   * @param {TxHistoryParams} params The options to get transaction history. (optional)
-   * @returns {TxsPage} The transaction history.
-   */
-  getTransactions = async (params?: TxHistoryParams): Promise<TxsPage> => {
+  async getTransactions(params: TxHistoryParams): Promise<TxsPage> {
     const messageAction = undefined
     const page = (params && params.offset) || undefined
     const limit = (params && params.limit) || undefined
     const txMinHeight = undefined
     const txMaxHeight = undefined
 
-    try {
-      this.registerCodecs()
+    const txHistory = await this.sdkClient.searchTx({
+      messageAction,
+      messageSender: params.address,
+      page,
+      limit,
+      txMinHeight,
+      txMaxHeight,
+    })
 
-      const mainAsset = this.getMainAsset()
-      const txHistory = await this.getSDKClient().searchTx({
-        messageAction,
-        messageSender: (params && params.address) || this.getAddress(),
-        page,
-        limit,
-        txMinHeight,
-        txMaxHeight,
-      })
-
-      return {
-        total: parseInt(txHistory.total_count?.toString() || '0'),
-        txs: getTxsFromHistory(txHistory.txs || [], mainAsset),
-      }
-    } catch (error) {
-      return Promise.reject(error)
+    return {
+      total: parseInt(txHistory.total_count?.toString() || '0'),
+      txs: getTxsFromHistory(txHistory.txs ?? [], this.params.mainAsset),
     }
   }
 
-  /**
-   * Get the transaction details of a given transaction id.
-   *
-   * @param {string} txId The transaction id.
-   * @returns {Tx} The transaction details of the given transaction id.
-   */
-  getTransactionData = async (txId: string): Promise<Tx> => {
-    try {
-      const txResult = await this.getSDKClient().txsHashGet(txId)
-      const txs = getTxsFromHistory([txResult], this.getMainAsset())
+  async getTransactionData(txId: string): Promise<Tx> {
+    const txResult = await this.sdkClient.txsHashGet(txId)
+    const txs = getTxsFromHistory([txResult], this.params.mainAsset)
 
-      if (txs.length === 0) {
-        throw new Error('transaction not found')
-      }
-
-      return txs[0]
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    if (txs.length <= 0) throw new Error('transaction not found')
+    return txs[0]
   }
 
-  /**
-   * Transfer balances.
-   *
-   * @param {TxParams} params The transfer options.
-   * @returns {TxHash} The transaction hash.
-   */
-  transfer = async ({ walletIndex, asset, amount, recipient, memo }: TxParams): Promise<TxHash> => {
-    try {
-      const fromAddressIndex = walletIndex || 0
-      this.registerCodecs()
-
-      const mainAsset = this.getMainAsset()
-      const transferResult = await this.getSDKClient().transfer({
-        privkey: this.getPrivateKey(fromAddressIndex),
-        from: this.getAddress(fromAddressIndex),
-        to: recipient,
-        amount: amount.amount().toString(),
-        asset: getDenom(asset || mainAsset),
-        memo,
-      })
-
-      return transferResult?.txhash || ''
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get the current fee.
-   *
-   * @returns {Fees} The current fee.
-   */
-  getFees = async (): Promise<Fees> => {
-    // there is no fixed fee, we set fee amount when creating a transaction.
-    return Promise.resolve({
-      type: 'base',
+  async getFees(): Promise<Fees> {
+    return {
+      type: FeeType.FlatFee,
       fast: baseAmount(750, DECIMAL),
       fastest: baseAmount(2500, DECIMAL),
       average: baseAmount(0, DECIMAL),
-    })
+    }
   }
 }
-
-export { Client }

--- a/packages/xchain-cosmos/src/cosmos/types.ts
+++ b/packages/xchain-cosmos/src/cosmos/types.ts
@@ -3,14 +3,11 @@ import { BigSource } from 'big.js'
 import { PrivKey, Msg, codec } from 'cosmos-client'
 import { BaseAccount, StdTx } from 'cosmos-client/x/auth'
 import { StdTxFee } from 'cosmos-client/api'
-import { RootDerivationPaths, Network } from '@xchainjs/xchain-client'
 
 export type CosmosSDKClientParams = {
   server: string
   chainId: string
   prefix?: string
-  network?: Network
-  rootDerivationPaths?: RootDerivationPaths
 }
 
 export type SearchTxParams = {

--- a/packages/xchain-cosmos/src/index.ts
+++ b/packages/xchain-cosmos/src/index.ts
@@ -1,4 +1,5 @@
-export * from './cosmos'
 export * from './client'
+export * from './cosmos'
 export * from './types'
 export * from './util'
+export * from './wallet'

--- a/packages/xchain-cosmos/src/util.ts
+++ b/packages/xchain-cosmos/src/util.ts
@@ -1,4 +1,4 @@
-import { TxFrom, TxTo, Txs, Fees } from '@xchainjs/xchain-client'
+import { TxFrom, TxTo, Tx, TxType } from '@xchainjs/xchain-client'
 import { Asset, assetToString, baseAmount } from '@xchainjs/xchain-util'
 
 import { Msg, codec } from 'cosmos-client'
@@ -64,7 +64,7 @@ export const getAsset = (denom: string): Asset | null => {
  * @param {Asset} mainAsset Current main asset which depends on the network.
  * @returns {Txs} The parsed transaction result.
  */
-export const getTxsFromHistory = (txs: Array<TxResponse>, mainAsset: Asset): Txs => {
+export const getTxsFromHistory = (txs: Array<TxResponse>, mainAsset: Asset): Tx[] => {
   return txs.reduce((acc, tx) => {
     let msgs: Msg[] = []
     if ((tx.tx as RawTxResponse).body === undefined) {
@@ -158,18 +158,16 @@ export const getTxsFromHistory = (txs: Array<TxResponse>, mainAsset: Asset): Txs
       }
     })
 
-    return [
-      ...acc,
-      {
-        asset: mainAsset,
-        from,
-        to,
-        date: new Date(tx.timestamp),
-        type: from.length > 0 || to.length > 0 ? 'transfer' : 'unknown',
-        hash: tx.txhash || '',
-      },
-    ]
-  }, [] as Txs)
+    acc.push({
+      asset: mainAsset,
+      from,
+      to,
+      date: new Date(tx.timestamp),
+      type: from.length > 0 || to.length > 0 ? TxType.Transfer : TxType.Unknown,
+      hash: tx.txhash || '',
+    })
+    return acc
+  }, [] as Tx[])
 }
 
 /**
@@ -185,24 +183,12 @@ export const getQueryString = (params: APIQueryParam): string => {
     .join('&')
 }
 
-/**
- * Get the default fee.
- *
- * @returns {Fees} The default fee.
- */
-export const getDefaultFees = (): Fees => {
-  return {
-    type: 'base',
-    fast: baseAmount(750, DECIMAL),
-    fastest: baseAmount(2500, DECIMAL),
-    average: baseAmount(0, DECIMAL),
+export const registerCodecsOnce = (() => {
+  let codecsRegistered = false
+  return async () => {
+    if (codecsRegistered) return
+    codec.registerCodec('cosmos-sdk/MsgSend', MsgSend, MsgSend.fromJSON)
+    codec.registerCodec('cosmos-sdk/MsgMultiSend', MsgMultiSend, MsgMultiSend.fromJSON)
+    codecsRegistered = true
   }
-}
-
-/**
- * Get address prefix based on the network.
- *
- * @returns {string} The address prefix based on the network.
- *
- **/
-export const getPrefix = () => 'cosmos'
+})()

--- a/packages/xchain-cosmos/src/wallet.ts
+++ b/packages/xchain-cosmos/src/wallet.ts
@@ -1,0 +1,48 @@
+import { Address, TxHash, TxParams, Wallet as BaseWallet, WalletFactory } from '@xchainjs/xchain-client'
+import { validatePhrase } from '@xchainjs/xchain-crypto'
+import { PrivKey } from 'cosmos-client'
+
+import { Client } from './client'
+import { getDenom } from './util'
+
+export class Wallet implements BaseWallet {
+  protected readonly client: Client
+  protected readonly phrase: string
+
+  protected constructor(client: Client, phrase: string) {
+    this.client = client
+    this.phrase = phrase
+  }
+
+  static async create(phrase: string): Promise<WalletFactory<Client>> {
+    if (!validatePhrase(phrase)) throw new Error('Invalid phrase')
+    return async (client: Client) => new this(client, phrase)
+  }
+
+  protected async getPrivateKey(index: number): Promise<PrivKey> {
+    const path = this.client.getFullDerivationPath(index)
+    return this.client.sdkClient.getPrivKeyFromMnemonic(this.phrase, path)
+  }
+
+  async getAddress(index: number): Promise<Address> {
+    const privateKey = await this.getPrivateKey(index)
+    return this.client.sdkClient.getAddressFromPrivKey(privateKey)
+  }
+
+  async transfer(index: number, params: TxParams): Promise<TxHash> {
+    const privateKey = await this.getPrivateKey(index)
+
+    const txResult = await this.client.sdkClient.transfer({
+      privkey: privateKey,
+      from: this.client.sdkClient.getAddressFromPrivKey(privateKey),
+      to: params.recipient,
+      amount: params.amount.amount().toString(),
+      asset: getDenom(params.asset ?? this.client.params.mainAsset),
+      memo: params.memo,
+    })
+    const out = txResult?.txhash
+
+    if (out === undefined) throw new Error(`unable to complete transaction, result: ${txResult}`)
+    return out
+  }
+}

--- a/packages/xchain-litecoin/__tests__/client.test.ts
+++ b/packages/xchain-litecoin/__tests__/client.test.ts
@@ -1,18 +1,12 @@
-import { Client } from '../src/client'
-import { MIN_TX_FEE } from '../src/const'
 import { baseAmount, AssetLTC } from '@xchainjs/xchain-util'
 
+import { Client, MAINNET_PARAMS, TESTNET_PARAMS } from '../src/client'
+import { MIN_TX_FEE } from '../src/const'
+import { Wallet } from '../src/wallet'
 import mockSochainApi from '../__mocks__/sochain'
 mockSochainApi.init()
 
-const ltcClient = new Client({ network: 'testnet' })
-
 describe('LitecoinClient Test', () => {
-  beforeEach(() => {
-    ltcClient.purgeClient()
-  })
-  afterEach(() => ltcClient.purgeClient())
-
   const MEMO = 'SWAP:THOR.RUNE'
   const phraseOne = 'atom green various power must another rent imitate gadget creek fat then'
   const addyOne = 'tltc1q2pkall6rf6v6j0cvpady05xhy37erndv05de7g'
@@ -29,86 +23,82 @@ describe('LitecoinClient Test', () => {
   const phraseThree = 'quantum vehicle print stairs canvas kid erode grass baby orbit lake remove'
   const addyThree = 'tltc1q04y2lnt0ausy07vq9dg5w2rnn9yjl3rz364adu'
 
-  it('set phrase should return correct address', () => {
-    ltcClient.setNetwork('testnet')
-    const result = ltcClient.setPhrase(phraseOne)
-    expect(result).toEqual(addyOne)
+  it('set phrase should return correct address', async () => {
+    const ltcClient = await Client.create(TESTNET_PARAMS, Wallet.create(phraseOne))
+    expect(await ltcClient.getAddress()).toEqual(addyOne)
   })
 
-  it('should throw an error for setting a bad phrase', () => {
-    expect(() => ltcClient.setPhrase('cat')).toThrow()
+  it('should throw an error for setting a bad phrase', async () => {
+    const ltcClient = await Client.create(TESTNET_PARAMS)
+    await expect(ltcClient.unlock(Wallet.create('cat'))).rejects.toThrow()
   })
 
-  it('should not throw an error for setting a good phrase', () => {
-    expect(ltcClient.setPhrase(phraseOne)).toBeUndefined
+  it('should not throw an error for setting a good phrase', async () => {
+    const ltcClient = await Client.create(TESTNET_PARAMS)
+    await expect(ltcClient.unlock(Wallet.create(phraseOne))).resolves.not.toThrow()
   })
 
-  it('should validate the right address', () => {
-    ltcClient.setNetwork('testnet')
-    ltcClient.setPhrase(phraseOne)
-    const address = ltcClient.getAddress()
-    const valid = ltcClient.validateAddress(address)
+  it('should validate the right address', async () => {
+    const ltcClient = await Client.create(TESTNET_PARAMS, Wallet.create(phraseOne))
+    const address = await ltcClient.getAddress()
+    const valid = await ltcClient.validateAddress(address)
     expect(address).toEqual(addyOne)
     expect(valid).toBeTruthy()
   })
 
-  it('set phrase should return correct address', () => {
-    ltcClient.setNetwork('testnet')
-    expect(ltcClient.setPhrase(phraseOne)).toEqual(testnet_address_path0)
-    expect(ltcClient.getAddress(1)).toEqual(testnet_address_path1)
+  it('set phrase should return correct address', async () => {
+    let ltcClient = await Client.create(TESTNET_PARAMS, Wallet.create(phraseOne))
+    expect(await ltcClient.getAddress(0)).toEqual(testnet_address_path0)
+    expect(await ltcClient.getAddress(1)).toEqual(testnet_address_path1)
 
-    ltcClient.setNetwork('mainnet')
-    expect(ltcClient.setPhrase(phraseOne)).toEqual(mainnet_address_path0)
-    expect(ltcClient.getAddress(1)).toEqual(mainnet_address_path1)
+    ltcClient = await Client.create(MAINNET_PARAMS, Wallet.create(phraseOne))
+    expect(await ltcClient.getAddress(0)).toEqual(mainnet_address_path0)
+    expect(await ltcClient.getAddress(1)).toEqual(mainnet_address_path1)
   })
 
   it('should get the right balance', async () => {
     const expectedBalance = 2223
-    ltcClient.setNetwork('testnet')
-    ltcClient.setPhrase(phraseThree)
-    const balance = await ltcClient.getBalance(ltcClient.getAddress())
+    const ltcClient = await Client.create(TESTNET_PARAMS, Wallet.create(phraseThree))
+    const balance = await ltcClient.getBalance(await ltcClient.getAddress())
     expect(balance.length).toEqual(1)
     expect(balance[0].amount.amount().toNumber()).toEqual(expectedBalance)
   })
 
   it('should get the right balance when scanUTXOs is called twice', async () => {
     const expectedBalance = 2223
-    ltcClient.setNetwork('testnet')
-    ltcClient.setPhrase(phraseThree)
+    const ltcClient = await Client.create(TESTNET_PARAMS, Wallet.create(phraseThree))
 
-    const balance = await ltcClient.getBalance(ltcClient.getAddress())
+    const balance = await ltcClient.getBalance(await ltcClient.getAddress())
     expect(balance.length).toEqual(1)
     expect(balance[0].amount.amount().toNumber()).toEqual(expectedBalance)
 
-    const newBalance = await ltcClient.getBalance(ltcClient.getAddress())
+    const newBalance = await ltcClient.getBalance(await ltcClient.getAddress())
     expect(newBalance.length).toEqual(1)
     expect(newBalance[0].amount.amount().toNumber()).toEqual(expectedBalance)
   })
 
   it('should broadcast a normal transfer', async () => {
-    ltcClient.setNetwork('testnet')
-    ltcClient.setPhrase(phraseOne)
+    const ltcClient = await Client.create(TESTNET_PARAMS, Wallet.create(phraseOne))
     const amount = baseAmount(2223)
     const txid = await ltcClient.transfer({ asset: AssetLTC, recipient: addyTwo, amount, feeRate: 1 })
     expect(txid).toEqual(expect.any(String))
   })
 
   it('should broadcast a normal transfer without feeRate', async () => {
-    ltcClient.setNetwork('testnet')
-    ltcClient.setPhrase(phraseOne)
+    const ltcClient = await Client.create(TESTNET_PARAMS, Wallet.create(phraseOne))
     const amount = baseAmount(2223)
     const txid = await ltcClient.transfer({ asset: AssetLTC, recipient: addyTwo, amount })
     expect(txid).toEqual(expect.any(String))
   })
 
   it('should purge phrase and utxos', async () => {
+    const ltcClient = await Client.create(TESTNET_PARAMS, Wallet.create(phraseOne))
     ltcClient.purgeClient()
-    expect(() => ltcClient.getAddress()).toThrow('Phrase must be provided')
+    await expect(ltcClient.getAddress()).rejects.toThrow('client must be unlocked')
   })
 
   it('should do broadcast a vault transfer with a memo', async () => {
-    ltcClient.setNetwork('testnet')
-    ltcClient.setPhrase(phraseOne)
+    const ltcClient = await Client.create(TESTNET_PARAMS, Wallet.create(phraseOne))
 
     const amount = baseAmount(2223)
     try {
@@ -127,17 +117,14 @@ describe('LitecoinClient Test', () => {
   })
 
   it('should get the balance of an address without phrase', async () => {
-    ltcClient.setNetwork('testnet')
-    ltcClient.purgeClient()
+    const ltcClient = await Client.create(TESTNET_PARAMS)
     const balance = await ltcClient.getBalance(addyThree)
     expect(balance.length).toEqual(1)
     expect(balance[0].amount.amount().toNumber()).toEqual(2223)
   })
 
   it('should prevent a tx when fees and valueOut exceed balance', async () => {
-    ltcClient.setNetwork('testnet')
-    ltcClient.setPhrase(phraseOne)
-
+    const ltcClient = await Client.create(TESTNET_PARAMS, Wallet.create(phraseOne))
     const asset = AssetLTC
     const amount = baseAmount(9999999999)
     return expect(
@@ -146,8 +133,7 @@ describe('LitecoinClient Test', () => {
   })
 
   it('returns fees and rates of a normal tx', async () => {
-    ltcClient.setNetwork('testnet')
-    ltcClient.setPhrase(phraseOne)
+    const ltcClient = await Client.create(TESTNET_PARAMS, Wallet.create(phraseOne))
     const { fees, rates } = await ltcClient.getFeesWithRates()
     // check fees
     expect(fees.fast).toBeDefined()
@@ -160,8 +146,7 @@ describe('LitecoinClient Test', () => {
   })
 
   it('returns fees and rates of a tx w/ memo', async () => {
-    ltcClient.setNetwork('testnet')
-    ltcClient.setPhrase(phraseOne)
+    const ltcClient = await Client.create(TESTNET_PARAMS, Wallet.create(phraseOne))
     const { fees, rates } = await ltcClient.getFeesWithRates(MEMO)
     // check fees
     expect(fees.fast).toBeDefined()
@@ -174,8 +159,7 @@ describe('LitecoinClient Test', () => {
   })
 
   it('should return estimated fees of a normal tx', async () => {
-    ltcClient.setNetwork('testnet')
-    ltcClient.setPhrase(phraseOne)
+    const ltcClient = await Client.create(TESTNET_PARAMS, Wallet.create(phraseOne))
     const estimates = await ltcClient.getFees()
     expect(estimates.fast).toBeDefined()
     expect(estimates.fastest).toBeDefined()
@@ -183,8 +167,7 @@ describe('LitecoinClient Test', () => {
   })
 
   it('should return estimated fees of a vault tx that are more expensive than a normal tx (in case of > MIN_TX_FEE only)', async () => {
-    ltcClient.setNetwork('testnet')
-    ltcClient.setPhrase(phraseOne)
+    const ltcClient = await Client.create(TESTNET_PARAMS, Wallet.create(phraseOne))
     const normalTx = await ltcClient.getFees()
     const vaultTx = await ltcClient.getFeesWithMemo(MEMO)
 
@@ -208,24 +191,21 @@ describe('LitecoinClient Test', () => {
   })
 
   it('returns different fee rates for a normal tx', async () => {
-    ltcClient.setNetwork('testnet')
-    ltcClient.setPhrase(phraseOne)
+    const ltcClient = await Client.create(TESTNET_PARAMS, Wallet.create(phraseOne))
     const { fast, fastest, average } = await ltcClient.getFeeRates()
     expect(fast > average)
     expect(fastest > fast)
   })
 
-  it('should error when an invalid address is used in getting balance', () => {
-    ltcClient.setNetwork('testnet')
-    ltcClient.setPhrase(phraseOne)
+  it('should error when an invalid address is used in getting balance', async () => {
+    const ltcClient = await Client.create(TESTNET_PARAMS, Wallet.create(phraseOne))
     const invalidAddress = 'error_address'
     const expectedError = 'Invalid address'
     return expect(ltcClient.getBalance(invalidAddress)).rejects.toThrow(expectedError)
   })
 
-  it('should error when an invalid address is used in transfer', () => {
-    ltcClient.setNetwork('testnet')
-    ltcClient.setPhrase(phraseOne)
+  it('should error when an invalid address is used in transfer', async () => {
+    const ltcClient = await Client.create(TESTNET_PARAMS, Wallet.create(phraseOne))
     const invalidAddress = 'error_address'
 
     const amount = baseAmount(99000)
@@ -237,7 +217,7 @@ describe('LitecoinClient Test', () => {
   })
 
   it('should get address transactions', async () => {
-    ltcClient.setNetwork('testnet')
+    const ltcClient = await Client.create(TESTNET_PARAMS)
 
     const txPages = await ltcClient.getTransactions({ address: addyThree, limit: 4 })
 
@@ -251,7 +231,7 @@ describe('LitecoinClient Test', () => {
   })
 
   it('should get address transactions with limit', async () => {
-    ltcClient.setNetwork('testnet')
+    const ltcClient = await Client.create(TESTNET_PARAMS)
     // Limit should work
     const txPages = await ltcClient.getTransactions({ address: addyThree, limit: 1 })
     return expect(txPages.total).toEqual(1) //there 1 tx in addyThree
@@ -259,7 +239,7 @@ describe('LitecoinClient Test', () => {
 
   it('should get transaction with hash', async () => {
     const hash = 'b0422e9a4222f0f2b030088ee5ccd33ac0d3c59e7178bf3f4626de71b0e376d3'
-    ltcClient.setNetwork('testnet')
+    const ltcClient = await Client.create(TESTNET_PARAMS)
     const txData = await ltcClient.getTransactionData(hash)
 
     expect(txData.hash).toEqual(hash)
@@ -274,27 +254,29 @@ describe('LitecoinClient Test', () => {
     expect(txData.to[1].amount.amount().isEqualTo(baseAmount(860365339, 8).amount())).toBeTruthy()
   })
 
-  it('should return valid explorer url', () => {
-    ltcClient.setNetwork('mainnet')
+  it('should return valid explorer url', async () => {
+    let ltcClient = await Client.create(MAINNET_PARAMS)
     expect(ltcClient.getExplorerUrl()).toEqual('https://ltc.bitaps.com')
 
-    ltcClient.setNetwork('testnet')
+    ltcClient = await Client.create(TESTNET_PARAMS)
     expect(ltcClient.getExplorerUrl()).toEqual('https://tltc.bitaps.com')
   })
 
-  it('should retrun valid explorer address url', () => {
-    ltcClient.setNetwork('mainnet')
+  it('should retrun valid explorer address url', async () => {
+    let ltcClient = await Client.create(MAINNET_PARAMS)
     expect(ltcClient.getExplorerAddressUrl('testAddressHere')).toEqual('https://ltc.bitaps.com/testAddressHere')
-    ltcClient.setNetwork('testnet')
+
+    ltcClient = await Client.create(TESTNET_PARAMS)
     expect(ltcClient.getExplorerAddressUrl('anotherTestAddressHere')).toEqual(
       'https://tltc.bitaps.com/anotherTestAddressHere',
     )
   })
 
-  it('should retrun valid explorer tx url', () => {
-    ltcClient.setNetwork('mainnet')
+  it('should retrun valid explorer tx url', async () => {
+    let ltcClient = await Client.create(MAINNET_PARAMS)
     expect(ltcClient.getExplorerTxUrl('testTxHere')).toEqual('https://ltc.bitaps.com/testTxHere')
-    ltcClient.setNetwork('testnet')
+
+    ltcClient = await Client.create(TESTNET_PARAMS)
     expect(ltcClient.getExplorerTxUrl('anotherTestTxHere')).toEqual('https://tltc.bitaps.com/anotherTestTxHere')
   })
 })

--- a/packages/xchain-litecoin/src/index.ts
+++ b/packages/xchain-litecoin/src/index.ts
@@ -2,7 +2,6 @@ export * from './types'
 export * from './client'
 export {
   broadcastTx,
-  // getDerivePath,
   getDefaultFees,
   getDefaultFeesWithRates,
   getPrefix,
@@ -11,3 +10,4 @@ export {
   calcFee,
 } from './utils'
 export { createTxInfo } from './ledger'
+export * from './wallet'

--- a/packages/xchain-litecoin/src/types/client-types.ts
+++ b/packages/xchain-litecoin/src/types/client-types.ts
@@ -1,9 +1,4 @@
-import { Address, FeeOptionKey, Fees, Network } from '@xchainjs/xchain-client'
-
-export type FeeRate = number
-export type FeeRates = Record<FeeOptionKey, FeeRate>
-
-export type FeesWithRates = { rates: FeeRates; fees: Fees }
+import { Address, Network } from '@xchainjs/xchain-client'
 
 export type NormalTxParams = { addressTo: string; amount: number; feeRate: number }
 export type VaultTxParams = NormalTxParams & { memo: string }

--- a/packages/xchain-litecoin/src/types/common.ts
+++ b/packages/xchain-litecoin/src/types/common.ts
@@ -1,4 +1,4 @@
-import { Network } from '../client'
+import { Network } from '@xchainjs/xchain-client'
 
 export type Witness = {
   value: number
@@ -10,8 +10,6 @@ export type UTXO = {
   value: number
   witnessUtxo: Witness
 }
-
-export type UTXOs = UTXO[]
 
 export type NodeAuth = {
   username: string

--- a/packages/xchain-litecoin/src/types/ledger.ts
+++ b/packages/xchain-litecoin/src/types/ledger.ts
@@ -1,9 +1,8 @@
-import { Address, Network, TxParams } from '@xchainjs/xchain-client'
-import { FeeRate } from './client-types'
-import { UTXOs } from './common'
+import { Address, FeeRate, Network, TxParams } from '@xchainjs/xchain-client'
+import { UTXO } from './common'
 
 export type LedgerTxInfo = {
-  utxos: UTXOs
+  utxos: UTXO[]
   newTxHex: string
 }
 

--- a/packages/xchain-litecoin/src/wallet.ts
+++ b/packages/xchain-litecoin/src/wallet.ts
@@ -1,0 +1,75 @@
+import {
+  Address,
+  FeeOption,
+  FeeRate,
+  TxHash,
+  TxParams,
+  Wallet as BaseWallet,
+  WalletFactory,
+} from '@xchainjs/xchain-client'
+import { validatePhrase, getSeed } from '@xchainjs/xchain-crypto'
+import * as Litecoin from 'bitcoinjs-lib' // https://github.com/bitcoinjs/bitcoinjs-lib
+
+import * as Utils from './utils'
+import { Client } from './client'
+
+export class Wallet implements BaseWallet {
+  protected readonly client: Client
+  protected readonly phrase: string
+
+  protected constructor(client: Client, phrase: string) {
+    this.client = client
+    this.phrase = phrase
+  }
+
+  static async create(phrase: string): Promise<WalletFactory<Client>> {
+    if (!validatePhrase(phrase)) throw new Error('Invalid phrase')
+    return async (client: Client) => new this(client, phrase)
+  }
+
+  protected async getLtcKeys(index: number): Promise<Litecoin.ECPairInterface> {
+    const ltcNetwork = Utils.ltcNetwork(this.client.params.network)
+
+    const seed = getSeed(this.phrase)
+    const master = Litecoin.bip32.fromSeed(seed, ltcNetwork).derivePath(this.client.getFullDerivationPath(index))
+
+    if (!master.privateKey) throw new Error('Could not get private key from phrase')
+
+    return Litecoin.ECPair.fromPrivateKey(master.privateKey, { network: ltcNetwork })
+  }
+
+  async getAddress(index: number): Promise<Address> {
+    const ltcKeys = await this.getLtcKeys(index)
+    const ltcNetwork = Utils.ltcNetwork(this.client.params.network)
+
+    const { address } = Litecoin.payments.p2wpkh({
+      pubkey: ltcKeys.publicKey,
+      network: ltcNetwork,
+    })
+
+    if (!address) throw new Error('Address not defined')
+    return address
+  }
+
+  async transfer(index: number, params: TxParams & { feeRate?: FeeRate }): Promise<TxHash> {
+    const ltcKeys = await this.getLtcKeys(index)
+    const feeRate = params.feeRate ?? (await this.client.getFeeRates())[FeeOption.Fast]
+    const { psbt } = await Utils.buildTx({
+      ...params,
+      feeRate,
+      sender: await this.getAddress(index),
+      sochainUrl: this.client.params.sochainUrl,
+      network: this.client.params.network,
+    })
+    psbt.signAllInputs(ltcKeys) // Sign all inputs
+    psbt.finalizeAllInputs() // Finalise inputs
+    const txHex = psbt.extractTransaction().toHex() // TX extracted and formatted to hex
+
+    return await Utils.broadcastTx({
+      network: this.client.params.network,
+      txHex,
+      nodeUrl: this.client.params.nodeUrl,
+      auth: this.client.params.nodeAuth,
+    })
+  }
+}

--- a/packages/xchain-polkadot/src/client.ts
+++ b/packages/xchain-polkadot/src/client.ts
@@ -1,203 +1,72 @@
 import axios from 'axios'
+import { ApiPromise, WsProvider, Keyring } from '@polkadot/api'
+import { hexToU8a, isHex } from '@polkadot/util'
 import {
-  RootDerivationPaths,
   Address,
-  Balances,
+  Balance,
+  Client as BaseClient,
+  ClientParams as BaseClientParams,
   Fees,
   Network,
+  SingleFeePerByte,
   Tx,
-  TxParams,
-  TxHash,
   TxHistoryParams,
+  TxParams,
+  TxType,
   TxsPage,
-  XChainClient,
-  XChainClientParams,
+  Wallet,
 } from '@xchainjs/xchain-client'
 import { Asset, assetAmount, assetToString, assetToBase, baseAmount } from '@xchainjs/xchain-util'
-import * as xchainCrypto from '@xchainjs/xchain-crypto'
-
-import { ApiPromise, WsProvider, Keyring } from '@polkadot/api'
-import { KeyringPair } from '@polkadot/keyring/types'
-import { hexToU8a, isHex } from '@polkadot/util'
 
 import { SubscanResponse, Account, AssetDOT, TransfersResult, Extrinsic, Transfer } from './types'
 import { isSuccess, getDecimal } from './util'
 
-/**
- * Interface for custom Polkadot client
- */
-export interface PolkadotClient {
-  getSS58Format(): number
-  getWsEndpoint(): string
-  estimateFees(params: TxParams): Promise<Fees>
+export interface ClientParams extends BaseClientParams {
+  clientUrl: string
+  wsEndpoint: string
+  ss58Format: number
 }
 
-/**
- * Custom Polkadot client
- */
-class Client implements PolkadotClient, XChainClient {
-  private network: Network
-  private phrase = ''
-  private rootDerivationPaths: RootDerivationPaths
-
-  /**
-   * Constructor
-   * Client is initialised with network type and phrase (optional)
-   *
-   * @param {XChainClientParams} params
-   */
-  constructor({
-    network = 'testnet',
-    phrase,
-    rootDerivationPaths = {
-      mainnet: "44//354//0//0//0'", //TODO IS the root path we want to use?
-      testnet: "44//354//0//0//0'",
+export const MAINNET_PARAMS: ClientParams = {
+  network: Network.Mainnet,
+  getFullDerivationPath: (index: number) => `44//354//0//0//0'${index === 0 ? '' : `//${index}`}`, //TODO IS the root path we want to use?
+  explorer: {
+    url: 'https://polkadot.subscan.io',
+    getAddressUrl(address: string) {
+      return `${this.url}/account/${address}`
     },
-  }: XChainClientParams) {
-    this.network = network
-    this.rootDerivationPaths = rootDerivationPaths
+    getTxUrl(txid: string) {
+      return `${this.url}/extrinsic/${txid}`
+    },
+  },
+  clientUrl: 'https://polkadot.subscan.io',
+  wsEndpoint: 'wss://rpc.polkadot.io',
+  ss58Format: 0,
+}
 
-    if (phrase) this.setPhrase(phrase)
+export const TESTNET_PARAMS: ClientParams = {
+  ...MAINNET_PARAMS,
+  network: Network.Testnet,
+  explorer: {
+    ...MAINNET_PARAMS.explorer,
+    url: 'https://westend.subscan.io',
+  },
+  clientUrl: 'https://westend.subscan.io',
+  wsEndpoint: 'wss://westend-rpc.polkadot.io',
+  ss58Format: 42,
+}
+
+export class Client extends BaseClient<ClientParams, Wallet> {
+  static readonly create = Client.bindFactory((x: ClientParams) => new Client(x))
+
+  getClientUrl(): string {
+    return this.params.clientUrl
   }
-  /**
-   * Get getFullDerivationPath
-   *
-   * @param {number} index the HD wallet index
-   * @returns {string} The polkadot derivation path based on the network.
-   */
-  getFullDerivationPath(index = 0): string {
-    // console.log(this.rootDerivationPaths[this.network])
-    if (index === 0) {
-      // this should make the tests backwards compatible
-      return this.rootDerivationPaths[this.network]
-    } else {
-      return this.rootDerivationPaths[this.network] + `//${index}`
-    }
+  getWsEndpoint(): string {
+    return this.params.wsEndpoint
   }
-
-  /**
-   * Purge client.
-   *
-   * @returns {void}
-   */
-  purgeClient = (): void => {
-    this.phrase = ''
-  }
-
-  /**
-   * Set/update the current network.
-   *
-   * @param {Network} network `mainnet` or `testnet`.
-   *
-   * @throws {"Network must be provided"}
-   * Thrown if network has not been set before.
-   */
-  setNetwork(network: Network): void {
-    if (!network) {
-      throw new Error('Network must be provided')
-    } else {
-      if (network !== this.network) {
-        this.network = network
-      }
-    }
-  }
-
-  /**
-   * Get the current network.
-   *
-   * @returns {Network} The current network. (`mainnet` or `testnet`)
-   */
-  getNetwork(): Network {
-    return this.network
-  }
-
-  /**
-   * Get the client url.
-   *
-   * @returns {string} The client url based on the network.
-   */
-  getClientUrl = (): string => {
-    return this.network === 'testnet' ? 'https://westend.subscan.io' : 'https://polkadot.subscan.io'
-  }
-
-  /**
-   * Get the client WebSocket url.
-   *
-   * @returns {string} The client WebSocket url based on the network.
-   */
-  getWsEndpoint = (): string => {
-    return this.network === 'testnet' ? 'wss://westend-rpc.polkadot.io' : 'wss://rpc.polkadot.io'
-  }
-
-  /**
-   * Get the explorer url.
-   *
-   * @returns {string} The explorer url based on the network.
-   */
-  getExplorerUrl = (): string => {
-    return this.network === 'testnet' ? 'https://westend.subscan.io' : 'https://polkadot.subscan.io'
-  }
-
-  /**
-   * Get the explorer url for the given address.
-   *
-   * @param {Address} address
-   * @returns {string} The explorer url for the given address based on the network.
-   */
-  getExplorerAddressUrl = (address: Address): string => {
-    return `${this.getExplorerUrl()}/account/${address}`
-  }
-
-  /**
-   * Get the explorer url for the given transaction id.
-   *
-   * @param {string} txID The transaction id
-   * @returns {string} The explorer url for the given transaction id based on the network.
-   */
-  getExplorerTxUrl = (txID: string): string => {
-    return `${this.getExplorerUrl()}/extrinsic/${txID}`
-  }
-
-  /**
-   * Get the SS58 format to be used for Polkadot Keyring.
-   *
-   * @returns {number} The SS58 format based on the network.
-   */
-  getSS58Format = (): number => {
-    return this.network === 'testnet' ? 42 : 0
-  }
-
-  /**
-   * Set/update a new phrase.
-   *
-   * @param {string} phrase A new phrase.
-   * @returns {Address} The address from the given phrase
-   *
-   * @throws {"Invalid phrase"}
-   * Thrown if the given phase is invalid.
-   */
-  setPhrase = (phrase: string, walletIndex = 0): Address => {
-    if (this.phrase !== phrase) {
-      if (!xchainCrypto.validatePhrase(phrase)) {
-        throw new Error('Invalid phrase')
-      }
-      this.phrase = phrase
-    }
-
-    return this.getAddress(walletIndex)
-  }
-
-  /**
-   * @private
-   * Private function to get Keyring pair for polkadotjs provider.
-   * @see https://polkadot.js.org/docs/api/start/keyring/#creating-a-keyring-instance
-   *
-   * @returns {KeyringPair} The keyring pair to be used to generate wallet address.
-   * */
-  private getKeyringPair = (index: number): KeyringPair => {
-    const key = new Keyring({ ss58Format: this.getSS58Format(), type: 'ed25519' })
-
-    return key.createFromUri(`${this.phrase}//${this.getFullDerivationPath(index)}`)
+  getSS58Format(): number {
+    return this.params.ss58Format
   }
 
   /**
@@ -208,263 +77,139 @@ class Client implements PolkadotClient, XChainClient {
    *
    * @returns {ApiPromise} The polkadotjs API provider based on the network.
    * */
-  private getAPI = async (): Promise<ApiPromise> => {
-    try {
-      const api = new ApiPromise({ provider: new WsProvider(this.getWsEndpoint()) })
-      await api.isReady
-
-      if (!api.isConnected) {
-        await api.connect()
-      }
-
-      return api
-    } catch (error) {
-      return Promise.reject(error)
-    }
+  async getAPI(): Promise<ApiPromise> {
+    const api = new ApiPromise({ provider: new WsProvider(this.getWsEndpoint()) })
+    await api.isReady
+    if (!api.isConnected) await api.connect()
+    return api
   }
 
-  /**
-   * Validate the given address.
-   * @see https://polkadot.js.org/docs/util-crypto/examples/validate-address
-   *
-   * @param {Address} address
-   * @returns {boolean} `true` or `false`
-   */
-  validateAddress = (address: string): boolean => {
+  async validateAddress(address: string): Promise<boolean> {
     try {
-      const key = new Keyring({ ss58Format: this.getSS58Format(), type: 'ed25519' })
+      const key = new Keyring({ ss58Format: this.params.ss58Format, type: 'ed25519' })
       return key.encodeAddress(isHex(address) ? hexToU8a(address) : key.decodeAddress(address)) === address
     } catch (error) {
       return false
     }
   }
 
-  /**
-   * Get the current address.
-   *
-   * Generates a network-specific key-pair by first converting the buffer to a Wallet-Import-Format (WIF)
-   * The address is then decoded into type P2WPKH and returned.
-   *
-   * @returns {Address} The current address.
-   *
-   * @throws {"Address not defined"} Thrown if failed creating account from phrase.
-   */
-  getAddress = (index = 0): Address => {
-    return this.getKeyringPair(index).address
-  }
+  async getBalance(address: Address, assets?: Asset[]): Promise<Balance[]> {
+    const response: SubscanResponse<Account> = await axios
+      .post(`${this.params.clientUrl}/api/open/account`, { address: address || this.getAddress() })
+      .then((res) => res.data)
 
-  /**
-   * Get the DOT balance of a given address.
-   *
-   * @param {Address} address By default, it will return the balance of the current wallet. (optional)
-   * @returns {Array<Balance>} The DOT balance of the address.
-   */
-  getBalance = async (address: Address, assets?: Asset[]): Promise<Balances> => {
-    try {
-      const response: SubscanResponse<Account> = await axios
-        .post(`${this.getClientUrl()}/api/open/account`, { address: address || this.getAddress() })
-        .then((res) => res.data)
-
-      if (!isSuccess(response)) {
-        throw new Error('Invalid address')
-      }
-
-      const account = response.data
-
-      return account && (!assets || assets.filter((asset) => assetToString(AssetDOT) === assetToString(asset)).length)
-        ? [
-            {
-              asset: AssetDOT,
-              amount: assetToBase(assetAmount(account.balance, getDecimal(this.network))),
-            },
-          ]
-        : []
-    } catch (error) {
-      return Promise.reject(error)
+    if (!isSuccess(response)) {
+      throw new Error('Invalid address')
     }
+
+    const account = response.data
+
+    return account && (!assets || assets.filter((asset) => assetToString(AssetDOT) === assetToString(asset)).length)
+      ? [
+          {
+            asset: AssetDOT,
+            amount: assetToBase(assetAmount(account.balance, getDecimal(this.params.network))),
+          },
+        ]
+      : []
   }
 
-  /**
-   * Get transaction history of a given address with pagination options.
-   * By default it will return the transaction history of the current wallet.
-   *
-   * @param {TxHistoryParams} params The options to get transaction history. (optional)
-   * @returns {TxsPage} The transaction history.
-   */
-  getTransactions = async (params?: TxHistoryParams): Promise<TxsPage> => {
-    const limit = params?.limit ?? 10
-    const offset = params?.offset ?? 0
+  async getTransactions(params: TxHistoryParams): Promise<TxsPage> {
+    const limit = params.limit ?? 10
+    const offset = params.offset ?? 0
 
-    try {
-      const response: SubscanResponse<TransfersResult> = await axios
-        .post(`${this.getClientUrl()}/api/scan/transfers`, {
-          address: params?.address,
-          row: limit,
-          page: offset,
-        })
-        .then((res) => res.data)
+    const response: SubscanResponse<TransfersResult> = await axios
+      .post(`${this.params.clientUrl}/api/scan/transfers`, {
+        address: params?.address,
+        row: limit,
+        page: offset,
+      })
+      .then((res) => res.data)
 
-      if (!isSuccess(response) || !response.data) {
-        throw new Error('Failed to get transactions')
-      }
+    if (!isSuccess(response) || !response.data) throw new Error('Failed to get transactions')
 
-      const transferResult: TransfersResult = response.data
+    const transferResult: TransfersResult = response.data
 
-      return {
-        total: transferResult.count,
-        txs: (transferResult.transfers || []).map((transfer) => ({
-          asset: AssetDOT,
-          from: [
-            {
-              from: transfer.from,
-              amount: assetToBase(assetAmount(transfer.amount, getDecimal(this.network))),
-            },
-          ],
-          to: [
-            {
-              to: transfer.to,
-              amount: assetToBase(assetAmount(transfer.amount, getDecimal(this.network))),
-            },
-          ],
-          date: new Date(transfer.block_timestamp * 1000),
-          type: 'transfer',
-          hash: transfer.hash,
-        })),
-      }
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  }
-
-  /**
-   * Get the transaction details of a given transaction id.
-   *
-   * @param {string} txId The transaction id.
-   * @returns {Tx} The transaction details of the given transaction id.
-   */
-  getTransactionData = async (txId: string): Promise<Tx> => {
-    try {
-      const response: SubscanResponse<Extrinsic> = await axios
-        .post(`${this.getClientUrl()}/api/scan/extrinsic`, {
-          hash: txId,
-        })
-        .then((res) => res.data)
-
-      if (!isSuccess(response) || !response.data) {
-        throw new Error('Failed to get transactions')
-      }
-
-      const extrinsic: Extrinsic = response.data
-      const transfer: Transfer = extrinsic.transfer
-
-      return {
+    return {
+      total: transferResult.count,
+      txs: (transferResult.transfers || []).map((transfer) => ({
         asset: AssetDOT,
         from: [
           {
             from: transfer.from,
-            amount: assetToBase(assetAmount(transfer.amount, getDecimal(this.network))),
+            amount: assetToBase(assetAmount(transfer.amount, getDecimal(this.params.network))),
           },
         ],
         to: [
           {
             to: transfer.to,
-            amount: assetToBase(assetAmount(transfer.amount, getDecimal(this.network))),
+            amount: assetToBase(assetAmount(transfer.amount, getDecimal(this.params.network))),
           },
         ],
-        date: new Date(extrinsic.block_timestamp * 1000),
-        type: 'transfer',
-        hash: extrinsic.extrinsic_hash,
-      }
-    } catch (error) {
-      return Promise.reject(error)
+        date: new Date(transfer.block_timestamp * 1000),
+        type: TxType.Transfer,
+        hash: transfer.hash,
+      })),
     }
   }
 
-  /**
-   * Transfer DOT.
-   *
-   * @param {TxParams} params The transfer options.
-   * @returns {TxHash} The transaction hash.
-   */
-  transfer = async (params: TxParams): Promise<TxHash> => {
-    try {
-      const api = await this.getAPI()
-      let transaction = null
-      const walletIndex = params.walletIndex || 0
-      // Createing a transfer
-      const transfer = api.tx.balances.transfer(params.recipient, params.amount.amount().toString())
-      if (!params.memo) {
-        // Send a simple transfer
-        transaction = transfer
-      } else {
-        // Send a `utility.batch` with two Calls: i) Balance.Transfer ii) System.Remark
+  async getTransactionData(txId: string): Promise<Tx> {
+    const response: SubscanResponse<Extrinsic> = await axios
+      .post(`${this.params.clientUrl}/api/scan/extrinsic`, {
+        hash: txId,
+      })
+      .then((res) => res.data)
 
-        // Creating a remark
-        const remark = api.tx.system.remark(params.memo)
+    if (!isSuccess(response) || !response.data) {
+      throw new Error('Failed to get transactions')
+    }
 
-        // Send the Batch Transaction
-        transaction = api.tx.utility.batch([transfer, remark])
-      }
+    const extrinsic: Extrinsic = response.data
+    const transfer: Transfer = extrinsic.transfer
 
-      // Check balances
-      const paymentInfo = await transaction.paymentInfo(this.getKeyringPair(walletIndex))
-      const fee = baseAmount(paymentInfo.partialFee.toString(), getDecimal(this.network))
-      const balances = await this.getBalance(this.getAddress(walletIndex), [AssetDOT])
-
-      if (!balances || params.amount.amount().plus(fee.amount()).isGreaterThan(balances[0].amount.amount())) {
-        throw new Error('insufficient balance')
-      }
-
-      const txHash = await transaction.signAndSend(this.getKeyringPair(walletIndex))
-      await api.disconnect()
-
-      return txHash.toString()
-    } catch (error) {
-      return Promise.reject(error)
+    return {
+      asset: AssetDOT,
+      from: [
+        {
+          from: transfer.from,
+          amount: assetToBase(assetAmount(transfer.amount, getDecimal(this.params.network))),
+        },
+      ],
+      to: [
+        {
+          to: transfer.to,
+          amount: assetToBase(assetAmount(transfer.amount, getDecimal(this.params.network))),
+        },
+      ],
+      date: new Date(extrinsic.block_timestamp * 1000),
+      type: TxType.Transfer,
+      hash: extrinsic.extrinsic_hash,
     }
   }
 
-  /**
-   * Get the current fee with transfer options.
-   *
-   * @see https://polkadot.js.org/docs/api/cookbook/tx/#how-do-i-estimate-the-transaction-fees
-   *
-   * @param {TxParams} params The transfer options.
-   * @returns {Fees} The estimated fees with the transfer options.
-   */
-  estimateFees = async (params: TxParams): Promise<Fees> => {
-    try {
-      const walletIndex = params.walletIndex ? params.walletIndex : 0
-      const api = await this.getAPI()
-      const info = await api.tx.balances
-        .transfer(params.recipient, params.amount.amount().toNumber())
-        .paymentInfo(this.getKeyringPair(walletIndex))
+  estimateFees(index: number, params: TxParams): Promise<Fees>
+  estimateFees(params: TxParams & { walletIndex?: number }): Promise<Fees>
+  async estimateFees(
+    indexOrParams: number | (TxParams & { walletIndex?: number }),
+    maybeParams?: TxParams,
+  ): Promise<Fees> {
+    const [index, params] = this.normalizeParams(indexOrParams, maybeParams)
+    const api = await this.getAPI()
+    const info = await api.tx.balances
+      .transfer(params.recipient, params.amount.amount().toNumber())
+      .paymentInfo(await this.getAddress(index))
 
-      const fee = baseAmount(info.partialFee.toString(), getDecimal(this.network))
-      await api.disconnect()
+    const fee = baseAmount(info.partialFee.toString(), getDecimal(this.params.network))
+    await api.disconnect()
 
-      return {
-        type: 'byte',
-        average: fee,
-        fast: fee,
-        fastest: fee,
-      }
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    return SingleFeePerByte(fee)
   }
 
-  /**
-   * Get the current fee.
-   *
-   * @returns {Fees} The current fee.
-   */
-  getFees = async (): Promise<Fees> => {
-    return await this.estimateFees({
-      recipient: this.getAddress(),
-      amount: baseAmount(0, getDecimal(this.network)),
+  async getFees(index?: number): Promise<Fees> {
+    index = index ?? 0
+    return await this.estimateFees(index, {
+      recipient: await this.getAddress(index),
+      amount: baseAmount(0, getDecimal(this.params.network)),
     })
   }
 }
-
-export { Client }

--- a/packages/xchain-polkadot/src/index.ts
+++ b/packages/xchain-polkadot/src/index.ts
@@ -1,3 +1,4 @@
 export * from './client'
 export * from './types'
 export * from './util'
+export * from './wallet'

--- a/packages/xchain-polkadot/src/util.ts
+++ b/packages/xchain-polkadot/src/util.ts
@@ -1,4 +1,4 @@
-import { Fees, Network } from '@xchainjs/xchain-client'
+import { Fees, Network, SingleFeePerByte } from '@xchainjs/xchain-client'
 import { assetAmount, assetToBase } from '@xchainjs/xchain-util'
 
 /**
@@ -27,19 +27,5 @@ export const getDecimal = (network: Network): number => {
 export const getDefaultFees = (network: Network): Fees => {
   const fee = assetToBase(assetAmount(0.015, getDecimal(network)))
 
-  return {
-    type: 'byte',
-    fast: fee,
-    fastest: fee,
-    average: fee,
-  }
+  return SingleFeePerByte(fee)
 }
-
-/**
- * Get address prefix based on the network.
- *
- * @param {string} network
- * @returns {string} The address prefix based on the network.
- *
- **/
-export const getPrefix = (network: string) => (network === 'testnet' ? '5' : '1')

--- a/packages/xchain-polkadot/src/wallet.ts
+++ b/packages/xchain-polkadot/src/wallet.ts
@@ -1,0 +1,69 @@
+import { Keyring } from '@polkadot/api'
+import { KeyringPair } from '@polkadot/keyring/types'
+import { Address, TxHash, TxParams, Wallet as BaseWallet, WalletFactory } from '@xchainjs/xchain-client'
+import { validatePhrase } from '@xchainjs/xchain-crypto'
+import { baseAmount } from '@xchainjs/xchain-util'
+
+import { Client } from './client'
+import { AssetDOT } from './types'
+import { getDecimal } from './util'
+
+export class Wallet implements BaseWallet {
+  protected readonly client: Client
+  protected readonly phrase: string
+
+  protected constructor(client: Client, phrase: string) {
+    this.client = client
+    this.phrase = phrase
+  }
+
+  static async create(phrase: string): Promise<WalletFactory<Client>> {
+    if (!validatePhrase(phrase)) throw new Error('Invalid phrase')
+    return async (client: Client) => new this(client, phrase)
+  }
+
+  protected async getKeyringPair(index: number): Promise<KeyringPair> {
+    const key = new Keyring({ ss58Format: this.client.params.ss58Format, type: 'ed25519' })
+    return key.createFromUri(`${this.phrase}//${this.client.getFullDerivationPath(index)}`)
+  }
+
+  async getAddress(index: number): Promise<Address> {
+    return (await this.getKeyringPair(index)).address
+  }
+
+  async transfer(index: number, params: TxParams): Promise<TxHash> {
+    const keyringPair = await this.getKeyringPair(index)
+    const address = await this.getAddress(index)
+
+    const api = await this.client.getAPI()
+    let transaction = null
+    // Createing a transfer
+    const transfer = api.tx.balances.transfer(params.recipient, params.amount.amount().toString())
+    if (!params.memo) {
+      // Send a simple transfer
+      transaction = transfer
+    } else {
+      // Send a `utility.batch` with two Calls: i) Balance.Transfer ii) System.Remark
+
+      // Creating a remark
+      const remark = api.tx.system.remark(params.memo)
+
+      // Send the Batch Transaction
+      transaction = api.tx.utility.batch([transfer, remark])
+    }
+
+    // Check balances
+    const paymentInfo = await transaction.paymentInfo(address)
+    const fee = baseAmount(paymentInfo.partialFee.toString(), getDecimal(this.client.params.network))
+    const balances = await this.client.getBalance(address, [AssetDOT])
+
+    if (!balances || params.amount.amount().plus(fee.amount()).isGreaterThan(balances[0].amount.amount())) {
+      throw new Error('insufficient balance')
+    }
+
+    const txHash = await transaction.signAndSend(keyringPair)
+    await api.disconnect()
+
+    return txHash.toString()
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3003,7 +3003,7 @@ bip174@^2.0.1:
   resolved "https://registry.yarnpkg.com/bip174/-/bip174-2.0.1.tgz#39cf8ca99e50ce538fb762589832f4481d07c254"
   integrity sha512-i3X26uKJOkDTAalYAp0Er+qGMDhrbbh2o93/xiPyAN2s25KrClSpe3VXo/7mNJoqA5qfko8rLS2l3RWZgYmjKQ==
 
-bip32@^2.0.4, bip32@^2.0.5:
+bip32@^2.0.4, bip32@^2.0.5, bip32@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/bip32/-/bip32-2.0.6.tgz#6a81d9f98c4cd57d05150c60d8f9e75121635134"
   integrity sha512-HpV5OMLLGTjSVblmrtYRfFFKuQB+GArM0+XP8HGWfJ5vxYBqo+DesvJwOdC2WJ3bCkZShGf0QIfoIpeomVzVdA==


### PR DESCRIPTION
This one forces you to build a new `Client` if you want to swap to/from testnet or change any other parameters, but it factors out the functions that require private key access into a per-chain `Wallet` type. It uses a lot less in the way of magical generic mumbo-jumbo, which is generally a sign that the API is converging towards something that makes sense -- making the parameters read-only _vastly_ simplifies things on that front.

The `Wallet` types basically just do `getAddress()`/`transfer()`/`multiSend()`. As an added bonus, they're swappable at runtime -- which might be convenient if you wanted to, say, build an interface layer which using `@shapeshiftoss/hdwallet-core` to get instante hardware wallet support.

So far, this refactor only extends to `xchain-client`, `xchain-cosmos`, `xchain-binance`, and `xchain-bitcoin`. I expect `xchain-ethereum` will be a PITA as usual, but everything else should be substantially similar to one of those types.

Comments welcome!