### PR TITLE
adding fee options to client interface such that one can call it in a…

### DIFF
--- a/packages/xchain-client/src/types.ts
+++ b/packages/xchain-client/src/types.ts
@@ -1,5 +1,5 @@
 import { Asset, BaseAmount } from '@xchainjs/xchain-util'
-import { BigNumber } from 'ethers'
+import { BigNumber } from 'bignumber.js'
 
 export type Address = string
 

--- a/packages/xchain-client/src/types.ts
+++ b/packages/xchain-client/src/types.ts
@@ -1,4 +1,5 @@
 import { Asset, BaseAmount } from '@xchainjs/xchain-util'
+import { BigNumber } from 'ethers'
 
 export type Address = string
 
@@ -57,6 +58,13 @@ export type TxParams = {
   memo?: string // optional memo to pass
 }
 
+export type FeeOptions = {
+  feeOptionKey?: FeeOptionKey
+  feeRate?: number
+  gasPrice?: BaseAmount
+  gasLimit?: BigNumber
+}
+
 // In most cases, clients don't expect any paramter in `getFees`
 // but in some cases, they do (e.g. in xchain-ethereum).
 // To workaround this, we just define an "empty" (optional) param for now.
@@ -107,7 +115,7 @@ export interface XChainClient {
 
   getFees(params?: FeesParams): Promise<Fees>
 
-  transfer(params: TxParams): Promise<TxHash>
+  transfer(params: TxParams & FeeOptions): Promise<TxHash>
 
   purgeClient(): void
 }


### PR DESCRIPTION
… generic way:

e.g.
if you get the client in a generic way and want to pass a customized gasprice in case it is ethereum
```
this.getClientFromAsset(asset).transfer({
    asset,
    recipient,
    amount: assetToBase(assetAmount),
    gasPrice,
});
```