### PR TITLE
Refactor remaining client objects to avoid fat-arrow methods

### DIFF
--- a/packages/xchain-binance/CHANGELOG.md
+++ b/packages/xchain-binance/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v.5.2.3 (2021-07-05)
+
+- refactored client methods to use regular method syntax (not fat arrow) in order for bcall to super.xxx() to work properly
+
 # v.5.2.2 (2021-06-29)
 
 - added support for pulling fees from thornode.

--- a/packages/xchain-binance/package.json
+++ b/packages/xchain-binance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-binance",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "Custom Binance client and utilities used by XChainJS clients",
   "keywords": [
     "BNB",

--- a/packages/xchain-binance/src/client.ts
+++ b/packages/xchain-binance/src/client.ts
@@ -264,7 +264,7 @@ class Client extends BaseXChainClient implements BinanceClient, XChainClient {
    * @param {TxHistoryParams} params The options to get transaction history. (optional)
    * @returns {TxsPage} The transaction history.
    */
-  getTransactions = async (params?: TxHistoryParams): Promise<TxsPage> => {
+  async getTransactions(params?: TxHistoryParams): Promise<TxsPage> {
     return await this.searchTransactions({
       address: params && params.address,
       limit: params && params.limit?.toString(),
@@ -280,7 +280,7 @@ class Client extends BaseXChainClient implements BinanceClient, XChainClient {
    * @param {string} txId The transaction id.
    * @returns {Tx} The transaction details of the given transaction id.
    */
-  getTransactionData = async (txId: string): Promise<Tx> => {
+  async getTransactionData(txId: string): Promise<Tx> {
     try {
       const txResult: TransactionResult = await axios
         .get(`${this.getClientUrl()}/api/v1/tx/${txId}?format=json`)
@@ -318,7 +318,7 @@ class Client extends BaseXChainClient implements BinanceClient, XChainClient {
    * @param {MultiSendParams} params The multi-send transfer options.
    * @returns {TxHash} The transaction hash.
    */
-  multiSend = async ({ walletIndex = 0, transactions, memo = '' }: MultiSendParams): Promise<TxHash> => {
+  async multiSend({ walletIndex = 0, transactions, memo = '' }: MultiSendParams): Promise<TxHash> {
     try {
       const derivedAddress = this.getAddress(walletIndex)
 
@@ -353,7 +353,7 @@ class Client extends BaseXChainClient implements BinanceClient, XChainClient {
    * @param {TxParams} params The transfer options.
    * @returns {TxHash} The transaction hash.
    */
-  transfer = async ({ walletIndex, asset, amount, recipient, memo }: TxParams): Promise<TxHash> => {
+  async transfer({ walletIndex, asset, amount, recipient, memo }: TxParams): Promise<TxHash> {
     try {
       await this.bncClient.initChain()
       await this.bncClient
@@ -379,7 +379,7 @@ class Client extends BaseXChainClient implements BinanceClient, XChainClient {
    *
    * @returns {TransferFee} The current transfer fee.
    */
-  private getTransferFee = async (): Promise<TransferFee> => {
+  private async getTransferFee(): Promise<TransferFee> {
     try {
       const feesArray = await axios
         .get<BinanceFees>(`${this.getClientUrl()}/api/v1/fees`)
@@ -449,7 +449,7 @@ class Client extends BaseXChainClient implements BinanceClient, XChainClient {
    *
    * @returns {SingleAndMultiFees} The current fee for both single and multi-send transaction.
    */
-  getSingleAndMultiFees = async (): Promise<{ single: Fees; multi: Fees }> => {
+  async getSingleAndMultiFees(): Promise<{ single: Fees; multi: Fees }> {
     try {
       const transferFee = await this.getTransferFee()
       const singleTxFee = baseAmount(transferFee.fixed_fee_params.fee)

--- a/packages/xchain-bitcoin/src/client.ts
+++ b/packages/xchain-bitcoin/src/client.ts
@@ -99,9 +99,6 @@ class Client extends BaseXChainClient implements BitcoinClient, XChainClient {
    * @param {Address} address
    * @returns {string} The explorer url for the given address based on the network.
    */
-  // getExplorerAddressUr(address: Address): string {
-  //   return `${this.getExplorerUrl()}/address/${address}`
-  // }
   getExplorerAddressUrl(address: string): string {
     return `${this.getExplorerUrl()}/address/${address}`
   }

--- a/packages/xchain-cosmos/CHANGELOG.md
+++ b/packages/xchain-cosmos/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v.0.13.4 (2021-07-05)
+
+- refactored client methods to use regular method syntax (not fat arrow) in order for bcall to super.xxx() to work properly
+
 # v.0.13.3 (2021-06-29)
 
 ### Fix

--- a/packages/xchain-cosmos/package.json
+++ b/packages/xchain-cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-cosmos",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Custom Cosmos client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",

--- a/packages/xchain-cosmos/src/client.ts
+++ b/packages/xchain-cosmos/src/client.ts
@@ -93,7 +93,7 @@ class Client implements CosmosClient, XChainClient {
    * @throws {"Network must be provided"}
    * Thrown if network has not been set before.
    */
-  setNetwork = (network: Network): void => {
+  setNetwork(network: Network): void {
     if (!network) {
       throw new Error('Network must be provided')
     } else {
@@ -116,7 +116,7 @@ class Client implements CosmosClient, XChainClient {
    *
    * @returns {void}
    */
-  private registerCodecs = (): void => {
+  private registerCodecs(): void {
     codec.registerCodec('cosmos-sdk/MsgSend', MsgSend, MsgSend.fromJSON)
     codec.registerCodec('cosmos-sdk/MsgMultiSend', MsgMultiSend, MsgMultiSend.fromJSON)
   }
@@ -126,7 +126,7 @@ class Client implements CosmosClient, XChainClient {
    *
    * @returns {string} The explorer url.
    */
-  getExplorerUrl = (): string => {
+  getExplorerUrl(): string {
     return this.network === 'testnet' ? 'https://gaia.bigdipper.live' : 'https://cosmos.bigdipper.live'
   }
 
@@ -136,7 +136,7 @@ class Client implements CosmosClient, XChainClient {
    * @param {Address} address
    * @returns {string} The explorer url for the given address.
    */
-  getExplorerAddressUrl = (address: Address): string => {
+  getExplorerAddressUrl(address: Address): string {
     return `${this.getExplorerUrl()}/account/${address}`
   }
 
@@ -146,7 +146,7 @@ class Client implements CosmosClient, XChainClient {
    * @param {string} txID
    * @returns {string} The explorer url for the given transaction id.
    */
-  getExplorerTxUrl = (txID: string): string => {
+  getExplorerTxUrl(txID: string): string {
     return `${this.getExplorerUrl()}/transactions/${txID}`
   }
 
@@ -159,7 +159,7 @@ class Client implements CosmosClient, XChainClient {
    * @throws {"Invalid phrase"}
    * Thrown if the given phase is invalid.
    */
-  setPhrase = (phrase: string, walletIndex = 0): Address => {
+  setPhrase(phrase: string, walletIndex = 0): Address {
     if (this.phrase !== phrase) {
       if (!xchainCrypto.validatePhrase(phrase)) {
         throw new Error('Invalid phrase')
@@ -180,12 +180,12 @@ class Client implements CosmosClient, XChainClient {
    * @throws {"Phrase not set"}
    * Throws an error if phrase has not been set before
    * */
-  private getPrivateKey = (index = 0): PrivKey => {
+  private getPrivateKey(index = 0): PrivKey {
     if (!this.phrase) throw new Error('Phrase not set')
 
     return this.getSDKClient().getPrivKeyFromMnemonic(this.phrase, this.getFullDerivationPath(index))
   }
-  getSDKClient = (): CosmosSDKClient => {
+  getSDKClient(): CosmosSDKClient {
     return this.sdkClients.get(this.network) || TESTNET_SDK
   }
 
@@ -206,7 +206,7 @@ class Client implements CosmosClient, XChainClient {
    *
    * @throws {Error} Thrown if phrase has not been set before. A phrase is needed to create a wallet and to derive an address from it.
    */
-  getAddress = (index = 0): string => {
+  getAddress(index = 0): string {
     if (!this.phrase) throw new Error('Phrase not set')
 
     return this.getSDKClient().getAddressFromMnemonic(this.phrase, this.getFullDerivationPath(index))
@@ -218,7 +218,7 @@ class Client implements CosmosClient, XChainClient {
    * @param {Address} address
    * @returns {boolean} `true` or `false`
    */
-  validateAddress = (address: Address): boolean => {
+  validateAddress(address: Address): boolean {
     return this.getSDKClient().checkAddress(address)
   }
 
@@ -227,7 +227,7 @@ class Client implements CosmosClient, XChainClient {
    *
    * @returns {string} The main asset based on the network.
    */
-  getMainAsset = (): Asset => {
+  getMainAsset(): Asset {
     return this.network === 'testnet' ? AssetMuon : AssetAtom
   }
 
@@ -238,7 +238,7 @@ class Client implements CosmosClient, XChainClient {
    * @param {Asset} asset If not set, it will return all assets available. (optional)
    * @returns {Array<Balance>} The balance of the address.
    */
-  getBalance = async (address: Address, assets?: Asset[]): Promise<Balances> => {
+  async getBalance(address: Address, assets?: Asset[]): Promise<Balances> {
     try {
       const balances = await this.getSDKClient().getBalance(address)
       const mainAsset = this.getMainAsset()
@@ -266,7 +266,7 @@ class Client implements CosmosClient, XChainClient {
    * @param {TxHistoryParams} params The options to get transaction history. (optional)
    * @returns {TxsPage} The transaction history.
    */
-  getTransactions = async (params?: TxHistoryParams): Promise<TxsPage> => {
+  async getTransactions(params?: TxHistoryParams): Promise<TxsPage> {
     const messageAction = undefined
     const page = (params && params.offset) || undefined
     const limit = (params && params.limit) || undefined
@@ -301,7 +301,7 @@ class Client implements CosmosClient, XChainClient {
    * @param {string} txId The transaction id.
    * @returns {Tx} The transaction details of the given transaction id.
    */
-  getTransactionData = async (txId: string): Promise<Tx> => {
+  async getTransactionData(txId: string): Promise<Tx> {
     try {
       const txResult = await this.getSDKClient().txsHashGet(txId)
       const txs = getTxsFromHistory([txResult], this.getMainAsset())
@@ -322,7 +322,7 @@ class Client implements CosmosClient, XChainClient {
    * @param {TxParams} params The transfer options.
    * @returns {TxHash} The transaction hash.
    */
-  transfer = async ({ walletIndex, asset, amount, recipient, memo }: TxParams): Promise<TxHash> => {
+  async transfer({ walletIndex, asset, amount, recipient, memo }: TxParams): Promise<TxHash> {
     try {
       const fromAddressIndex = walletIndex || 0
       this.registerCodecs()
@@ -348,7 +348,7 @@ class Client implements CosmosClient, XChainClient {
    *
    * @returns {Fees} The current fee.
    */
-  getFees = async (): Promise<Fees> => {
+  async getFees(): Promise<Fees> {
     // there is no fixed fee, we set fee amount when creating a transaction.
     return Promise.resolve({
       type: 'base',

--- a/packages/xchain-cosmos/src/cosmos/sdk-client.ts
+++ b/packages/xchain-cosmos/src/cosmos/sdk-client.ts
@@ -38,12 +38,12 @@ export class CosmosSDKClient {
     this.sdk = new CosmosSDK(this.server, this.chainId)
   }
 
-  updatePrefix = (prefix: string) => {
+  updatePrefix(prefix: string) {
     this.prefix = prefix
     this.setPrefix()
   }
 
-  setPrefix = (): void => {
+  setPrefix(): void {
     AccAddress.setBech32Prefix(
       this.prefix,
       this.prefix + 'pub',
@@ -54,20 +54,20 @@ export class CosmosSDKClient {
     )
   }
 
-  getAddressFromPrivKey = (privkey: PrivKey): string => {
+  getAddressFromPrivKey(privkey: PrivKey): string {
     this.setPrefix()
 
     return AccAddress.fromPublicKey(privkey.getPubKey()).toBech32()
   }
 
-  getAddressFromMnemonic = (mnemonic: string, derivationPath: string): string => {
+  getAddressFromMnemonic(mnemonic: string, derivationPath: string): string {
     this.setPrefix()
     const privKey = this.getPrivKeyFromMnemonic(mnemonic, derivationPath)
 
     return AccAddress.fromPublicKey(privKey.getPubKey()).toBech32()
   }
 
-  getPrivKeyFromMnemonic = (mnemonic: string, derivationPath: string): PrivKey => {
+  getPrivKeyFromMnemonic(mnemonic: string, derivationPath: string): PrivKey {
     const seed = xchainCrypto.getSeed(mnemonic)
     const node = BIP32.fromSeed(seed)
     const child = node.derivePath(derivationPath)
@@ -79,7 +79,7 @@ export class CosmosSDKClient {
     return new PrivKeySecp256k1(child.privateKey)
   }
 
-  checkAddress = (address: string): boolean => {
+  checkAddress(address: string): boolean {
     try {
       this.setPrefix()
 
@@ -93,7 +93,7 @@ export class CosmosSDKClient {
     }
   }
 
-  getBalance = async (address: string): Promise<Coin[]> => {
+  async getBalance(address: string): Promise<Coin[]> {
     try {
       this.setPrefix()
 
@@ -105,14 +105,14 @@ export class CosmosSDKClient {
     }
   }
 
-  searchTx = async ({
+  async searchTx({
     messageAction,
     messageSender,
     page,
     limit,
     txMinHeight,
     txMaxHeight,
-  }: SearchTxParams): Promise<TxHistoryResponse> => {
+  }: SearchTxParams): Promise<TxHistoryResponse> {
     try {
       const queryParameter: APIQueryParam = {}
       if (messageAction !== undefined) {
@@ -144,7 +144,7 @@ export class CosmosSDKClient {
     }
   }
 
-  searchTxFromRPC = async ({
+  async searchTxFromRPC({
     messageAction,
     messageSender,
     transferSender,
@@ -156,7 +156,7 @@ export class CosmosSDKClient {
     rpcEndpoint,
   }: SearchTxParams & {
     rpcEndpoint: string
-  }): Promise<RPCTxSearchResult> => {
+  }): Promise<RPCTxSearchResult> {
     try {
       const queryParameter: string[] = []
       if (messageAction !== undefined) {
@@ -199,7 +199,7 @@ export class CosmosSDKClient {
     }
   }
 
-  txsHashGet = async (hash: string): Promise<TxResponse> => {
+  async txsHashGet(hash: string): Promise<TxResponse> {
     try {
       this.setPrefix()
 
@@ -209,7 +209,7 @@ export class CosmosSDKClient {
     }
   }
 
-  transfer = async ({
+  async transfer({
     privkey,
     from,
     to,
@@ -220,7 +220,7 @@ export class CosmosSDKClient {
       amount: [],
       gas: '200000',
     },
-  }: TransferParams): Promise<BroadcastTxCommitResult> => {
+  }: TransferParams): Promise<BroadcastTxCommitResult> {
     try {
       this.setPrefix()
 
@@ -251,11 +251,7 @@ export class CosmosSDKClient {
     }
   }
 
-  signAndBroadcast = async (
-    unsignedStdTx: StdTx,
-    privkey: PrivKey,
-    signer: AccAddress,
-  ): Promise<BroadcastTxCommitResult> => {
+  async signAndBroadcast(unsignedStdTx: StdTx, privkey: PrivKey, signer: AccAddress): Promise<BroadcastTxCommitResult> {
     try {
       this.setPrefix()
 

--- a/packages/xchain-ethereum/CHANGELOG.md
+++ b/packages/xchain-ethereum/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v.0.22.2 (2021-07-05)
+
+- refactored client methods to use regular method syntax (not fat arrow) in order for bcall to super.xxx() to work properly
+
 # v.0.22.1 (2021-06-30)
 
 ### Fix

--- a/packages/xchain-ethereum/package.json
+++ b/packages/xchain-ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-ethereum",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Ethereum client for XChainJS",
   "keywords": [
     "XChain",

--- a/packages/xchain-ethereum/src/client.ts
+++ b/packages/xchain-ethereum/src/client.ts
@@ -125,7 +125,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    *
    * @returns {void}
    */
-  purgeClient = (): void => {
+  purgeClient(): void {
     super.purgeClient()
     this.hdNode = HDNode.fromMnemonic('')
   }
@@ -136,7 +136,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    * @param {string} url The explorer url.
    * @returns {void}
    */
-  setExplorerURL = (url: ExplorerUrl): void => {
+  setExplorerURL(url: ExplorerUrl): void {
     this.explorerUrl = url
   }
 
@@ -165,10 +165,10 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    * @throws {"Phrase must be provided"}
    * Thrown if phrase has not been set before. A phrase is needed to create a wallet and to derive an address from it.
    */
-  getWallet = (walletIndex = 0): ethers.Wallet => {
+  getWallet(walletIndex = 0): ethers.Wallet {
     return new Wallet(this.hdNode.derivePath(this.getFullDerivationPath(walletIndex))).connect(this.getProvider())
   }
-  setupProviders = (): void => {
+  setupProviders(): void {
     if (this.infuraCreds) {
       // Infura provider takes either a string of project id
       // or an object of id and secret
@@ -191,7 +191,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    *
    * @returns {Provider} The current etherjs Provider interface.
    */
-  getProvider = (): Provider => {
+  getProvider(): Provider {
     return this.providers.get(this.network) || getDefaultProvider(this.network)
   }
 
@@ -200,7 +200,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    *
    * @returns {EtherscanProvider} The current etherjs EtherscanProvider interface.
    */
-  getEtherscanProvider = (): EtherscanProvider => {
+  getEtherscanProvider(): EtherscanProvider {
     return new EtherscanProvider(this.ethNetwork, this.etherscanApiKey)
   }
 
@@ -209,7 +209,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    *
    * @returns {string} The explorer url for ethereum based on the current network.
    */
-  getExplorerUrl = (): string => {
+  getExplorerUrl(): string {
     return this.getExplorerUrlByNetwork(this.getNetwork())
   }
 
@@ -218,7 +218,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    *
    * @returns {ExplorerUrl} The explorer url (both mainnet and testnet) for ethereum.
    */
-  private getDefaultExplorerURL = (): ExplorerUrl => {
+  private getDefaultExplorerURL(): ExplorerUrl {
     return {
       testnet: 'https://ropsten.etherscan.io',
       mainnet: 'https://etherscan.io',
@@ -231,7 +231,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    * @param {Network} network
    * @returns {string} The explorer url for ethereum based on the network.
    */
-  private getExplorerUrlByNetwork = (network: Network): string => {
+  private getExplorerUrlByNetwork(network: Network): string {
     return this.explorerUrl[network]
   }
 
@@ -241,7 +241,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    * @param {Address} address
    * @returns {string} The explorer url for the given address.
    */
-  getExplorerAddressUrl = (address: Address): string => {
+  getExplorerAddressUrl(address: Address): string {
     return `${this.getExplorerUrl()}/address/${address}`
   }
 
@@ -251,7 +251,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    * @param {string} txID
    * @returns {string} The explorer url for the given transaction id.
    */
-  getExplorerTxUrl = (txID: string): string => {
+  getExplorerTxUrl(txID: string): string {
     return `${this.getExplorerUrl()}/tx/${txID}`
   }
 
@@ -264,7 +264,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    * @throws {"Network must be provided"}
    * Thrown if network has not been set before.
    */
-  setNetwork = (network: XChainNetwork): void => {
+  setNetwork(network: XChainNetwork): void {
     super.setNetwork(network)
     this.ethNetwork = xchainNetworkToEths(network)
   }
@@ -290,7 +290,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    * @param {Address} address
    * @returns {boolean} `true` or `false`
    */
-  validateAddress = (address: Address): boolean => {
+  validateAddress(address: Address): boolean {
     return validateAddress(address)
   }
 
@@ -302,7 +302,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    *
    * @throws {"Invalid asset"} throws when the give asset is an invalid one
    */
-  getBalance = async (address: Address, assets?: Asset[]): Promise<Balances> => {
+  async getBalance(address: Address, assets?: Asset[]): Promise<Balances> {
     try {
       const ethAddress = address || this.getAddress()
       // get ETH balance directly from provider
@@ -388,7 +388,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    * @param {TxHistoryParams} params The options to get transaction history. (optional)
    * @returns {TxsPage} The transaction history.
    */
-  getTransactions = async (params?: TxHistoryParams): Promise<TxsPage> => {
+  async getTransactions(params?: TxHistoryParams): Promise<TxsPage> {
     try {
       const offset = params?.offset || 0
       const limit = params?.limit || 10
@@ -437,7 +437,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    * @throws {"Need to provide valid txId"}
    * Thrown if the given txId is invalid.
    */
-  getTransactionData = async (txId: string, assetAddress?: Address): Promise<Tx> => {
+  async getTransactionData(txId: string, assetAddress?: Address): Promise<Tx> {
     try {
       if (this.getNetwork() === 'mainnet') {
         // use ethplorerAPI for mainnet - ignore assetAddress
@@ -508,7 +508,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    * Thrown if the given contract address is empty.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  call = async <T>({ walletIndex = 0, contractAddress, abi, funcName, funcParams = [] }: CallParams): Promise<T> => {
+  async call<T>({ walletIndex = 0, contractAddress, abi, funcName, funcParams = [] }: CallParams): Promise<T> {
     if (!contractAddress) {
       return Promise.reject(new Error('contractAddress must be provided'))
     }
@@ -528,13 +528,13 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    * @throws {"address must be provided"}
    * Thrown if the given contract address is empty.
    */
-  estimateCall = async ({
+  async estimateCall({
     contractAddress,
     abi,
     funcName,
     funcParams = [],
     walletIndex = 0,
-  }: EstimateCallParams): Promise<BigNumber> => {
+  }: EstimateCallParams): Promise<BigNumber> {
     if (!contractAddress) {
       return Promise.reject(new Error('contractAddress must be provided'))
     }
@@ -551,12 +551,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    * @param {number} walletIndex (optional) HD wallet index
    * @returns {boolean} `true` or `false`.
    */
-  isApproved = async ({
-    contractAddress,
-    spenderAddress,
-    amount,
-    walletIndex = 0,
-  }: IsApprovedParams): Promise<boolean> => {
+  async isApproved({ contractAddress, spenderAddress, amount, walletIndex = 0 }: IsApprovedParams): Promise<boolean> {
     // since amount is optional, set it to smallest amount by default
     const txAmount = BigNumber.from(amount?.amount().toFixed() ?? 1)
     const owner = this.getAddress(walletIndex)
@@ -580,14 +575,14 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    *
    * @returns {TransactionResponse} The transaction result.
    */
-  approve = async ({
+  async approve({
     contractAddress,
     spenderAddress,
     feeOptionKey = 'fastest',
     amount,
     walletIndex = 0,
     gasLimitFallback,
-  }: ApproveParams): Promise<TransactionResponse> => {
+  }: ApproveParams): Promise<TransactionResponse> {
     const gasPrice = BigNumber.from(
       (
         await this.estimateGasPrices()
@@ -623,12 +618,12 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    * @param {BaseAmount} amount The amount of token. By default, it will be unlimited token allowance. (optional)
    * @returns {BigNumber} The estimated gas limit.
    */
-  estimateApprove = async ({
+  async estimateApprove({
     contractAddress,
     spenderAddress,
     walletIndex = 0,
     amount,
-  }: EstimateApproveParams): Promise<BigNumber> => {
+  }: EstimateApproveParams): Promise<BigNumber> {
     try {
       const txAmount = amount ? BigNumber.from(amount.amount().toFixed()) : MAX_APPROVAL
       const gasLimit = await this.estimateCall({
@@ -660,7 +655,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    * @throws {"Invalid asset address"}
    * Thrown if the given asset is invalid.
    */
-  transfer = async ({
+  async transfer({
     walletIndex = 0,
     asset,
     memo,
@@ -673,7 +668,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
     feeOptionKey?: FeeOptionKey
     gasPrice?: BaseAmount
     gasLimit?: BigNumber
-  }): Promise<TxHash> => {
+  }): Promise<TxHash> {
     try {
       const txAmount = BigNumber.from(amount.amount().toFixed())
 
@@ -742,7 +737,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    *
    * @throws {"Failed to estimate gas price"} Thrown if failed to estimate gas price.
    */
-  estimateGasPrices = async (): Promise<GasPrices> => {
+  async estimateGasPrices(): Promise<GasPrices> {
     try {
       // Note: `rates` are in `gwei`
       // @see https://gitlab.com/thorchain/thornode/-/blob/develop/x/thorchain/querier.go#L416-420
@@ -765,7 +760,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    *
    * @throws {"Failed to estimate gas price"} Thrown if failed to estimate gas price.
    */
-  estimateGasPricesFromEtherscan = async (): Promise<GasPrices> => {
+  async estimateGasPricesFromEtherscan(): Promise<GasPrices> {
     try {
       const etherscan = this.getEtherscanProvider()
       const response: GasOracleResponse = await etherscanAPI.getGasOracle(etherscan.baseUrl, etherscan.apiKey)
@@ -793,7 +788,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    *
    * @throws {"Failed to estimate gas limit"} Thrown if failed to estimate gas limit.
    */
-  estimateGasLimit = async ({ asset, recipient, amount, memo }: FeesParams): Promise<BigNumber> => {
+  async estimateGasLimit({ asset, recipient, amount, memo }: FeesParams): Promise<BigNumber> {
     try {
       const txAmount = BigNumber.from(amount.amount().toFixed())
 
@@ -837,7 +832,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    *
    * @throws {"Failed to estimate fees, gas price, gas limit"} Thrown if failed to estimate fees, gas price, gas limit.
    */
-  estimateFeesWithGasPricesAndLimits = async (params: FeesParams): Promise<FeesWithGasPricesAndLimits> => {
+  async estimateFeesWithGasPricesAndLimits(params: FeesParams): Promise<FeesWithGasPricesAndLimits> {
     try {
       // gas prices
       const gasPrices = await this.estimateGasPrices()
@@ -876,7 +871,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    *
    * @throws {"Failed to get fees"} Thrown if failed to get fees.
    */
-  getFees = async (params: XFeesParams & FeesParams): Promise<Fees> => {
+  async getFees(params: XFeesParams & FeesParams): Promise<Fees> {
     if (!params) return Promise.reject('Params need to be passed')
 
     try {

--- a/packages/xchain-polkadot/CHANGELOG.md
+++ b/packages/xchain-polkadot/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v.0.8.3 (2021-07-05)
+
+- refactored client methods to use regular method syntax (not fat arrow) in order for bcall to super.xxx() to work properly
+
 # v.0.8.2 (2021-06-01)
 
 - updated peer deps

--- a/packages/xchain-polkadot/package.json
+++ b/packages/xchain-polkadot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-polkadot",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Custom Polkadot client and utilities used by XChainJS clients",
   "keywords": [
     "THORChain",

--- a/packages/xchain-polkadot/src/client.ts
+++ b/packages/xchain-polkadot/src/client.ts
@@ -80,7 +80,7 @@ class Client implements PolkadotClient, XChainClient {
    *
    * @returns {void}
    */
-  purgeClient = (): void => {
+  purgeClient(): void {
     this.phrase = ''
   }
 
@@ -116,7 +116,7 @@ class Client implements PolkadotClient, XChainClient {
    *
    * @returns {string} The client url based on the network.
    */
-  getClientUrl = (): string => {
+  getClientUrl(): string {
     return this.network === 'testnet' ? 'https://westend.subscan.io' : 'https://polkadot.subscan.io'
   }
 
@@ -125,7 +125,7 @@ class Client implements PolkadotClient, XChainClient {
    *
    * @returns {string} The client WebSocket url based on the network.
    */
-  getWsEndpoint = (): string => {
+  getWsEndpoint(): string {
     return this.network === 'testnet' ? 'wss://westend-rpc.polkadot.io' : 'wss://rpc.polkadot.io'
   }
 
@@ -134,7 +134,7 @@ class Client implements PolkadotClient, XChainClient {
    *
    * @returns {string} The explorer url based on the network.
    */
-  getExplorerUrl = (): string => {
+  getExplorerUrl(): string {
     return this.network === 'testnet' ? 'https://westend.subscan.io' : 'https://polkadot.subscan.io'
   }
 
@@ -144,7 +144,7 @@ class Client implements PolkadotClient, XChainClient {
    * @param {Address} address
    * @returns {string} The explorer url for the given address based on the network.
    */
-  getExplorerAddressUrl = (address: Address): string => {
+  getExplorerAddressUrl(address: Address): string {
     return `${this.getExplorerUrl()}/account/${address}`
   }
 
@@ -154,7 +154,7 @@ class Client implements PolkadotClient, XChainClient {
    * @param {string} txID The transaction id
    * @returns {string} The explorer url for the given transaction id based on the network.
    */
-  getExplorerTxUrl = (txID: string): string => {
+  getExplorerTxUrl(txID: string): string {
     return `${this.getExplorerUrl()}/extrinsic/${txID}`
   }
 
@@ -163,7 +163,7 @@ class Client implements PolkadotClient, XChainClient {
    *
    * @returns {number} The SS58 format based on the network.
    */
-  getSS58Format = (): number => {
+  getSS58Format(): number {
     return this.network === 'testnet' ? 42 : 0
   }
 
@@ -176,7 +176,7 @@ class Client implements PolkadotClient, XChainClient {
    * @throws {"Invalid phrase"}
    * Thrown if the given phase is invalid.
    */
-  setPhrase = (phrase: string, walletIndex = 0): Address => {
+  setPhrase(phrase: string, walletIndex = 0): Address {
     if (this.phrase !== phrase) {
       if (!xchainCrypto.validatePhrase(phrase)) {
         throw new Error('Invalid phrase')
@@ -194,7 +194,7 @@ class Client implements PolkadotClient, XChainClient {
    *
    * @returns {KeyringPair} The keyring pair to be used to generate wallet address.
    * */
-  private getKeyringPair = (index: number): KeyringPair => {
+  private getKeyringPair(index: number): KeyringPair {
     const key = new Keyring({ ss58Format: this.getSS58Format(), type: 'ed25519' })
 
     return key.createFromUri(`${this.phrase}//${this.getFullDerivationPath(index)}`)
@@ -208,7 +208,7 @@ class Client implements PolkadotClient, XChainClient {
    *
    * @returns {ApiPromise} The polkadotjs API provider based on the network.
    * */
-  private getAPI = async (): Promise<ApiPromise> => {
+  private async getAPI(): Promise<ApiPromise> {
     try {
       const api = new ApiPromise({ provider: new WsProvider(this.getWsEndpoint()) })
       await api.isReady
@@ -230,7 +230,7 @@ class Client implements PolkadotClient, XChainClient {
    * @param {Address} address
    * @returns {boolean} `true` or `false`
    */
-  validateAddress = (address: string): boolean => {
+  validateAddress(address: string): boolean {
     try {
       const key = new Keyring({ ss58Format: this.getSS58Format(), type: 'ed25519' })
       return key.encodeAddress(isHex(address) ? hexToU8a(address) : key.decodeAddress(address)) === address
@@ -249,7 +249,7 @@ class Client implements PolkadotClient, XChainClient {
    *
    * @throws {"Address not defined"} Thrown if failed creating account from phrase.
    */
-  getAddress = (index = 0): Address => {
+  getAddress(index = 0): Address {
     return this.getKeyringPair(index).address
   }
 
@@ -259,7 +259,7 @@ class Client implements PolkadotClient, XChainClient {
    * @param {Address} address By default, it will return the balance of the current wallet. (optional)
    * @returns {Array<Balance>} The DOT balance of the address.
    */
-  getBalance = async (address: Address, assets?: Asset[]): Promise<Balances> => {
+  async getBalance(address: Address, assets?: Asset[]): Promise<Balances> {
     try {
       const response: SubscanResponse<Account> = await axios
         .post(`${this.getClientUrl()}/api/open/account`, { address: address || this.getAddress() })
@@ -291,7 +291,7 @@ class Client implements PolkadotClient, XChainClient {
    * @param {TxHistoryParams} params The options to get transaction history. (optional)
    * @returns {TxsPage} The transaction history.
    */
-  getTransactions = async (params?: TxHistoryParams): Promise<TxsPage> => {
+  async getTransactions(params?: TxHistoryParams): Promise<TxsPage> {
     const limit = params?.limit ?? 10
     const offset = params?.offset ?? 0
 
@@ -342,7 +342,7 @@ class Client implements PolkadotClient, XChainClient {
    * @param {string} txId The transaction id.
    * @returns {Tx} The transaction details of the given transaction id.
    */
-  getTransactionData = async (txId: string): Promise<Tx> => {
+  async getTransactionData(txId: string): Promise<Tx> {
     try {
       const response: SubscanResponse<Extrinsic> = await axios
         .post(`${this.getClientUrl()}/api/scan/extrinsic`, {
@@ -386,7 +386,7 @@ class Client implements PolkadotClient, XChainClient {
    * @param {TxParams} params The transfer options.
    * @returns {TxHash} The transaction hash.
    */
-  transfer = async (params: TxParams): Promise<TxHash> => {
+  async transfer(params: TxParams): Promise<TxHash> {
     try {
       const api = await this.getAPI()
       let transaction = null
@@ -432,7 +432,7 @@ class Client implements PolkadotClient, XChainClient {
    * @param {TxParams} params The transfer options.
    * @returns {Fees} The estimated fees with the transfer options.
    */
-  estimateFees = async (params: TxParams): Promise<Fees> => {
+  async estimateFees(params: TxParams): Promise<Fees> {
     try {
       const walletIndex = params.walletIndex ? params.walletIndex : 0
       const api = await this.getAPI()
@@ -459,7 +459,7 @@ class Client implements PolkadotClient, XChainClient {
    *
    * @returns {Fees} The current fee.
    */
-  getFees = async (): Promise<Fees> => {
+  async getFees(): Promise<Fees> {
     return await this.estimateFees({
       recipient: this.getAddress(),
       amount: baseAmount(0, getDecimal(this.network)),

--- a/packages/xchain-thorchain/CHANGELOG.md
+++ b/packages/xchain-thorchain/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v.0.17.2 (2021-07-05)
+
+- refactored client methods to use regular method syntax (not fat arrow) in order for bcall to super.xxx() to work properly
+
 # v.0.17.1 (2021-06-29)
 
 ### Fix

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-thorchain",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Custom Thorchain client and utilities used by XChainJS clients",
   "keywords": [
     "THORChain",

--- a/packages/xchain-thorchain/src/client.ts
+++ b/packages/xchain-thorchain/src/client.ts
@@ -104,7 +104,7 @@ class Client implements ThorchainClient, XChainClient {
    *
    * @returns {void}
    */
-  purgeClient = (): void => {
+  purgeClient(): void {
     this.phrase = ''
   }
 
@@ -117,7 +117,7 @@ class Client implements ThorchainClient, XChainClient {
    * @throws {"Network must be provided"}
    * Thrown if network has not been set before.
    */
-  setNetwork = (network: Network): void => {
+  setNetwork(network: Network): void {
     if (!network) {
       throw new Error('Network must be provided')
     }
@@ -131,7 +131,7 @@ class Client implements ThorchainClient, XChainClient {
    *
    * @returns {Network} The current network. (`mainnet` or `testnet`)
    */
-  getNetwork = (): Network => {
+  getNetwork(): Network {
     return this.network
   }
 
@@ -141,7 +141,7 @@ class Client implements ThorchainClient, XChainClient {
    * @param {ClientUrl} clientUrl The client url to be set.
    * @returns {void}
    */
-  setClientUrl = (clientUrl: ClientUrl): void => {
+  setClientUrl(clientUrl: ClientUrl): void {
     this.clientUrl = clientUrl
   }
 
@@ -150,7 +150,9 @@ class Client implements ThorchainClient, XChainClient {
    *
    * @returns {NodeUrl} The client url for thorchain based on the current network.
    */
-  getClientUrl = (): NodeUrl => this.clientUrl[this.network]
+  getClientUrl(): NodeUrl {
+    return this.clientUrl[this.network]
+  }
 
   /**
    * Set/update the explorer URLs.
@@ -158,7 +160,7 @@ class Client implements ThorchainClient, XChainClient {
    * @param {ExplorerUrls} urls The explorer urls to be set.
    * @returns {void}
    */
-  setExplorerUrls = (urls: ExplorerUrls): void => {
+  setExplorerUrls(urls: ExplorerUrls): void {
     this.explorerUrls = urls
   }
 
@@ -167,7 +169,7 @@ class Client implements ThorchainClient, XChainClient {
    *
    * @returns {string} The explorer url for thorchain based on the current network.
    */
-  getExplorerUrl = (): string => {
+  getExplorerUrl(): string {
     return this.explorerUrls.root[this.network]
   }
 
@@ -175,14 +177,16 @@ class Client implements ThorchainClient, XChainClient {
    * Get cosmos client
    * @returns {CosmosSDKClient} current cosmos client
    */
-  getCosmosClient = (): CosmosSDKClient => this.cosmosClient
+  getCosmosClient(): CosmosSDKClient {
+    return this.cosmosClient
+  }
 
   /**
    * Get the chain id.
    *
    * @returns {string} The chain id based on the network.
    */
-  getChainId = (): string => {
+  getChainId(): string {
     return 'thorchain'
   }
 
@@ -192,8 +196,9 @@ class Client implements ThorchainClient, XChainClient {
    * @param {Address} address
    * @returns {string} The explorer url for the given address.
    */
-  getExplorerAddressUrl = (address: Address): string =>
-    getExplorerAddressUrl({ urls: this.explorerUrls, network: this.network, address })
+  getExplorerAddressUrl(address: Address): string {
+    return getExplorerAddressUrl({ urls: this.explorerUrls, network: this.network, address })
+  }
 
   /**
    * Get the explorer url for the given transaction id.
@@ -201,8 +206,9 @@ class Client implements ThorchainClient, XChainClient {
    * @param {string} txID
    * @returns {string} The explorer url for the given transaction id.
    */
-  getExplorerTxUrl = (txID: string): string =>
-    getExplorerTxUrl({ urls: this.explorerUrls, network: this.network, txID })
+  getExplorerTxUrl(txID: string): string {
+    return getExplorerTxUrl({ urls: this.explorerUrls, network: this.network, txID })
+  }
 
   /**
    * Set/update a new phrase
@@ -213,7 +219,7 @@ class Client implements ThorchainClient, XChainClient {
    * @throws {"Invalid phrase"}
    * Thrown if the given phase is invalid.
    */
-  setPhrase = (phrase: string, walletIndex = 0): Address => {
+  setPhrase(phrase: string, walletIndex = 0): Address {
     if (this.phrase !== phrase) {
       if (!xchainCrypto.validatePhrase(phrase)) {
         throw new Error('Invalid phrase')
@@ -243,8 +249,9 @@ class Client implements ThorchainClient, XChainClient {
    * @throws {"Phrase not set"}
    * Throws an error if phrase has not been set before
    * */
-  private getPrivateKey = (index = 0): PrivKey =>
-    this.cosmosClient.getPrivKeyFromMnemonic(this.phrase, this.getFullDerivationPath(index))
+  private getPrivateKey(index = 0): PrivKey {
+    return this.cosmosClient.getPrivKeyFromMnemonic(this.phrase, this.getFullDerivationPath(index))
+  }
 
   /**
    * Get the current address.
@@ -253,7 +260,7 @@ class Client implements ThorchainClient, XChainClient {
    *
    * @throws {Error} Thrown if phrase has not been set before. A phrase is needed to create a wallet and to derive an address from it.
    */
-  getAddress = (index = 0): string => {
+  getAddress(index = 0): string {
     const address = this.cosmosClient.getAddressFromMnemonic(this.phrase, this.getFullDerivationPath(index))
     if (!address) {
       throw new Error('address not defined')
@@ -268,7 +275,7 @@ class Client implements ThorchainClient, XChainClient {
    * @param {Address} address
    * @returns {boolean} `true` or `false`
    */
-  validateAddress = (address: Address): boolean => {
+  validateAddress(address: Address): boolean {
     return this.cosmosClient.checkAddress(address)
   }
 
@@ -279,7 +286,7 @@ class Client implements ThorchainClient, XChainClient {
    * @param {Asset} asset If not set, it will return all assets available. (optional)
    * @returns {Array<Balance>} The balance of the address.
    */
-  getBalance = async (address: Address, assets?: Asset[]): Promise<Balances> => {
+  async getBalance(address: Address, assets?: Asset[]): Promise<Balances> {
     try {
       const balances = await this.cosmosClient.getBalance(address)
       return balances
@@ -372,7 +379,7 @@ class Client implements ThorchainClient, XChainClient {
    * @param {string} txId The transaction id.
    * @returns {Tx} The transaction details of the given transaction id.
    */
-  getTransactionData = async (txId: string, address: Address): Promise<Tx> => {
+  async getTransactionData(txId: string, address: Address): Promise<Tx> {
     try {
       const txResult = await this.cosmosClient.txsHashGet(txId)
       const txData: TxData | null = txResult.logs ? getDepositTxDataFromLogs(txResult.logs, address) : null
@@ -404,7 +411,7 @@ class Client implements ThorchainClient, XChainClient {
    * @param {string} txId The transaction id.
    * @returns {Tx} The transaction details of the given transaction id.
    */
-  getDepositTransaction = async (txId: string): Promise<Omit<Tx, 'date'>> => {
+  async getDepositTransaction(txId: string): Promise<Omit<Tx, 'date'>> {
     try {
       const result: TxResult = await axios
         .get(`${this.getClientUrl().node}/thorchain/tx/${txId}`)
@@ -449,7 +456,7 @@ class Client implements ThorchainClient, XChainClient {
    *
    * @throws {"Invalid client url"} Thrown if the client url is an invalid one.
    */
-  private buildDepositTx = async (msgNativeTx: MsgNativeTx): Promise<StdTx> => {
+  private async buildDepositTx(msgNativeTx: MsgNativeTx): Promise<StdTx> {
     try {
       const response: ThorchainDepositResponse = await axios
         .post(`${this.getClientUrl().node}/thorchain/deposit`, {
@@ -488,7 +495,7 @@ class Client implements ThorchainClient, XChainClient {
    * @throws {"insufficient funds"} Thrown if the wallet has insufficient funds.
    * @throws {"failed to broadcast transaction"} Thrown if failed to broadcast transaction.
    */
-  deposit = async ({ walletIndex = 0, asset = AssetRune, amount, memo }: DepositParam): Promise<TxHash> => {
+  async deposit({ walletIndex = 0, asset = AssetRune, amount, memo }: DepositParam): Promise<TxHash> {
     try {
       const assetBalance = await this.getBalance(this.getAddress(walletIndex), [asset])
 
@@ -529,7 +536,7 @@ class Client implements ThorchainClient, XChainClient {
    * @param {TxParams} params The transfer options.
    * @returns {TxHash} The transaction hash.
    */
-  transfer = async ({ walletIndex = 0, asset = AssetRune, amount, recipient, memo }: TxParams): Promise<TxHash> => {
+  async transfer({ walletIndex = 0, asset = AssetRune, amount, recipient, memo }: TxParams): Promise<TxHash> {
     try {
       registerCodecs(this.network)
 
@@ -567,7 +574,7 @@ class Client implements ThorchainClient, XChainClient {
    *
    * @returns {Fees}
    */
-  getFees = async (): Promise<Fees> => {
+  async getFees(): Promise<Fees> {
     return Promise.resolve(getDefaultFees())
   }
 }


### PR DESCRIPTION
Finishes removing fat-arrow methods throughout the codebase; this was started by #380. Using fat-arrow methods assigned as fields implicitly binds their value of `this` to the value present in the constructor; this can cause unexpected interactions with the JS prototype inheritance model.

(This is a part of the changeset currently known as #376; I'm working on factoring out some of its parts that are separable concerns and make the diffs hard to read if all rolled into one thing.)