### PR TITLE
Remove unhelpful try/catch statements

### DIFF
--- a/packages/xchain-bitcoin/src/blockstream-api.ts
+++ b/packages/xchain-bitcoin/src/blockstream-api.ts
@@ -10,11 +10,7 @@ import { BroadcastTxParams } from './types/common'
  * @returns {string} Transaction ID.
  */
 export const broadcastTx = async ({ network, txHex, blockstreamUrl }: BroadcastTxParams): Promise<string> => {
-  try {
-    const url = network === 'testnet' ? `${blockstreamUrl}/testnet/api/tx` : `${blockstreamUrl}/api/tx`
-    const txid: string = (await axios.post(url, txHex)).data
-    return txid
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const url = network === 'testnet' ? `${blockstreamUrl}/testnet/api/tx` : `${blockstreamUrl}/api/tx`
+  const txid: string = (await axios.post(url, txHex)).data
+  return txid
 }

--- a/packages/xchain-bitcoin/src/haskoin-api.ts
+++ b/packages/xchain-bitcoin/src/haskoin-api.ts
@@ -42,27 +42,23 @@ export const getUnspentTxs = async (address: string): Promise<UtxoData[]> => {
 }
 
 export const getConfirmedUnspentTxs = async (address: string): Promise<UtxoData[]> => {
-  try {
-    const allUtxos = await getUnspentTxs(address)
+  const allUtxos = await getUnspentTxs(address)
 
-    const confirmedUTXOs: UtxoData[] = []
+  const confirmedUTXOs: UtxoData[] = []
 
-    await Promise.all(
-      allUtxos.map(async (tx: UtxoData) => {
-        const { is_confirmed: isTxConfirmed } = await getIsTxConfirmed({
-          sochainUrl: SOCHAIN_API_URL,
-          network: 'mainnet',
-          hash: tx.txid,
-        })
+  await Promise.all(
+    allUtxos.map(async (tx: UtxoData) => {
+      const { is_confirmed: isTxConfirmed } = await getIsTxConfirmed({
+        sochainUrl: SOCHAIN_API_URL,
+        network: 'mainnet',
+        hash: tx.txid,
+      })
 
-        if (isTxConfirmed) {
-          confirmedUTXOs.push(tx)
-        }
-      }),
-    )
+      if (isTxConfirmed) {
+        confirmedUTXOs.push(tx)
+      }
+    }),
+  )
 
-    return confirmedUTXOs
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  return confirmedUTXOs
 }

--- a/packages/xchain-bitcoin/src/ledger.ts
+++ b/packages/xchain-bitcoin/src/ledger.ts
@@ -8,14 +8,10 @@ import * as Utils from './utils'
  * @returns {LedgerTxInfo} The transaction info used for ledger sign.
  */
 export const createTxInfo = async (params: LedgerTxInfoParams): Promise<LedgerTxInfo> => {
-  try {
-    const { psbt, utxos } = await Utils.buildTx(params)
+  const { psbt, utxos } = await Utils.buildTx(params)
 
-    return {
-      utxos,
-      newTxHex: psbt.data.globalMap.unsignedTx.toBuffer().toString('hex'),
-    }
-  } catch (e) {
-    return Promise.reject(e)
+  return {
+    utxos,
+    newTxHex: psbt.data.globalMap.unsignedTx.toBuffer().toString('hex'),
   }
 }

--- a/packages/xchain-bitcoin/src/sochain-api.ts
+++ b/packages/xchain-bitcoin/src/sochain-api.ts
@@ -31,14 +31,10 @@ const toSochainNetwork = (net: string): string => {
  * @returns {BtcAddressDTO}
  */
 export const getAddress = async ({ sochainUrl, network, address }: AddressParams): Promise<BtcAddressDTO> => {
-  try {
-    const url = `${sochainUrl}/address/${toSochainNetwork(network)}/${address}`
-    const response = await axios.get(url)
-    const addressResponse: SochainResponse<BtcAddressDTO> = response.data
-    return addressResponse.data
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const url = `${sochainUrl}/address/${toSochainNetwork(network)}/${address}`
+  const response = await axios.get(url)
+  const addressResponse: SochainResponse<BtcAddressDTO> = response.data
+  return addressResponse.data
 }
 
 /**
@@ -52,14 +48,10 @@ export const getAddress = async ({ sochainUrl, network, address }: AddressParams
  * @returns {Transactions}
  */
 export const getTx = async ({ sochainUrl, network, hash }: TxHashParams): Promise<Transaction> => {
-  try {
-    const url = `${sochainUrl}/get_tx/${toSochainNetwork(network)}/${hash}`
-    const response = await axios.get(url)
-    const tx: SochainResponse<Transaction> = response.data
-    return tx.data
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const url = `${sochainUrl}/get_tx/${toSochainNetwork(network)}/${hash}`
+  const response = await axios.get(url)
+  const tx: SochainResponse<Transaction> = response.data
+  return tx.data
 }
 
 /**
@@ -73,18 +65,14 @@ export const getTx = async ({ sochainUrl, network, hash }: TxHashParams): Promis
  * @returns {number}
  */
 export const getBalance = async ({ sochainUrl, network, address }: AddressParams): Promise<BaseAmount> => {
-  try {
-    const url = `${sochainUrl}/get_address_balance/${toSochainNetwork(network)}/${address}`
-    const response = await axios.get(url)
-    const balanceResponse: SochainResponse<BtcGetBalanceDTO> = response.data
-    const confirmed = assetAmount(balanceResponse.data.confirmed_balance, BTC_DECIMAL)
-    const unconfirmed = assetAmount(balanceResponse.data.unconfirmed_balance, BTC_DECIMAL)
-    const netAmt = confirmed.amount().plus(unconfirmed.amount())
-    const result = assetToBase(assetAmount(netAmt, BTC_DECIMAL))
-    return result
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const url = `${sochainUrl}/get_address_balance/${toSochainNetwork(network)}/${address}`
+  const response = await axios.get(url)
+  const balanceResponse: SochainResponse<BtcGetBalanceDTO> = response.data
+  const confirmed = assetAmount(balanceResponse.data.confirmed_balance, BTC_DECIMAL)
+  const unconfirmed = assetAmount(balanceResponse.data.unconfirmed_balance, BTC_DECIMAL)
+  const netAmt = confirmed.amount().plus(unconfirmed.amount())
+  const result = assetToBase(assetAmount(netAmt, BTC_DECIMAL))
+  return result
 }
 
 /**
@@ -103,31 +91,27 @@ export const getUnspentTxs = async ({
   address,
   startingFromTxId,
 }: AddressParams): Promise<BtcAddressUTXOs> => {
-  try {
-    let resp = null
-    if (startingFromTxId) {
-      resp = await axios.get(`${sochainUrl}/get_tx_unspent/${toSochainNetwork(network)}/${address}/${startingFromTxId}`)
-    } else {
-      resp = await axios.get(`${sochainUrl}/get_tx_unspent/${toSochainNetwork(network)}/${address}`)
-    }
-    const response: SochainResponse<BtcUnspentTxsDTO> = resp.data
-    const txs = response.data.txs
-    if (txs.length === 100) {
-      //fetch the next batch
-      const lastTxId = txs[99].txid
+  let resp = null
+  if (startingFromTxId) {
+    resp = await axios.get(`${sochainUrl}/get_tx_unspent/${toSochainNetwork(network)}/${address}/${startingFromTxId}`)
+  } else {
+    resp = await axios.get(`${sochainUrl}/get_tx_unspent/${toSochainNetwork(network)}/${address}`)
+  }
+  const response: SochainResponse<BtcUnspentTxsDTO> = resp.data
+  const txs = response.data.txs
+  if (txs.length === 100) {
+    //fetch the next batch
+    const lastTxId = txs[99].txid
 
-      const nextBatch = await getUnspentTxs({
-        sochainUrl,
-        network,
-        address,
-        startingFromTxId: lastTxId,
-      })
-      return txs.concat(nextBatch)
-    } else {
-      return txs
-    }
-  } catch (error) {
-    return Promise.reject(error)
+    const nextBatch = await getUnspentTxs({
+      sochainUrl,
+      network,
+      address,
+      startingFromTxId: lastTxId,
+    })
+    return txs.concat(nextBatch)
+  } else {
+    return txs
   }
 }
 
@@ -142,14 +126,10 @@ export const getUnspentTxs = async ({
  * @returns {TxConfirmedStatus}
  */
 export const getIsTxConfirmed = async ({ sochainUrl, network, hash }: TxHashParams): Promise<TxConfirmedStatus> => {
-  try {
-    const { data } = await axios.get<SochainResponse<TxConfirmedStatus>>(
-      `${sochainUrl}/is_tx_confirmed/${toSochainNetwork(network)}/${hash}`,
-    )
-    return data.data
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const { data } = await axios.get<SochainResponse<TxConfirmedStatus>>(
+    `${sochainUrl}/is_tx_confirmed/${toSochainNetwork(network)}/${hash}`,
+  )
+  return data.data
 }
 
 /**
@@ -167,33 +147,29 @@ export const getConfirmedUnspentTxs = async ({
   network,
   address,
 }: AddressParams): Promise<BtcAddressUTXOs> => {
-  try {
-    const txs = await getUnspentTxs({
-      sochainUrl,
-      network,
-      address,
-    })
+  const txs = await getUnspentTxs({
+    sochainUrl,
+    network,
+    address,
+  })
 
-    const confirmedUTXOs: BtcAddressUTXOs = []
+  const confirmedUTXOs: BtcAddressUTXOs = []
 
-    await Promise.all(
-      txs.map(async (tx: BtcAddressUTXO) => {
-        const { is_confirmed: isTxConfirmed } = await getIsTxConfirmed({
-          sochainUrl,
-          network,
-          hash: tx.txid,
-        })
+  await Promise.all(
+    txs.map(async (tx: BtcAddressUTXO) => {
+      const { is_confirmed: isTxConfirmed } = await getIsTxConfirmed({
+        sochainUrl,
+        network,
+        hash: tx.txid,
+      })
 
-        if (isTxConfirmed) {
-          confirmedUTXOs.push(tx)
-        }
-      }),
-    )
+      if (isTxConfirmed) {
+        confirmedUTXOs.push(tx)
+      }
+    }),
+  )
 
-    return confirmedUTXOs
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  return confirmedUTXOs
 }
 
 /**

--- a/packages/xchain-bitcoin/src/utils.ts
+++ b/packages/xchain-bitcoin/src/utils.ts
@@ -113,18 +113,14 @@ export const btcNetwork = (network: Network): Bitcoin.Network => {
  * @returns {Array<Balance>} The balances of the given address.
  */
 export const getBalance = async (params: AddressParams): Promise<Balance[]> => {
-  try {
-    const balance =
-      params.network === 'testnet' ? await sochain.getBalance(params) : await haskoinApi.getBalance(params.address)
-    return [
-      {
-        asset: AssetBTC,
-        amount: balance,
-      },
-    ]
-  } catch (error) {
-    return Promise.reject(new Error('Invalid address'))
-  }
+  const balance =
+    params.network === 'testnet' ? await sochain.getBalance(params) : await haskoinApi.getBalance(params.address)
+  return [
+    {
+      asset: AssetBTC,
+      amount: balance,
+    },
+  ]
 }
 
 /**
@@ -229,72 +225,61 @@ export const buildTx = async ({
   sochainUrl: string
   spendPendingUTXO?: boolean
 }): Promise<{ psbt: Bitcoin.Psbt; utxos: UTXOs }> => {
-  try {
-    // search only confirmed UTXOs if pending UTXO is not allowed
-    const confirmedOnly = !spendPendingUTXO
-    const utxos = await scanUTXOs({ sochainUrl, network, address: sender, confirmedOnly })
+  // search only confirmed UTXOs if pending UTXO is not allowed
+  const confirmedOnly = !spendPendingUTXO
+  const utxos = await scanUTXOs({ sochainUrl, network, address: sender, confirmedOnly })
 
-    if (utxos.length === 0) {
-      return Promise.reject(Error('No utxos to send'))
-    }
+  if (utxos.length === 0) throw new Error('No utxos to send')
+  if (!validateAddress(recipient, network)) throw new Error('Invalid address')
 
-    if (!validateAddress(recipient, network)) {
-      return Promise.reject(new Error('Invalid address'))
-    }
+  const feeRateWhole = Number(feeRate.toFixed(0))
+  const compiledMemo = memo ? compileMemo(memo) : null
 
-    const feeRateWhole = Number(feeRate.toFixed(0))
-    const compiledMemo = memo ? compileMemo(memo) : null
+  const targetOutputs = []
 
-    const targetOutputs = []
-
-    //1. add output amount and recipient to targets
-    targetOutputs.push({
-      address: recipient,
-      value: amount.amount().toNumber(),
-    })
-    //2. add output memo to targets (optional)
-    if (compiledMemo) {
-      targetOutputs.push({ script: compiledMemo, value: 0 })
-    }
-    const { inputs, outputs } = accumulative(utxos, targetOutputs, feeRateWhole)
-
-    // .inputs and .outputs will be undefined if no solution was found
-    if (!inputs || !outputs) {
-      return Promise.reject(Error('Insufficient Balance for transaction'))
-    }
-
-    const psbt = new Bitcoin.Psbt({ network: btcNetwork(network) }) // Network-specific
-
-    // psbt add input from accumulative inputs
-    inputs.forEach((utxo: UTXO) =>
-      psbt.addInput({
-        hash: utxo.hash,
-        index: utxo.index,
-        witnessUtxo: utxo.witnessUtxo,
-      }),
-    )
-
-    // psbt add outputs from accumulative outputs
-    outputs.forEach((output: Bitcoin.PsbtTxOutput) => {
-      if (!output.address) {
-        //an empty address means this is the  change ddress
-        output.address = sender
-      }
-      if (!output.script) {
-        psbt.addOutput(output)
-      } else {
-        //we need to add the compiled memo this way to
-        //avoid dust error tx when accumulating memo output with 0 value
-        if (compiledMemo) {
-          psbt.addOutput({ script: compiledMemo, value: 0 })
-        }
-      }
-    })
-
-    return { psbt, utxos }
-  } catch (e) {
-    return Promise.reject(e)
+  //1. add output amount and recipient to targets
+  targetOutputs.push({
+    address: recipient,
+    value: amount.amount().toNumber(),
+  })
+  //2. add output memo to targets (optional)
+  if (compiledMemo) {
+    targetOutputs.push({ script: compiledMemo, value: 0 })
   }
+  const { inputs, outputs } = accumulative(utxos, targetOutputs, feeRateWhole)
+
+  // .inputs and .outputs will be undefined if no solution was found
+  if (!inputs || !outputs) throw new Error('Insufficient Balance for transaction')
+
+  const psbt = new Bitcoin.Psbt({ network: btcNetwork(network) }) // Network-specific
+
+  // psbt add input from accumulative inputs
+  inputs.forEach((utxo: UTXO) =>
+    psbt.addInput({
+      hash: utxo.hash,
+      index: utxo.index,
+      witnessUtxo: utxo.witnessUtxo,
+    }),
+  )
+
+  // psbt add outputs from accumulative outputs
+  outputs.forEach((output: Bitcoin.PsbtTxOutput) => {
+    if (!output.address) {
+      //an empty address means this is the  change ddress
+      output.address = sender
+    }
+    if (!output.script) {
+      psbt.addOutput(output)
+    } else {
+      //we need to add the compiled memo this way to
+      //avoid dust error tx when accumulating memo output with 0 value
+      if (compiledMemo) {
+        psbt.addOutput({ script: compiledMemo, value: 0 })
+      }
+    }
+  })
+
+  return { psbt, utxos }
 }
 
 /**

--- a/packages/xchain-bitcoincash/src/client.ts
+++ b/packages/xchain-bitcoincash/src/client.ts
@@ -235,7 +235,8 @@ class Client extends BaseXChainClient implements BitcoinCashClient, XChainClient
       params: { offset, limit },
     })
 
-    if (!account || !txs) throw new Error('Invalid address')
+    if (!account) throw new Error(`Invalid address: ${address}`)
+    if (!txs) throw new Error(`Transactions could not found for address ${address}`)
 
     return {
       total: account.txs,

--- a/packages/xchain-bitcoincash/src/haskoin-api.ts
+++ b/packages/xchain-bitcoincash/src/haskoin-api.ts
@@ -10,6 +10,8 @@ import {
 } from './types'
 import { DEFAULT_SUGGESTED_TRANSACTION_FEE } from './utils'
 
+type ErrorResponse = { error: unknown }
+
 /**
  * Check error response.
  *
@@ -17,7 +19,7 @@ import { DEFAULT_SUGGESTED_TRANSACTION_FEE } from './utils'
  * @returns {boolean}
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const isErrorResponse = (response: any): boolean => {
+const isErrorResponse = (response: any): response is ErrorResponse => {
   return !!response.error
 }
 
@@ -31,19 +33,9 @@ const isErrorResponse = (response: any): boolean => {
  * @throws {"failed to query account by a given address"} thrown if failed to query account by a given address
  */
 export const getAccount = async ({ haskoinUrl, address }: AddressParams): Promise<AddressBalance> => {
-  try {
-    const result: AddressBalance | null = await axios
-      .get(`${haskoinUrl}/address/${address}/balance`)
-      .then((response) => (isErrorResponse(response.data) ? null : response.data))
-
-    if (!result) {
-      throw new Error('failed to query account by a given address')
-    }
-
-    return result
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const result: AddressBalance | ErrorResponse = (await axios.get(`${haskoinUrl}/address/${address}/balance`)).data
+  if (!result || isErrorResponse(result)) throw new Error('failed to query account by a given address')
+  return result
 }
 
 /**
@@ -56,19 +48,9 @@ export const getAccount = async ({ haskoinUrl, address }: AddressParams): Promis
  * @throws {"failed to query transaction by a given hash"} thrown if failed to query transaction by a given hash
  */
 export const getTransaction = async ({ haskoinUrl, txId }: TxHashParams): Promise<Transaction> => {
-  try {
-    const result: Transaction | null = await axios
-      .get(`${haskoinUrl}/transaction/${txId}`)
-      .then((response) => (isErrorResponse(response.data) ? null : response.data))
-
-    if (!result) {
-      throw new Error('failed to query transaction by a given hash')
-    }
-
-    return result
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const result: Transaction | ErrorResponse = (await axios.get(`${haskoinUrl}/transaction/${txId}`)).data
+  if (!result || isErrorResponse(result)) throw new Error('failed to query transaction by a given hash')
+  return result
 }
 
 /**
@@ -81,19 +63,9 @@ export const getTransaction = async ({ haskoinUrl, txId }: TxHashParams): Promis
  * @throws {"failed to query transaction by a given hash"} thrown if failed to query raw transaction by a given hash
  */
 export const getRawTransaction = async ({ haskoinUrl, txId }: TxHashParams): Promise<string> => {
-  try {
-    const result: RawTransaction | null = await axios
-      .get(`${haskoinUrl}/transaction/${txId}/raw`)
-      .then((response) => (isErrorResponse(response.data) ? null : response.data))
-
-    if (!result) {
-      throw new Error('failed to query transaction by a given hash')
-    }
-
-    return result.result
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const result: RawTransaction | ErrorResponse = (await axios.get(`${haskoinUrl}/transaction/${txId}/raw`)).data
+  if (!result || isErrorResponse(result)) throw new Error('failed to query transaction by a given hash')
+  return result.result
 }
 
 /**
@@ -111,21 +83,11 @@ export const getTransactions = async ({
   address,
   params,
 }: AddressParams & { params: TransactionsQueryParam }): Promise<Transaction[]> => {
-  try {
-    const result: Transaction[] | null = await axios
-      .get(`${haskoinUrl}/address/${address}/transactions/full`, {
-        params,
-      })
-      .then((response) => (isErrorResponse(response.data) ? null : response.data))
-
-    if (!result) {
-      throw new Error('failed to query transactions')
-    }
-
-    return result
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const result: Transaction[] | ErrorResponse = (
+    await axios.get(`${haskoinUrl}/address/${address}/transactions/full`, { params })
+  ).data
+  if (!result || isErrorResponse(result)) throw new Error('failed to query transactions')
+  return result
 }
 
 /**
@@ -138,23 +100,15 @@ export const getTransactions = async ({
  * @throws {"failed to query unspent transactions"} thrown if failed to query unspent transactions
  */
 export const getUnspentTransactions = async ({ haskoinUrl, address }: AddressParams): Promise<TxUnspent[]> => {
-  try {
-    // Get transacton count for a given address.
-    const account = await getAccount({ haskoinUrl, address })
+  // Get transacton count for a given address.
+  const account = await getAccount({ haskoinUrl, address })
 
-    // Set limit to the transaction count to be all the utxos.
-    const result: TxUnspent[] | null = await axios
-      .get(`${haskoinUrl}/address/${address}/unspent?limit=${account?.utxo}`)
-      .then((response) => (isErrorResponse(response.data) ? null : response.data))
-
-    if (!result) {
-      throw new Error('failed to query unspent transactions')
-    }
-
-    return result
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  // Set limit to the transaction count to be all the utxos.
+  const result: TxUnspent[] | ErrorResponse = (
+    await axios.get(`${haskoinUrl}/address/${address}/unspent?limit${account?.utxo}`)
+  ).data
+  if (!result || isErrorResponse(result)) throw new Error('failed to query unspent transactions')
+  return result
 }
 
 /**

--- a/packages/xchain-bitcoincash/src/haskoin-api.ts
+++ b/packages/xchain-bitcoincash/src/haskoin-api.ts
@@ -34,7 +34,7 @@ const isErrorResponse = (response: any): response is ErrorResponse => {
  */
 export const getAccount = async ({ haskoinUrl, address }: AddressParams): Promise<AddressBalance> => {
   const result: AddressBalance | ErrorResponse = (await axios.get(`${haskoinUrl}/address/${address}/balance`)).data
-  if (!result || isErrorResponse(result)) throw new Error('failed to query account by a given address')
+  if (!result || isErrorResponse(result)) throw new Error(`failed to query account by given address ${address}`)
   return result
 }
 
@@ -49,7 +49,7 @@ export const getAccount = async ({ haskoinUrl, address }: AddressParams): Promis
  */
 export const getTransaction = async ({ haskoinUrl, txId }: TxHashParams): Promise<Transaction> => {
   const result: Transaction | ErrorResponse = (await axios.get(`${haskoinUrl}/transaction/${txId}`)).data
-  if (!result || isErrorResponse(result)) throw new Error('failed to query transaction by a given hash')
+  if (!result || isErrorResponse(result)) throw new Error(`failed to query transaction by a given hash ${txId}`)
   return result
 }
 
@@ -64,7 +64,7 @@ export const getTransaction = async ({ haskoinUrl, txId }: TxHashParams): Promis
  */
 export const getRawTransaction = async ({ haskoinUrl, txId }: TxHashParams): Promise<string> => {
   const result: RawTransaction | ErrorResponse = (await axios.get(`${haskoinUrl}/transaction/${txId}/raw`)).data
-  if (!result || isErrorResponse(result)) throw new Error('failed to query transaction by a given hash')
+  if (!result || isErrorResponse(result)) throw new Error(`failed to query transaction by a given hash ${txId}`)
   return result.result
 }
 

--- a/packages/xchain-bitcoincash/src/node-api.ts
+++ b/packages/xchain-bitcoincash/src/node-api.ts
@@ -10,27 +10,23 @@ import { TxBroadcastResponse, TxBroadcastParams } from './types'
  * @returns {string} Transaction ID.
  */
 export const broadcastTx = async ({ txHex, auth, nodeUrl }: TxBroadcastParams): Promise<string> => {
-  try {
-    const response: TxBroadcastResponse = (
-      await axios.post(
-        nodeUrl,
-        {
-          jsonrpc: '2.0',
-          method: 'sendrawtransaction',
-          params: [txHex],
-          id: uniqid(),
-        },
-        {
-          auth,
-        },
-      )
-    ).data
-    if (response.error) {
-      throw new Error(`failed to broadcast a transaction: ${response.error}`)
-    }
-
-    return response.result
-  } catch (error) {
-    return Promise.reject(error)
+  const response: TxBroadcastResponse = (
+    await axios.post(
+      nodeUrl,
+      {
+        jsonrpc: '2.0',
+        method: 'sendrawtransaction',
+        params: [txHex],
+        id: uniqid(),
+      },
+      {
+        auth,
+      },
+    )
+  ).data
+  if (response.error) {
+    throw new Error(`failed to broadcast a transaction: ${response.error}`)
   }
+
+  return response.result
 }

--- a/packages/xchain-bitcoincash/src/utils.ts
+++ b/packages/xchain-bitcoincash/src/utils.ts
@@ -73,7 +73,7 @@ export function getFee(inputs: number, feeRate: FeeRate, data: Buffer | null = n
  */
 export const getBalance = async (params: AddressParams): Promise<Balance[]> => {
   const account = await getAccount(params)
-  if (!account) throw new Error('No bchBalance found')
+  if (!account) throw new Error('BCH balance not found')
 
   const confirmed = baseAmount(account.confirmed, BCH_DECIMAL)
   const unconfirmed = baseAmount(account.unconfirmed, BCH_DECIMAL)

--- a/packages/xchain-cosmos/src/client.ts
+++ b/packages/xchain-cosmos/src/client.ts
@@ -239,24 +239,19 @@ class Client implements CosmosClient, XChainClient {
    * @returns {Array<Balance>} The balance of the address.
    */
   async getBalance(address: Address, assets?: Asset[]): Promise<Balances> {
-    try {
-      const balances = await this.getSDKClient().getBalance(address)
-      const mainAsset = this.getMainAsset()
+    const balances = await this.getSDKClient().getBalance(address)
+    const mainAsset = this.getMainAsset()
 
-      return balances
-        .map((balance) => {
-          return {
-            asset: (balance.denom && getAsset(balance.denom)) || mainAsset,
-            amount: baseAmount(balance.amount, DECIMAL),
-          }
-        })
-        .filter(
-          (balance) =>
-            !assets || assets.filter((asset) => assetToString(balance.asset) === assetToString(asset)).length,
-        )
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    return balances
+      .map((balance) => {
+        return {
+          asset: (balance.denom && getAsset(balance.denom)) || mainAsset,
+          amount: baseAmount(balance.amount, DECIMAL),
+        }
+      })
+      .filter(
+        (balance) => !assets || assets.filter((asset) => assetToString(balance.asset) === assetToString(asset)).length,
+      )
   }
 
   /**
@@ -273,25 +268,21 @@ class Client implements CosmosClient, XChainClient {
     const txMinHeight = undefined
     const txMaxHeight = undefined
 
-    try {
-      this.registerCodecs()
+    this.registerCodecs()
 
-      const mainAsset = this.getMainAsset()
-      const txHistory = await this.getSDKClient().searchTx({
-        messageAction,
-        messageSender: (params && params.address) || this.getAddress(),
-        page,
-        limit,
-        txMinHeight,
-        txMaxHeight,
-      })
+    const mainAsset = this.getMainAsset()
+    const txHistory = await this.getSDKClient().searchTx({
+      messageAction,
+      messageSender: (params && params.address) || this.getAddress(),
+      page,
+      limit,
+      txMinHeight,
+      txMaxHeight,
+    })
 
-      return {
-        total: parseInt(txHistory.total_count?.toString() || '0'),
-        txs: getTxsFromHistory(txHistory.txs || [], mainAsset),
-      }
-    } catch (error) {
-      return Promise.reject(error)
+    return {
+      total: parseInt(txHistory.total_count?.toString() || '0'),
+      txs: getTxsFromHistory(txHistory.txs || [], mainAsset),
     }
   }
 
@@ -302,18 +293,11 @@ class Client implements CosmosClient, XChainClient {
    * @returns {Tx} The transaction details of the given transaction id.
    */
   async getTransactionData(txId: string): Promise<Tx> {
-    try {
-      const txResult = await this.getSDKClient().txsHashGet(txId)
-      const txs = getTxsFromHistory([txResult], this.getMainAsset())
+    const txResult = await this.getSDKClient().txsHashGet(txId)
+    const txs = getTxsFromHistory([txResult], this.getMainAsset())
+    if (txs.length === 0) throw new Error('transaction not found')
 
-      if (txs.length === 0) {
-        throw new Error('transaction not found')
-      }
-
-      return txs[0]
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    return txs[0]
   }
 
   /**
@@ -323,24 +307,20 @@ class Client implements CosmosClient, XChainClient {
    * @returns {TxHash} The transaction hash.
    */
   async transfer({ walletIndex, asset, amount, recipient, memo }: TxParams): Promise<TxHash> {
-    try {
-      const fromAddressIndex = walletIndex || 0
-      this.registerCodecs()
+    const fromAddressIndex = walletIndex || 0
+    this.registerCodecs()
 
-      const mainAsset = this.getMainAsset()
-      const transferResult = await this.getSDKClient().transfer({
-        privkey: this.getPrivateKey(fromAddressIndex),
-        from: this.getAddress(fromAddressIndex),
-        to: recipient,
-        amount: amount.amount().toString(),
-        asset: getDenom(asset || mainAsset),
-        memo,
-      })
+    const mainAsset = this.getMainAsset()
+    const transferResult = await this.getSDKClient().transfer({
+      privkey: this.getPrivateKey(fromAddressIndex),
+      from: this.getAddress(fromAddressIndex),
+      to: recipient,
+      amount: amount.amount().toString(),
+      asset: getDenom(asset || mainAsset),
+      memo,
+    })
 
-      return transferResult?.txhash || ''
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    return transferResult?.txhash || ''
   }
 
   /**
@@ -350,12 +330,12 @@ class Client implements CosmosClient, XChainClient {
    */
   async getFees(): Promise<Fees> {
     // there is no fixed fee, we set fee amount when creating a transaction.
-    return Promise.resolve({
+    return {
       type: 'base',
       fast: baseAmount(750, DECIMAL),
       fastest: baseAmount(2500, DECIMAL),
       average: baseAmount(0, DECIMAL),
-    })
+    }
   }
 }
 

--- a/packages/xchain-crypto/src/crypto.ts
+++ b/packages/xchain-crypto/src/crypto.ts
@@ -153,30 +153,24 @@ export const encryptToKeyStore = async (phrase: string, password: string): Promi
  */
 export const decryptFromKeystore = async (keystore: Keystore, password: string): Promise<string> => {
   const kdfparams = keystore.crypto.kdfparams
-  try {
-    const derivedKey = await pbkdf2Async(
-      Buffer.from(password),
-      Buffer.from(kdfparams.salt, 'hex'),
-      kdfparams.c,
-      kdfparams.dklen,
-      hashFunction,
-    )
+  const derivedKey = await pbkdf2Async(
+    Buffer.from(password),
+    Buffer.from(kdfparams.salt, 'hex'),
+    kdfparams.c,
+    kdfparams.dklen,
+    hashFunction,
+  )
 
-    const ciphertext = Buffer.from(keystore.crypto.ciphertext, 'hex')
-    const mac = blake256(Buffer.concat([derivedKey.slice(16, 32), ciphertext]))
+  const ciphertext = Buffer.from(keystore.crypto.ciphertext, 'hex')
+  const mac = blake256(Buffer.concat([derivedKey.slice(16, 32), ciphertext]))
 
-    if (mac !== keystore.crypto.mac) {
-      return Promise.reject('Invalid password')
-    }
-    const decipher = crypto.createDecipheriv(
-      keystore.crypto.cipher,
-      derivedKey.slice(0, 16),
-      Buffer.from(keystore.crypto.cipherparams.iv, 'hex'),
-    )
+  if (mac !== keystore.crypto.mac) throw new Error('Invalid password')
+  const decipher = crypto.createDecipheriv(
+    keystore.crypto.cipher,
+    derivedKey.slice(0, 16),
+    Buffer.from(keystore.crypto.cipherparams.iv, 'hex'),
+  )
 
-    const phrase = Buffer.concat([decipher.update(ciphertext), decipher.final()])
-    return Promise.resolve(phrase.toString('utf8'))
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const phrase = Buffer.concat([decipher.update(ciphertext), decipher.final()])
+  return phrase.toString('utf8')
 }

--- a/packages/xchain-ethereum/src/ethplorer-api.ts
+++ b/packages/xchain-ethereum/src/ethplorer-api.ts
@@ -12,16 +12,12 @@ import { AddressInfo, TransactionInfo, TransactionOperation } from './types'
  * @returns {AddressInfo} The address information.
  */
 export const getAddress = async (baseUrl: string, address: string, apiKey?: string): Promise<AddressInfo> => {
-  try {
-    const response = await axios.get(`${baseUrl}/getAddressInfo/${address}`, {
-      params: {
-        apiKey: apiKey || 'freekey',
-      },
-    })
-    return response.data
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const response = await axios.get(`${baseUrl}/getAddressInfo/${address}`, {
+    params: {
+      apiKey: apiKey || 'freekey',
+    },
+  })
+  return response.data
 }
 
 /**
@@ -35,16 +31,12 @@ export const getAddress = async (baseUrl: string, address: string, apiKey?: stri
  * @returns {Transactions} The transaction result.
  */
 export const getTxInfo = async (baseUrl: string, hash: string, apiKey?: string): Promise<TransactionInfo> => {
-  try {
-    const response = await axios.get(`${baseUrl}/getTxInfo/${hash}`, {
-      params: {
-        apiKey: apiKey || 'freekey',
-      },
-    })
-    return response.data
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const response = await axios.get(`${baseUrl}/getTxInfo/${hash}`, {
+    params: {
+      apiKey: apiKey || 'freekey',
+    },
+  })
+  return response.data
 }
 
 /**
@@ -66,18 +58,14 @@ export const getAddressTransactions = async (
   timestamp?: number,
   apiKey?: string,
 ): Promise<TransactionInfo[]> => {
-  try {
-    const response = await axios.get(`${baseUrl}/getAddressTransactions/${address}`, {
-      params: {
-        apiKey: apiKey || 'freekey',
-        limit,
-        timestamp,
-      },
-    })
-    return response.data
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const response = await axios.get(`${baseUrl}/getAddressTransactions/${address}`, {
+    params: {
+      apiKey: apiKey || 'freekey',
+      limit,
+      timestamp,
+    },
+  })
+  return response.data
 }
 
 /**
@@ -101,19 +89,15 @@ export const getAddressHistory = async (
   timestamp?: number,
   apiKey?: string,
 ): Promise<TransactionOperation[]> => {
-  try {
-    const response = await axios.get(`${baseUrl}/getAddressHistory/${address}`, {
-      params: {
-        apiKey: apiKey || 'freekey',
-        token,
-        limit,
-        timestamp,
-        showZeroValues: true,
-        type: 'transfer',
-      },
-    })
-    return response.data.operations
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const response = await axios.get(`${baseUrl}/getAddressHistory/${address}`, {
+    params: {
+      apiKey: apiKey || 'freekey',
+      token,
+      limit,
+      timestamp,
+      showZeroValues: true,
+      type: 'transfer',
+    },
+  })
+  return response.data.operations
 }

--- a/packages/xchain-ethereum/src/utils.ts
+++ b/packages/xchain-ethereum/src/utils.ts
@@ -333,26 +333,17 @@ export const filterSelfTxs = <T extends { from: string; to: string; hash: string
  * @returns {Number} the decimal of a given asset
  *
  * @throws {"Invalid asset"} Thrown if the given asset is invalid
- * @throws {"Invalid provider"} Thrown if the given provider is invalid
  */
 export const getDecimal = async (asset: Asset, provider: providers.Provider): Promise<number> => {
-  if (assetToString(asset) === assetToString(AssetETH)) {
-    return Promise.resolve(ETH_DECIMAL)
-  }
+  if (assetToString(asset) === assetToString(AssetETH)) return ETH_DECIMAL
 
   const assetAddress = getTokenAddress(asset)
-  if (!assetAddress) {
-    throw new Error(`Invalid asset ${assetToString(asset)}`)
-  }
+  if (!assetAddress) throw new Error(`Invalid asset ${assetToString(asset)}`)
 
-  try {
-    const contract: ethers.Contract = new ethers.Contract(assetAddress, erc20ABI, provider)
-    const decimal: ethers.BigNumberish = await contract.decimals()
+  const contract: ethers.Contract = new ethers.Contract(assetAddress, erc20ABI, provider)
+  const decimal: ethers.BigNumberish = await contract.decimals()
 
-    return ethers.BigNumber.from(decimal).toNumber()
-  } catch (err) {
-    throw new Error(`Invalid provider: ${err}`)
-  }
+  return ethers.BigNumber.from(decimal).toNumber()
 }
 
 /**

--- a/packages/xchain-litecoin/__tests__/client.test.ts
+++ b/packages/xchain-litecoin/__tests__/client.test.ts
@@ -219,7 +219,7 @@ describe('LitecoinClient Test', () => {
     ltcClient.setNetwork('testnet')
     ltcClient.setPhrase(phraseOne)
     const invalidAddress = 'error_address'
-    const expectedError = 'Invalid address'
+    const expectedError = 'Could not get balances for address error_address'
     return expect(ltcClient.getBalance(invalidAddress)).rejects.toThrow(expectedError)
   })
 

--- a/packages/xchain-litecoin/src/ledger.ts
+++ b/packages/xchain-litecoin/src/ledger.ts
@@ -8,14 +8,10 @@ import * as Utils from './utils'
  * @returns {LedgerTxInfo} The transaction info used for ledger sign.
  */
 export const createTxInfo = async (params: LedgerTxInfoParams): Promise<LedgerTxInfo> => {
-  try {
-    const { psbt, utxos } = await Utils.buildTx(params)
+  const { psbt, utxos } = await Utils.buildTx(params)
 
-    return {
-      utxos,
-      newTxHex: psbt.data.globalMap.unsignedTx.toBuffer().toString('hex'),
-    }
-  } catch (e) {
-    return Promise.reject(e)
+  return {
+    utxos,
+    newTxHex: psbt.data.globalMap.unsignedTx.toBuffer().toString('hex'),
   }
 }

--- a/packages/xchain-litecoin/src/node-api.ts
+++ b/packages/xchain-litecoin/src/node-api.ts
@@ -10,28 +10,24 @@ import { BroadcastTxParams } from './types/common'
  * @returns {string} Transaction ID.
  */
 export const broadcastTx = async ({ txHex, auth, nodeUrl }: BroadcastTxParams): Promise<string> => {
-  try {
-    const uniqueId = new Date().getTime().toString() // for unique id
-    const response: TxBroadcastResponse = (
-      await axios.post(
-        nodeUrl,
-        {
-          jsonrpc: '2.0',
-          method: 'sendrawtransaction',
-          params: [txHex],
-          id: uniqueId,
-        },
-        {
-          auth,
-        },
-      )
-    ).data
-    if (response.error) {
-      throw new Error(`failed to broadcast a transaction: ${response.error}`)
-    }
-
-    return response.result
-  } catch (error) {
-    return Promise.reject(error)
+  const uniqueId = new Date().getTime().toString() // for unique id
+  const response: TxBroadcastResponse = (
+    await axios.post(
+      nodeUrl,
+      {
+        jsonrpc: '2.0',
+        method: 'sendrawtransaction',
+        params: [txHex],
+        id: uniqueId,
+      },
+      {
+        auth,
+      },
+    )
+  ).data
+  if (response.error) {
+    throw new Error(`failed to broadcast a transaction: ${response.error}`)
   }
+
+  return response.result
 }

--- a/packages/xchain-litecoin/src/sochain-api.ts
+++ b/packages/xchain-litecoin/src/sochain-api.ts
@@ -29,14 +29,10 @@ const toSochainNetwork = (net: string): string => {
  * @returns {LtcAddressDTO}
  */
 export const getAddress = async ({ sochainUrl, network, address }: AddressParams): Promise<LtcAddressDTO> => {
-  try {
-    const url = `${sochainUrl}/address/${toSochainNetwork(network)}/${address}`
-    const response = await axios.get(url)
-    const addressResponse: SochainResponse<LtcAddressDTO> = response.data
-    return addressResponse.data
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const url = `${sochainUrl}/address/${toSochainNetwork(network)}/${address}`
+  const response = await axios.get(url)
+  const addressResponse: SochainResponse<LtcAddressDTO> = response.data
+  return addressResponse.data
 }
 
 /**
@@ -50,14 +46,10 @@ export const getAddress = async ({ sochainUrl, network, address }: AddressParams
  * @returns {Transactions}
  */
 export const getTx = async ({ sochainUrl, network, hash }: TxHashParams): Promise<Transaction> => {
-  try {
-    const url = `${sochainUrl}/get_tx/${toSochainNetwork(network)}/${hash}`
-    const response = await axios.get(url)
-    const tx: SochainResponse<Transaction> = response.data
-    return tx.data
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const url = `${sochainUrl}/get_tx/${toSochainNetwork(network)}/${hash}`
+  const response = await axios.get(url)
+  const tx: SochainResponse<Transaction> = response.data
+  return tx.data
 }
 
 /**
@@ -71,18 +63,14 @@ export const getTx = async ({ sochainUrl, network, hash }: TxHashParams): Promis
  * @returns {number}
  */
 export const getBalance = async ({ sochainUrl, network, address }: AddressParams): Promise<BaseAmount> => {
-  try {
-    const url = `${sochainUrl}/get_address_balance/${toSochainNetwork(network)}/${address}`
-    const response = await axios.get(url)
-    const balanceResponse: SochainResponse<LtcGetBalanceDTO> = response.data
-    const confirmed = assetAmount(balanceResponse.data.confirmed_balance, LTC_DECIMAL)
-    const unconfirmed = assetAmount(balanceResponse.data.unconfirmed_balance, LTC_DECIMAL)
-    const netAmt = confirmed.amount().plus(unconfirmed.amount())
-    const result = assetToBase(assetAmount(netAmt, LTC_DECIMAL))
-    return result
-  } catch (error) {
-    return Promise.reject(error)
-  }
+  const url = `${sochainUrl}/get_address_balance/${toSochainNetwork(network)}/${address}`
+  const response = await axios.get(url)
+  const balanceResponse: SochainResponse<LtcGetBalanceDTO> = response.data
+  const confirmed = assetAmount(balanceResponse.data.confirmed_balance, LTC_DECIMAL)
+  const unconfirmed = assetAmount(balanceResponse.data.unconfirmed_balance, LTC_DECIMAL)
+  const netAmt = confirmed.amount().plus(unconfirmed.amount())
+  const result = assetToBase(assetAmount(netAmt, LTC_DECIMAL))
+  return result
 }
 
 /**
@@ -101,31 +89,27 @@ export const getUnspentTxs = async ({
   address,
   startingFromTxId,
 }: AddressParams): Promise<LtcAddressUTXOs> => {
-  try {
-    let resp = null
-    if (startingFromTxId) {
-      resp = await axios.get(`${sochainUrl}/get_tx_unspent/${toSochainNetwork(network)}/${address}/${startingFromTxId}`)
-    } else {
-      resp = await axios.get(`${sochainUrl}/get_tx_unspent/${toSochainNetwork(network)}/${address}`)
-    }
-    const response: SochainResponse<LtcUnspentTxsDTO> = resp.data
-    const txs = response.data.txs
-    if (txs.length === 100) {
-      //fetch the next batch
-      const lastTxId = txs[99].txid
+  let resp = null
+  if (startingFromTxId) {
+    resp = await axios.get(`${sochainUrl}/get_tx_unspent/${toSochainNetwork(network)}/${address}/${startingFromTxId}`)
+  } else {
+    resp = await axios.get(`${sochainUrl}/get_tx_unspent/${toSochainNetwork(network)}/${address}`)
+  }
+  const response: SochainResponse<LtcUnspentTxsDTO> = resp.data
+  const txs = response.data.txs
+  if (txs.length === 100) {
+    //fetch the next batch
+    const lastTxId = txs[99].txid
 
-      const nextBatch = await getUnspentTxs({
-        sochainUrl,
-        network,
-        address,
-        startingFromTxId: lastTxId,
-      })
-      return txs.concat(nextBatch)
-    } else {
-      return txs
-    }
-  } catch (error) {
-    return Promise.reject(error)
+    const nextBatch = await getUnspentTxs({
+      sochainUrl,
+      network,
+      address,
+      startingFromTxId: lastTxId,
+    })
+    return txs.concat(nextBatch)
+  } else {
+    return txs
   }
 }
 

--- a/packages/xchain-litecoin/src/utils.ts
+++ b/packages/xchain-litecoin/src/utils.ts
@@ -120,7 +120,7 @@ export const getBalance = async (params: AddressParams): Promise<Balance[]> => {
       },
     ]
   } catch (error) {
-    throw new Error('Invalid address')
+    throw new Error(`Could not get balances for address ${params.address}`)
   }
 }
 


### PR DESCRIPTION
This is based on #381.

There are a lot of unhelpful try/catch statements in the library (generally of the form `try { } catch (e) { return Promise.reject(e) }`) which don't actually do anything. This gets rid of them.

(This is a part of the changeset currently known as #376; I'm working on factoring out some of its parts that are separable concerns and make the diffs hard to read if all rolled into one thing.)