### PR TITLE
Unrequire phrase ethereum

### DIFF
--- a/packages/xchain-ethereum/__tests__/client.mainnet.test.ts
+++ b/packages/xchain-ethereum/__tests__/client.mainnet.test.ts
@@ -23,6 +23,14 @@ describe('Client Test', () => {
     nock.cleanAll()
   })
 
+  it('creates a client without a phrase', () => {
+    expect(() => {
+      new Client({
+        network: 'mainnet',
+      })
+    }).not.toThrow()
+  })
+
   it('derive path correctly with bip44', () => {
     const ethClient = new Client({
       network: 'mainnet',

--- a/packages/xchain-ethereum/__tests__/client.testnet.test.ts
+++ b/packages/xchain-ethereum/__tests__/client.testnet.test.ts
@@ -48,6 +48,14 @@ describe('Client Test', () => {
     nock.cleanAll()
   })
 
+  it('creates a client without a phrase', () => {
+    expect(() => {
+      new Client({
+        network: 'testnet',
+      })
+    }).not.toThrow()
+  })
+
   it('should throw error on bad phrase', () => {
     expect(() => {
       new Client({ phrase: 'bad bad phrase' })

--- a/packages/xchain-ethereum/src/client.ts
+++ b/packages/xchain-ethereum/src/client.ts
@@ -35,6 +35,7 @@ import {
   FeeOptionKey,
   FeesParams as XFeesParams,
   BaseXChainClient,
+  RootDerivationPaths,
 } from '@xchainjs/xchain-client'
 import { AssetETH, baseAmount, BaseAmount, assetToString, Asset, delay } from '@xchainjs/xchain-util'
 import * as ethplorerAPI from './ethplorer-api'
@@ -89,6 +90,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
   private infuraCreds: InfuraCreds | undefined
   private ethplorerUrl: string
   private ethplorerApiKey: string
+  private rootDerivationPaths: RootDerivationPaths
   private providers: Map<XChainNetwork, Provider> = new Map<XChainNetwork, Provider>()
 
   /**
@@ -117,7 +119,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
     this.ethplorerApiKey = ethplorerApiKey
     this.explorerUrl = explorerUrl || this.getDefaultExplorerURL()
     this.setupProviders()
-    this.setPhrase(phrase)
+    phrase && this.setPhrase(phrase)
   }
 
   /**

--- a/packages/xchain-ethereum/src/client.ts
+++ b/packages/xchain-ethereum/src/client.ts
@@ -35,7 +35,6 @@ import {
   FeeOptionKey,
   FeesParams as XFeesParams,
   BaseXChainClient,
-  RootDerivationPaths,
 } from '@xchainjs/xchain-client'
 import { AssetETH, baseAmount, BaseAmount, assetToString, Asset, delay } from '@xchainjs/xchain-util'
 import * as ethplorerAPI from './ethplorer-api'
@@ -90,7 +89,6 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
   private infuraCreds: InfuraCreds | undefined
   private ethplorerUrl: string
   private ethplorerApiKey: string
-  private rootDerivationPaths: RootDerivationPaths
   private providers: Map<XChainNetwork, Provider> = new Map<XChainNetwork, Provider>()
 
   /**


### PR DESCRIPTION
phrases should not be required for creating the client or reading the blockchain
a conditional was added during the constructor to check if a phrase was passed, and consequently not call `client.setPhrase(` if it is not

~i also noted that the `RootDerivationPaths` was not defined in the eth package~ looks like it was just my editor.