### PR TITLE
[xchain-eth] Fix `isApproved` call

### DIFF
--- a/packages/xchain-client/src/BaseXChainClient.ts
+++ b/packages/xchain-client/src/BaseXChainClient.ts
@@ -66,6 +66,7 @@ export abstract class BaseXChainClient implements XChainClient {
   public getNetwork(): Network {
     return this.network
   }
+
   protected async getFeeRatesFromThorchain(): Promise<FeeRates> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const respData = (await this.thornodeAPIGet('/inbound_addresses')) as any[]
@@ -80,6 +81,7 @@ export abstract class BaseXChainClient implements XChainClient {
     }
     return feeRates
   }
+
   protected async thornodeAPIGet(endpoint: string): Promise<unknown> {
     const url = this.network === 'testnet' ? TESTNET_THORNODE_API_BASE : MAINNET_THORNODE_API_BASE
     return (await axios.get(url + endpoint)).data
@@ -89,6 +91,7 @@ export abstract class BaseXChainClient implements XChainClient {
    * Set/update a new phrase
    *
    * @param {string} phrase A new phrase.
+   * @param {number} walletIndex (optional) HD wallet index
    * @returns {Address} The address from the given phrase
    *
    * @throws {"Invalid phrase"}
@@ -108,11 +111,11 @@ export abstract class BaseXChainClient implements XChainClient {
   /**
    * Get getFullDerivationPath
    *
-   * @param {number} index the HD wallet index
+   * @param {number} walletIndex HD wallet index
    * @returns {string} The bitcoin derivation path based on the network.
    */
-  protected getFullDerivationPath(index: number): string {
-    return this.rootDerivationPaths ? `${this.rootDerivationPaths[this.network]}${index}` : ''
+  protected getFullDerivationPath(walletIndex: number): string {
+    return this.rootDerivationPaths ? `${this.rootDerivationPaths[this.network]}${walletIndex}` : ''
   }
   /**
    * Purge client.

--- a/packages/xchain-ethereum/CHANGELOG.md
+++ b/packages/xchain-ethereum/CHANGELOG.md
@@ -1,3 +1,17 @@
+# v.0.22.0 (2021-06-30)
+
+### Fix
+
+- `isApproved` returned always `false`
+
+### Breaking change
+
+- Parameter object for `call`, `estimateCall`, `isApproved` methods
+
+### Add
+
+- Optional `gasLimitFallback` parameter for `approve` call
+
 # v.0.21.4 (2021-06-07)
 
 ### Fix

--- a/packages/xchain-ethereum/__tests__/client.testnet.test.ts
+++ b/packages/xchain-ethereum/__tests__/client.testnet.test.ts
@@ -457,18 +457,18 @@ describe('Client Test', () => {
       '0x0000000000000000000000000000000000000000000000000000000000000064',
     )
 
-    let isApproved = await ethClient.isApproved(
-      '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
-      '0x4f96fe3b7a6cf9725f59d353f723c1bdb64ca6aa',
-      baseAmount(100, ETH_DECIMAL),
-    )
+    let isApproved = await ethClient.isApproved({
+      contractAddress: '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
+      spenderAddress: '0x4f96fe3b7a6cf9725f59d353f723c1bdb64ca6aa',
+      amount: baseAmount(100, ETH_DECIMAL),
+    })
     expect(isApproved).toEqual(true)
 
-    isApproved = await ethClient.isApproved(
-      '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
-      '0x4f96fe3b7a6cf9725f59d353f723c1bdb64ca6aa',
-      baseAmount(101, ETH_DECIMAL),
-    )
+    isApproved = await ethClient.isApproved({
+      contractAddress: '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
+      spenderAddress: '0x4f96fe3b7a6cf9725f59d353f723c1bdb64ca6aa',
+      amount: baseAmount(101, ETH_DECIMAL),
+    })
     expect(isApproved).toEqual(false)
   })
 
@@ -484,8 +484,8 @@ describe('Client Test', () => {
     mock_all_api(etherscanUrl, ropstenInfuraUrl, ropstenAlchemyUrl, 'eth_estimateGas', '0x5208')
 
     const gasLimit = await ethClient.estimateApprove({
-      spender: '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
-      sender: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+      contractAddress: '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
+      spenderAddress: '0xdac17f958d2ee523a2206206994597c13d831ec7',
       amount: baseAmount(100, ETH_DECIMAL),
     })
     expect(gasLimit.eq(21000)).toBeTruthy()
@@ -511,8 +511,8 @@ describe('Client Test', () => {
 
     const tx = await ethClient.approve({
       walletIndex: 0,
-      spender: '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
-      sender: '0xd15ffaef3112460bf3bcd81087fcbbce394e2ae7',
+      contractAddress: '0xd15ffaef3112460bf3bcd81087fcbbce394e2ae7',
+      spenderAddress: '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
       feeOptionKey: 'fastest',
       amount: baseAmount(100, ETH_DECIMAL),
     })
@@ -530,13 +530,18 @@ describe('Client Test', () => {
     mock_all_api(etherscanUrl, ropstenInfuraUrl, ropstenAlchemyUrl, 'eth_gasPrice', '0xb2d05e00')
     mock_all_api(etherscanUrl, ropstenInfuraUrl, ropstenAlchemyUrl, 'eth_estimateGas', '0x5208')
 
-    const gasLimit = await ethClient.estimateCall('0xd15ffaef3112460bf3bcd81087fcbbce394e2ae7', erc20ABI, 'transfer', [
-      '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
-      BigNumber.from(baseAmount('10000000000000', ETH_DECIMAL).amount().toString()),
-      {
-        from: ethClient.getAddress(),
-      },
-    ])
+    const gasLimit = await ethClient.estimateCall({
+      contractAddress: '0xd15ffaef3112460bf3bcd81087fcbbce394e2ae7',
+      abi: erc20ABI,
+      funcName: 'transfer',
+      funcParams: [
+        '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
+        BigNumber.from(baseAmount('10000000000000', ETH_DECIMAL).amount().toString()),
+        {
+          from: ethClient.getAddress(),
+        },
+      ],
+    })
 
     expect(gasLimit.toString()).toEqual('21000')
   })
@@ -574,12 +579,12 @@ describe('Client Test', () => {
 
     const prices = await ethClient.estimateGasPrices()
 
-    const txResult = await ethClient.call<TransactionResponse>(
-      0,
-      '0xd15ffaef3112460bf3bcd81087fcbbce394e2ae7',
-      erc20ABI,
-      'transfer',
-      [
+    const txResult = await ethClient.call<TransactionResponse>({
+      walletIndex: 0,
+      contractAddress: '0xd15ffaef3112460bf3bcd81087fcbbce394e2ae7',
+      abi: erc20ABI,
+      funcName: 'transfer',
+      funcParams: [
         '0x8c2a90d36ec9f745c9b28b588cba5e2a978a1656',
         BigNumber.from(baseAmount('10000000000000', ETH_DECIMAL).amount().toString()),
         // Here the tx overrides
@@ -588,7 +593,7 @@ describe('Client Test', () => {
           gasPrice: BigNumber.from(prices.average.amount().toString()),
         },
       ],
-    )
+    })
 
     expect(txResult.hash).toEqual('0xbc5f55b97b816d1c30138d26bce5434ff28828b15ee79aa79aebf70f786a3fe8')
   })

--- a/packages/xchain-ethereum/package.json
+++ b/packages/xchain-ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-ethereum",
-  "version": "0.21.4",
+  "version": "0.22.0",
   "description": "Ethereum client for XChainJS",
   "keywords": [
     "XChain",

--- a/packages/xchain-ethereum/src/client.ts
+++ b/packages/xchain-ethereum/src/client.ts
@@ -547,7 +547,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    */
   isApproved = async ({ contractAddress, spenderAddress, amount }: IsApprovedParams): Promise<boolean> => {
     // since amount is optional, set it to smallest amount by default
-    const txAmount = BigNumber.from(amount?.amount() ?? 1)
+    const txAmount = BigNumber.from(amount?.amount().toFixed() ?? 1)
     const owner = this.getAddress()
     const allowance = await this.call<BigNumberish>({
       contractAddress,
@@ -743,10 +743,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
         fast: baseAmount(rates.fast, ETH_DECIMAL),
         fastest: baseAmount(rates.fastest, ETH_DECIMAL),
       }
-    } catch (error) {
-      console.log(error)
-      console.warn(`Error pulling rates from thorchain, will try alternate`)
-    }
+    } catch (error) {}
     //should only get here if thor fails
     return await this.estimateGasPricesFromEtherscan()
   }

--- a/packages/xchain-ethereum/src/client.ts
+++ b/packages/xchain-ethereum/src/client.ts
@@ -17,6 +17,7 @@ import {
   CallParams,
   IsApprovedParams,
   EstimateCallParams,
+  EstimateApproveParams,
 } from './types'
 import {
   Address,
@@ -65,7 +66,7 @@ export interface EthereumClient {
   estimateGasPrices(): Promise<GasPrices>
   estimateGasLimit(params: FeesParams): Promise<BigNumber>
   estimateFeesWithGasPricesAndLimits(params: FeesParams): Promise<FeesWithGasPricesAndLimits>
-
+  estimateApprove(params: EstimateApproveParams): Promise<BigNumber>
   isApproved(params: IsApprovedParams): Promise<boolean>
   approve(params: ApproveParams): Promise<TransactionResponse>
 }
@@ -617,7 +618,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
     amount,
     gasLimitFallback,
     walletIndex,
-  }: Omit<ApproveParams, 'feeOptionKey'>): Promise<BigNumber> => {
+  }: EstimateApproveParams): Promise<BigNumber> => {
     try {
       const txAmount = amount ? BigNumber.from(amount.amount().toFixed()) : MAX_APPROVAL
       const gasLimit = await this.estimateCall({

--- a/packages/xchain-ethereum/src/client.ts
+++ b/packages/xchain-ethereum/src/client.ts
@@ -14,6 +14,9 @@ import {
   FeesWithGasPricesAndLimits,
   InfuraCreds,
   ApproveParams,
+  CallParams,
+  IsApprovedParams,
+  EstimateCallParams,
 } from './types'
 import {
   RootDerivationPaths,
@@ -58,30 +61,14 @@ import {
  */
 export interface EthereumClient {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  call<T>(
-    walletIndex: number,
-    asset: Address,
-    abi: ethers.ContractInterface,
-    func: string,
-    params: Array<unknown>,
-  ): Promise<T>
-  estimateCall(
-    asset: Address,
-    abi: ethers.ContractInterface,
-    func: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    params: Array<any>,
-  ): Promise<BigNumber>
+  call<T>(params: CallParams): Promise<T>
+  estimateCall(asset: EstimateCallParams): Promise<BigNumber>
   estimateGasPrices(): Promise<GasPrices>
   estimateGasLimit(params: FeesParams): Promise<BigNumber>
   estimateFeesWithGasPricesAndLimits(params: FeesParams): Promise<FeesWithGasPricesAndLimits>
 
-  isApproved(spender: Address, sender: Address, amount: BaseAmount): Promise<boolean>
-  approve(
-    params: ApproveParams & {
-      feeOptionKey?: FeeOptionKey
-    },
-  ): Promise<TransactionResponse>
+  isApproved(params: IsApprovedParams): Promise<boolean>
+  approve(params: ApproveParams): Promise<TransactionResponse>
 }
 
 export type EthereumClientParams = XChainClientParams & {
@@ -383,8 +370,9 @@ export default class Client implements XChainClient, EthereumClient {
               apiKey: etherscan.apiKey,
             })
             const decimals =
-              BigNumber.from(await this.call<BigNumberish>(0, assetAddress, erc20ABI, 'decimals', [])).toNumber() ||
-              ETH_DECIMAL
+              BigNumber.from(
+                await this.call<BigNumberish>({ contractAddress: assetAddress, abi: erc20ABI, funcName: 'decimals' }),
+              ).toNumber() || ETH_DECIMAL
 
             if (!Number.isNaN(decimals)) {
               balances.push({
@@ -530,71 +518,68 @@ export default class Client implements XChainClient, EthereumClient {
   /**
    * Call a contract function.
    * @template T The result interface.
-   * @param {Address} address The contract address.
+   * @param {Address} contractAddress The contract address.
    * @param {ContractInterface} abi The contract ABI json.
-   * @param {string} func The function to be called.
-   * @param {Array<any>} params The parameters of the function.
+   * @param {string} funcName The function to be called.
+   * @param {Array<any>} funcParams The parameters of the function.
    * @returns {T} The result of the contract function call.
    *
    * @throws {"address must be provided"}
    * Thrown if the given contract address is empty.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  call = async <T>(
-    walletIndex = 0,
-    contractAddress: Address,
-    abi: ethers.ContractInterface,
-    func: string,
-    params: Array<unknown>,
-  ): Promise<T> => {
+  call = async <T>({ walletIndex = 0, contractAddress, abi, funcName, funcParams = [] }: CallParams): Promise<T> => {
     if (!contractAddress) {
       return Promise.reject(new Error('contractAddress must be provided'))
     }
     const contract = new ethers.Contract(contractAddress, abi, this.getProvider()).connect(this.getWallet(walletIndex))
-    return contract[func](...params)
+    return contract[funcName](...funcParams)
   }
 
   /**
    * Call a contract function.
-   * @param {Address} address The contract address.
+   * @param {Address} contractAddress The contract address.
    * @param {ContractInterface} abi The contract ABI json.
-   * @param {string} func The function to be called.
-   * @param {Array<any>} params The parameters of the function.
+   * @param {string} funcName The function to be called.
+   * @param {Array<any>} funcParams The parameters of the function.
    * @returns {BigNumber} The result of the contract function call.
    *
    * @throws {"address must be provided"}
    * Thrown if the given contract address is empty.
    */
-  estimateCall = async (
-    contractAddress: Address,
-    abi: ethers.ContractInterface,
-    func: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    params: Array<any>,
-  ): Promise<BigNumber> => {
+  estimateCall = async ({
+    contractAddress,
+    abi,
+    funcName,
+    funcParams = [],
+    walletIndex = 0,
+  }: EstimateCallParams): Promise<BigNumber> => {
     if (!contractAddress) {
       return Promise.reject(new Error('contractAddress must be provided'))
     }
-    const contract = new ethers.Contract(contractAddress, abi, this.getProvider()).connect(this.getWallet(0))
-    return contract.estimateGas[func](...params)
+    const contract = new ethers.Contract(contractAddress, abi, this.getProvider()).connect(this.getWallet(walletIndex))
+    return contract.estimateGas[funcName](...funcParams)
   }
 
   /**
    * Check allowance.
    *
-   * @param {Address} spender The spender address.
-   * @param {Address} sender The sender address.
-   * @param {BaseAmount} amount The amount of token.
+   * @param {Address} contractAddress The spender address.
+   * @param {Address} spenderAddress The spender address.
+   * @param {BaseAmount} amount The amount to check if it's allowed to spend or not (optional).
    * @returns {boolean} `true` or `false`.
    */
-  isApproved = async (spender: Address, sender: Address, amount: BaseAmount): Promise<boolean> => {
-    try {
-      const txAmount = BigNumber.from(amount.amount().toFixed())
-      const allowance = await this.call<BigNumberish>(0, sender, erc20ABI, 'allowance', [spender, spender])
-      return txAmount.lte(allowance)
-    } catch (error) {
-      return Promise.reject(error)
-    }
+  isApproved = async ({ contractAddress, spenderAddress, amount }: IsApprovedParams): Promise<boolean> => {
+    // since amount is optional, set it to smallest amount by default
+    const txAmount = BigNumber.from(amount?.amount() ?? 1)
+    const owner = this.getAddress()
+    const allowance = await this.call<BigNumberish>({
+      contractAddress,
+      abi: erc20ABI,
+      funcName: 'allowance',
+      funcParams: [owner, spenderAddress],
+    })
+    return txAmount.lte(allowance)
   }
 
   /**
@@ -608,37 +593,38 @@ export default class Client implements XChainClient, EthereumClient {
    * @returns {TransactionResponse} The transaction result.
    */
   approve = async ({
-    walletIndex = 0,
-    spender,
-    sender,
-    feeOptionKey,
+    contractAddress,
+    spenderAddress,
+    feeOptionKey = 'fastest',
     amount,
+    walletIndex = 0,
+    gasLimitFallback,
   }: ApproveParams): Promise<TransactionResponse> => {
-    const gasPrice =
-      feeOptionKey &&
-      BigNumber.from(
-        (
-          await this.estimateGasPrices()
-            .then((prices) => prices[feeOptionKey])
-            .catch(() => getDefaultGasPrices()[feeOptionKey])
-        )
-          .amount()
-          .toFixed(),
+    const gasPrice = BigNumber.from(
+      (
+        await this.estimateGasPrices()
+          .then((prices) => prices[feeOptionKey])
+          .catch(() => getDefaultGasPrices()[feeOptionKey])
       )
-    const gasLimit = await this.estimateApprove({ spender, sender, amount }).catch(() => undefined)
+        .amount()
+        .toFixed(),
+    )
+    const gasLimit = await this.estimateApprove({
+      walletIndex,
+      spenderAddress,
+      contractAddress,
+      amount,
+      gasLimitFallback,
+    }).catch(() => undefined)
 
-    try {
-      const txAmount = amount ? BigNumber.from(amount.amount().toFixed()) : MAX_APPROVAL
-      const txResult = await this.call<TransactionResponse>(walletIndex, sender, erc20ABI, 'approve', [
-        spender,
-        txAmount,
-        { from: this.getAddress(), gasPrice, gasLimit },
-      ])
-
-      return txResult
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    const txAmount = amount ? BigNumber.from(amount.amount().toFixed()) : MAX_APPROVAL
+    return await this.call<TransactionResponse>({
+      walletIndex,
+      contractAddress,
+      abi: erc20ABI,
+      funcName: 'approve',
+      funcParams: [spenderAddress, txAmount, { from: this.getAddress(), gasPrice, gasLimit }],
+    })
   }
 
   /**
@@ -650,20 +636,26 @@ export default class Client implements XChainClient, EthereumClient {
    * @returns {BigNumber} The estimated gas limit.
    */
   estimateApprove = async ({
-    spender,
-    sender,
+    contractAddress,
+    spenderAddress,
     amount,
-  }: Omit<ApproveParams, 'feeOptionKey' | 'walletIndex'>): Promise<BigNumber> => {
+    gasLimitFallback,
+    walletIndex,
+  }: Omit<ApproveParams, 'feeOptionKey'>): Promise<BigNumber> => {
     try {
       const txAmount = amount ? BigNumber.from(amount.amount().toFixed()) : MAX_APPROVAL
-      const gasLimit = await this.estimateCall(sender, erc20ABI, 'approve', [
-        spender,
-        txAmount,
-        { from: this.getAddress() },
-      ])
+      const gasLimit = await this.estimateCall({
+        walletIndex,
+        contractAddress,
+        abi: erc20ABI,
+        funcName: 'approve',
+        funcParams: [spenderAddress, txAmount, { from: this.getAddress() }],
+      })
 
       return gasLimit
     } catch (error) {
+      // return `gasLimitFallback` if available
+      if (gasLimitFallback) return BigNumber.from(gasLimitFallback)
       return Promise.reject(error)
     }
   }
@@ -732,11 +724,13 @@ export default class Client implements XChainClient, EthereumClient {
       let txResult
       if (assetAddress && !isETHAddress) {
         // Transfer ERC20
-        txResult = await this.call<TransactionResponse>(walletIndex, assetAddress, erc20ABI, 'transfer', [
-          recipient,
-          txAmount,
-          Object.assign({}, overrides),
-        ])
+        txResult = await this.call<TransactionResponse>({
+          walletIndex,
+          contractAddress: assetAddress,
+          abi: erc20ABI,
+          funcName: 'transfer',
+          funcParams: [recipient, txAmount, Object.assign({}, overrides)],
+        })
       } else {
         // Transfer ETH
         const transactionRequest = Object.assign(

--- a/packages/xchain-ethereum/src/types/client-types.ts
+++ b/packages/xchain-ethereum/src/types/client-types.ts
@@ -42,9 +42,23 @@ export type FeesParams = C.FeesParams & C.TxParams
 export type FeesWithGasPricesAndLimits = { fees: C.Fees; gasPrices: GasPrices; gasLimit: BigNumber }
 
 export type ApproveParams = {
-  walletIndex: number
-  spender: Address
-  sender: Address
+  walletIndex?: number
+  contractAddress: Address
+  spenderAddress: Address
   feeOptionKey?: FeeOptionKey
   amount?: BaseAmount
+  // Optional fallback for gasLimit
+  gasLimitFallback?: ethers.BigNumberish
 }
+
+export type IsApprovedParams = { contractAddress: Address; spenderAddress: Address; amount?: BaseAmount }
+
+export type CallParams = {
+  walletIndex?: number
+  contractAddress: Address
+  abi: ethers.ContractInterface
+  funcName: string
+  funcParams?: Array<unknown>
+}
+
+export type EstimateCallParams = Pick<CallParams, 'contractAddress' | 'abi' | 'funcName' | 'funcParams' | 'walletIndex'>

--- a/packages/xchain-ethereum/src/types/client-types.ts
+++ b/packages/xchain-ethereum/src/types/client-types.ts
@@ -47,13 +47,18 @@ export type ApproveParams = {
   spenderAddress: Address
   feeOptionKey?: FeeOptionKey
   amount?: BaseAmount
-  // Optional fallback for gasLimit
+  // Optional fallback in case estimation for gas limit fails
   gasLimitFallback?: ethers.BigNumberish
 }
 
-export type EstimateApproveParams = Omit<ApproveParams, 'feeOptionKey'>
+export type EstimateApproveParams = Omit<ApproveParams, 'feeOptionKey' | 'gasLimitFallback'>
 
-export type IsApprovedParams = { contractAddress: Address; spenderAddress: Address; amount?: BaseAmount }
+export type IsApprovedParams = {
+  walletIndex?: number
+  contractAddress: Address
+  spenderAddress: Address
+  amount?: BaseAmount
+}
 
 export type CallParams = {
   walletIndex?: number

--- a/packages/xchain-ethereum/src/types/client-types.ts
+++ b/packages/xchain-ethereum/src/types/client-types.ts
@@ -51,6 +51,8 @@ export type ApproveParams = {
   gasLimitFallback?: ethers.BigNumberish
 }
 
+export type EstimateApproveParams = Omit<ApproveParams, 'feeOptionKey'>
+
 export type IsApprovedParams = { contractAddress: Address; spenderAddress: Address; amount?: BaseAmount }
 
 export type CallParams = {


### PR DESCRIPTION
Before `isApproved` returned always `false`, it missed to passed`owner` address to ERC20 contract `allowance` function. This PR fixes it. It will also fixes issues based on failing `allowance` handling in ASGARDEX desktop (see https://github.com/thorchain/asgardex-electron/issues/1595, https://github.com/thorchain/asgardex-electron/issues/1594)

- [x] Parameter object for `call`, `estimateCall`, `isApproved` methods
- [x] Optional `gasLimitFallback` param for `approve` call
- [x] Add `estimateApprovel` to `interface EthereumClient`
- [x] Update tests
- [x] Remove log statements
- [x] Bump `v0.22.0`



