### PR TITLE
refactored client methods to use regular method syntax (not fat arrow)

### DIFF
--- a/packages/xchain-bitcoin/CHANGELOG.md
+++ b/packages/xchain-bitcoin/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v.0.15.10 (2021-07-03)
+
+- refactored client methods to use regular method syntax (not fat arrow) in order for bcall to super.xxx() to work properly
+
 # v.0.15.9 (2021-06-29)
 
 - added support for pulling fees from thornode.

--- a/packages/xchain-bitcoin/package.json
+++ b/packages/xchain-bitcoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-bitcoin",
-  "version": "0.15.9",
+  "version": "0.15.10",
   "description": "Custom Bitcoin client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",

--- a/packages/xchain-bitcoin/src/client.ts
+++ b/packages/xchain-bitcoin/src/client.ts
@@ -69,7 +69,7 @@ class Client extends BaseXChainClient implements BitcoinClient, XChainClient {
    * @param {string} url The new sochain url.
    * @returns {void}
    */
-  setSochainUrl = (url: string): void => {
+  setSochainUrl(url: string): void {
     this.sochainUrl = url
   }
 
@@ -79,7 +79,7 @@ class Client extends BaseXChainClient implements BitcoinClient, XChainClient {
    * @param {string} url The new blockstream url.
    * @returns {void}
    */
-  setBlockstreamUrl = (url: string): void => {
+  setBlockstreamUrl(url: string): void {
     this.blockstreamUrl = url
   }
 
@@ -88,7 +88,7 @@ class Client extends BaseXChainClient implements BitcoinClient, XChainClient {
    *
    * @returns {string} The explorer url based on the network.
    */
-  getExplorerUrl = (): string => {
+  getExplorerUrl(): string {
     const networkPath = Utils.isTestnet(this.network) ? '/testnet' : ''
     return `https://blockstream.info${networkPath}`
   }
@@ -99,17 +99,19 @@ class Client extends BaseXChainClient implements BitcoinClient, XChainClient {
    * @param {Address} address
    * @returns {string} The explorer url for the given address based on the network.
    */
-  getExplorerAddressUrl = (address: Address): string => {
+  // getExplorerAddressUr(address: Address): string {
+  //   return `${this.getExplorerUrl()}/address/${address}`
+  // }
+  getExplorerAddressUrl(address: string): string {
     return `${this.getExplorerUrl()}/address/${address}`
   }
-
   /**
    * Get the explorer url for the given transaction id.
    *
    * @param {string} txID The transaction id
    * @returns {string} The explorer url for the given transaction id based on the network.
    */
-  getExplorerTxUrl = (txID: string): string => {
+  getExplorerTxUrl(txID: string): string {
     return `${this.getExplorerUrl()}/tx/${txID}`
   }
 
@@ -124,7 +126,7 @@ class Client extends BaseXChainClient implements BitcoinClient, XChainClient {
    * @throws {"Phrase must be provided"} Thrown if phrase has not been set before.
    * @throws {"Address not defined"} Thrown if failed creating account from phrase.
    */
-  getAddress = (index = 0): Address => {
+  getAddress(index = 0): Address {
     if (index < 0) {
       throw new Error('index must be greater than zero')
     }
@@ -155,7 +157,7 @@ class Client extends BaseXChainClient implements BitcoinClient, XChainClient {
    *
    * @throws {"Could not get private key from phrase"} Throws an error if failed creating BTC keys from the given phrase
    * */
-  private getBtcKeys = (phrase: string, index = 0): Bitcoin.ECPairInterface => {
+  private getBtcKeys(phrase: string, index = 0): Bitcoin.ECPairInterface {
     const btcNetwork = Utils.btcNetwork(this.network)
 
     const seed = getSeed(phrase)
@@ -174,7 +176,9 @@ class Client extends BaseXChainClient implements BitcoinClient, XChainClient {
    * @param {Address} address
    * @returns {boolean} `true` or `false`
    */
-  validateAddress = (address: string): boolean => Utils.validateAddress(address, this.network)
+  validateAddress(address: string): boolean {
+    return Utils.validateAddress(address, this.network)
+  }
 
   /**
    * Get the BTC balance of a given address.
@@ -182,7 +186,7 @@ class Client extends BaseXChainClient implements BitcoinClient, XChainClient {
    * @param {Address} the BTC address
    * @returns {Array<Balance>} The BTC balance of the address.
    */
-  getBalance = async (address: Address): Promise<Balance[]> => {
+  async getBalance(address: Address): Promise<Balance[]> {
     return Utils.getBalance({
       sochainUrl: this.sochainUrl,
       network: this.network,
@@ -197,7 +201,7 @@ class Client extends BaseXChainClient implements BitcoinClient, XChainClient {
    * @param {TxHistoryParams} params The options to get transaction history. (optional)
    * @returns {TxsPage} The transaction history.
    */
-  getTransactions = async (params?: TxHistoryParams): Promise<TxsPage> => {
+  async getTransactions(params?: TxHistoryParams): Promise<TxsPage> {
     // Sochain API doesn't have pagination parameter
     const offset = params?.offset ?? 0
     const limit = params?.limit || 10
@@ -250,7 +254,7 @@ class Client extends BaseXChainClient implements BitcoinClient, XChainClient {
    * @param {string} txId The transaction id.
    * @returns {Tx} The transaction details of the given transaction id.
    */
-  getTransactionData = async (txId: string): Promise<Tx> => {
+  async getTransactionData(txId: string): Promise<Tx> {
     try {
       const rawTx = await sochain.getTx({
         sochainUrl: this.sochainUrl,
@@ -279,7 +283,7 @@ class Client extends BaseXChainClient implements BitcoinClient, XChainClient {
    * @param {string} memo The memo to be used for fee calculation (optional)
    * @returns {FeesWithRates} The fees and rates
    */
-  getFeesWithRates = async (memo?: string): Promise<FeesWithRates> => {
+  async getFeesWithRates(memo?: string): Promise<FeesWithRates> {
     let rates: FeeRates | undefined = undefined
 
     try {
@@ -313,7 +317,7 @@ class Client extends BaseXChainClient implements BitcoinClient, XChainClient {
    *
    * @returns {Fees} The fees without memo
    */
-  getFees = async (): Promise<Fees> => {
+  async getFees(): Promise<Fees> {
     const { fees } = await this.getFeesWithRates()
     return fees
   }
@@ -325,7 +329,7 @@ class Client extends BaseXChainClient implements BitcoinClient, XChainClient {
    * @param {string} memo
    * @returns {Fees} The fees with memo
    */
-  getFeesWithMemo = async (memo: string): Promise<Fees> => {
+  async getFeesWithMemo(memo: string): Promise<Fees> {
     const { fees } = await this.getFeesWithRates(memo)
     return fees
   }
@@ -336,7 +340,7 @@ class Client extends BaseXChainClient implements BitcoinClient, XChainClient {
    *
    * @returns {FeeRates} The fee rate
    */
-  getFeeRates = async (): Promise<FeeRates> => {
+  async getFeeRates(): Promise<FeeRates> {
     const { rates } = await this.getFeesWithRates()
     return rates
   }
@@ -347,7 +351,7 @@ class Client extends BaseXChainClient implements BitcoinClient, XChainClient {
    * @param {TxParams&FeeRate} params The transfer options.
    * @returns {TxHash} The transaction hash.
    */
-  transfer = async (params: TxParams & { feeRate?: FeeRate }): Promise<TxHash> => {
+  async transfer(params: TxParams & { feeRate?: FeeRate }): Promise<TxHash> {
     const fromAddressIndex = params?.walletIndex || 0
 
     // set the default fee rate to `fast`

--- a/packages/xchain-litecoin/CHANGELOG.md
+++ b/packages/xchain-litecoin/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v.0.6.8 (2021-07-03)
+
+- refactored client methods to use regular method syntax (not fat arrow) in order for bcall to super.xxx() to work properly
+
 # v.0.6.7 (2021-06-29)
 
 - added support for pulling fees from thornode.

--- a/packages/xchain-litecoin/package.json
+++ b/packages/xchain-litecoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-litecoin",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Custom Litecoin client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",

--- a/packages/xchain-litecoin/src/client.ts
+++ b/packages/xchain-litecoin/src/client.ts
@@ -88,7 +88,7 @@ class Client extends BaseXChainClient implements LitecoinClient, XChainClient {
    * @param {string} url The new sochain url.
    * @returns {void}
    */
-  setSochainUrl = (url: string): void => {
+  setSochainUrl(url: string): void {
     this.sochainUrl = url
   }
 
@@ -97,7 +97,7 @@ class Client extends BaseXChainClient implements LitecoinClient, XChainClient {
    *
    * @returns {string} The explorer url based on the network.
    */
-  getExplorerUrl = (): string => {
+  getExplorerUrl(): string {
     return Utils.isTestnet(this.network) ? 'https://tltc.bitaps.com' : 'https://ltc.bitaps.com'
   }
 
@@ -107,7 +107,7 @@ class Client extends BaseXChainClient implements LitecoinClient, XChainClient {
    * @param {Address} address
    * @returns {string} The explorer url for the given address based on the network.
    */
-  getExplorerAddressUrl = (address: Address): string => {
+  getExplorerAddressUrl(address: Address): string {
     return `${this.getExplorerUrl()}/${address}`
   }
 
@@ -117,7 +117,7 @@ class Client extends BaseXChainClient implements LitecoinClient, XChainClient {
    * @param {string} txID The transaction id
    * @returns {string} The explorer url for the given transaction id based on the network.
    */
-  getExplorerTxUrl = (txID: string): string => {
+  getExplorerTxUrl(txID: string): string {
     return `${this.getExplorerUrl()}/${txID}`
   }
 
@@ -132,7 +132,7 @@ class Client extends BaseXChainClient implements LitecoinClient, XChainClient {
    * @throws {"Phrase must be provided"} Thrown if phrase has not been set before.
    * @throws {"Address not defined"} Thrown if failed creating account from phrase.
    */
-  getAddress = (index = 0): Address => {
+  getAddress(index = 0): Address {
     if (index < 0) {
       throw new Error('index must be greater than zero')
     }
@@ -164,7 +164,7 @@ class Client extends BaseXChainClient implements LitecoinClient, XChainClient {
    *
    * @throws {"Could not get private key from phrase"} Throws an error if failed creating LTC keys from the given phrase
    * */
-  private getLtcKeys = (phrase: string, index = 0): Litecoin.ECPairInterface => {
+  private getLtcKeys(phrase: string, index = 0): Litecoin.ECPairInterface {
     const ltcNetwork = Utils.ltcNetwork(this.network)
 
     const seed = getSeed(phrase)
@@ -183,7 +183,9 @@ class Client extends BaseXChainClient implements LitecoinClient, XChainClient {
    * @param {Address} address
    * @returns {boolean} `true` or `false`
    */
-  validateAddress = (address: string): boolean => Utils.validateAddress(address, this.network)
+  validateAddress(address: string): boolean {
+    return Utils.validateAddress(address, this.network)
+  }
 
   /**
    * Get the LTC balance of a given address.
@@ -191,7 +193,7 @@ class Client extends BaseXChainClient implements LitecoinClient, XChainClient {
    * @param {Address} address By default, it will return the balance of the current wallet. (optional)
    * @returns {Array<Balance>} The LTC balance of the address.
    */
-  getBalance = async (address: Address): Promise<Balance[]> => {
+  async getBalance(address: Address): Promise<Balance[]> {
     try {
       return Utils.getBalance({
         sochainUrl: this.sochainUrl,
@@ -210,7 +212,7 @@ class Client extends BaseXChainClient implements LitecoinClient, XChainClient {
    * @param {TxHistoryParams} params The options to get transaction history. (optional)
    * @returns {TxsPage} The transaction history.
    */
-  getTransactions = async (params?: TxHistoryParams): Promise<TxsPage> => {
+  async getTransactions(params?: TxHistoryParams): Promise<TxsPage> {
     // Sochain API doesn't have pagination parameter
     const offset = params?.offset ?? 0
     const limit = params?.limit || 10
@@ -263,7 +265,7 @@ class Client extends BaseXChainClient implements LitecoinClient, XChainClient {
    * @param {string} txId The transaction id.
    * @returns {Tx} The transaction details of the given transaction id.
    */
-  getTransactionData = async (txId: string): Promise<Tx> => {
+  async getTransactionData(txId: string): Promise<Tx> {
     try {
       const rawTx = await sochain.getTx({
         sochainUrl: this.sochainUrl,
@@ -291,7 +293,7 @@ class Client extends BaseXChainClient implements LitecoinClient, XChainClient {
    * @param {string} memo The memo to be used for fee calculation (optional)
    * @returns {FeesWithRates} The fees and rates
    */
-  getFeesWithRates = async (memo?: string): Promise<FeesWithRates> => {
+  async getFeesWithRates(memo?: string): Promise<FeesWithRates> {
     let rates: FeeRates | undefined = undefined
     try {
       rates = await this.getFeeRatesFromThorchain()
@@ -310,7 +312,7 @@ class Client extends BaseXChainClient implements LitecoinClient, XChainClient {
 
     return { fees, rates }
   }
-  private getFeeRatesFromSoChain = async (): Promise<FeeRates> => {
+  private async getFeeRatesFromSoChain(): Promise<FeeRates> {
     const nextBlockFeeRate = await sochain.getSuggestedTxFee()
     const rates: FeeRates = {
       fastest: nextBlockFeeRate * 5,
@@ -326,7 +328,7 @@ class Client extends BaseXChainClient implements LitecoinClient, XChainClient {
    *
    * @returns {Fees} The fees without memo
    */
-  getFees = async (): Promise<Fees> => {
+  async getFees(): Promise<Fees> {
     try {
       const { fees } = await this.getFeesWithRates()
       return fees
@@ -342,7 +344,7 @@ class Client extends BaseXChainClient implements LitecoinClient, XChainClient {
    * @param {string} memo
    * @returns {Fees} The fees with memo
    */
-  getFeesWithMemo = async (memo: string): Promise<Fees> => {
+  async getFeesWithMemo(memo: string): Promise<Fees> {
     try {
       const { fees } = await this.getFeesWithRates(memo)
       return fees
@@ -357,7 +359,7 @@ class Client extends BaseXChainClient implements LitecoinClient, XChainClient {
    *
    * @returns {FeeRates} The fee rate
    */
-  getFeeRates = async (): Promise<FeeRates> => {
+  async getFeeRates(): Promise<FeeRates> {
     try {
       const { rates } = await this.getFeesWithRates()
       return rates
@@ -372,7 +374,7 @@ class Client extends BaseXChainClient implements LitecoinClient, XChainClient {
    * @param {TxParams&FeeRate} params The transfer options.
    * @returns {TxHash} The transaction hash.
    */
-  transfer = async (params: TxParams & { feeRate?: FeeRate }): Promise<TxHash> => {
+  async transfer(params: TxParams & { feeRate?: FeeRate }): Promise<TxHash> {
     try {
       const fromAddressIndex = params?.walletIndex || 0
       const feeRate = params.feeRate || (await this.getFeeRates()).fast


### PR DESCRIPTION
- refactored LTC client methods to use regular method syntax (not fat arrow) in order for call to super.xxx() to work properly
- refactored BTC client methods to use regular method syntax (not fat arrow) in order for call to super.xxx() to work properly