### PR TITLE
Remove trivial array types

### DIFF
--- a/packages/xchain-binance/src/client.ts
+++ b/packages/xchain-binance/src/client.ts
@@ -3,7 +3,7 @@ import * as crypto from '@binance-chain/javascript-sdk/lib/crypto'
 import { SignedSend } from '@binance-chain/javascript-sdk/lib/types'
 import {
   Address,
-  Balances,
+  Balance,
   BaseXChainClient,
   Fees,
   Network,
@@ -11,7 +11,6 @@ import {
   TxHash,
   TxHistoryParams,
   TxParams,
-  Txs,
   TxsPage,
   XChainClient,
   XChainClientParams,
@@ -31,7 +30,7 @@ import {
 import axios from 'axios'
 
 import {
-  Balances as BinanceBalances,
+  Balance as BinanceBalance,
   Fees as BinanceFees,
   TransactionResult,
   TransferFee,
@@ -195,10 +194,10 @@ class Client extends BaseXChainClient implements BinanceClient, XChainClient {
    *
    * @param {Address | number} address By default, it will return the balance of the current wallet. (optional)
    * @param {Asset} asset If not set, it will return all assets available. (optional)
-   * @returns {Array<Balance>} The balance of the address.
+   * @returns {Balance[]} The balance of the address.
    */
-  async getBalance(address: Address, assets?: Asset[]): Promise<Balances> {
-    const balances: BinanceBalances = await this.bncClient.getBalance(address)
+  async getBalance(address: Address, assets?: Asset[]): Promise<Balance[]> {
+    const balances: BinanceBalance[] = await this.bncClient.getBalance(address)
 
     return balances
       .map((balance) => {
@@ -244,7 +243,7 @@ class Client extends BaseXChainClient implements BinanceClient, XChainClient {
 
     return {
       total: txHistory.total,
-      txs: txHistory.tx.map(parseTx).filter(Boolean) as Txs,
+      txs: txHistory.tx.map(parseTx).filter(Boolean) as Tx[],
     }
   }
 

--- a/packages/xchain-binance/src/types/binance-ws.ts
+++ b/packages/xchain-binance/src/types/binance-ws.ts
@@ -15,8 +15,6 @@ export type Asset = {
   A: string
 }
 
-export type Assets = Asset[]
-
 /**
  * Event type of WS streams
  * @see https://docs.binance.org/api-reference/dex-api/ws-streams.html
@@ -77,13 +75,11 @@ export type Order = {
   O: number
 }
 
-export type Orders = Order[]
-
 /**
  * Orders event
  * @see https://docs.binance.org/api-reference/dex-api/ws-streams.html#1-orders
  */
-export type OrdersEvent = WSEvent<Orders>
+export type OrdersEvent = WSEvent<Order[]>
 
 export type Balance = {
   // Asset
@@ -96,24 +92,20 @@ export type Balance = {
   r: string
 }
 
-export type Balances = Balance[]
-
 export type Account = {
   // Event type
   e: string
   // Event height
   E: number
   // balances
-  B: Balances
+  B: Balance[]
 }
-
-export type Accounts = Account[]
 
 /**
  * Accounts event
  * @see https://docs.binance.org/api-reference/dex-api/ws-streams.html#2-account
  */
-export type AccountsEvent = WSEvent<Accounts>
+export type AccountsEvent = WSEvent<Account[]>
 
 export type AccountTrade = {
   /**
@@ -123,10 +115,8 @@ export type AccountTrade = {
   /**
    * Asset to trade
    */
-  c: Assets
+  c: Asset[]
 }
-
-export type AccountTrades = AccountTrade[]
 
 /**
  * Payload of a transfer event
@@ -153,7 +143,7 @@ export type Transfer = {
    * Sender address
    */
   f: string
-  t: AccountTrades
+  t: AccountTrade[]
 }
 
 /**
@@ -206,16 +196,10 @@ export type Trade = {
 }
 
 /**
- * Trades event payload
- * @see https://docs.binance.org/api-reference/dex-api/ws-streams.html#4-trades
- */
-export type Trades = Trade
-
-/**
  * Trade event
  * @see https://docs.binance.org/api-reference/dex-api/ws-streams.html#4-trades
  */
-export type TradesEvent = WSEvent<Trades>
+export type TradesEvent = WSEvent<Trade[]>
 
 export type Kline = {
   // Kline start time
@@ -323,13 +307,11 @@ export type SymbolTicker = {
  */
 export type SymbolTickerEvent = WSEvent<SymbolTicker>
 
-export type SymbolTickers = SymbolTicker[]
-
 /**
  * Symbol tickers event
  * @see https://docs.binance.org/api-reference/dex-api/ws-streams.html#9-all-symbols-ticker-streams
  */
-export type SymbolTickersEvent = WSEvent<SymbolTickers>
+export type SymbolTickersEvent = WSEvent<SymbolTicker[]>
 
 export type MiniTicker = {
   // Event type
@@ -358,14 +340,12 @@ export type MiniTicker = {
  */
 export type MiniTickerEvent = WSEvent<MiniTicker>
 
-export type MiniTickers = MiniTicker[]
-
 /**
  * Payload of a mini tickers event
  * @see https://docs.binance.org/api-reference/dex-api/ws-streams.html#10-individual-symbol-mini-ticker-streams
  */
 
-export type MiniTickersEvent = WSEvent<MiniTickers>
+export type MiniTickersEvent = WSEvent<MiniTicker[]>
 
 export type BlockHeight = { h: number }
 

--- a/packages/xchain-binance/src/types/binance.ts
+++ b/packages/xchain-binance/src/types/binance.ts
@@ -191,7 +191,7 @@ export type TxPage = {
   /**
    * List of transactions
    */
-  tx: Txs
+  tx: Tx[]
 }
 
 export type FeeType =
@@ -248,7 +248,7 @@ export type DexFees = {
   dex_fee_fields: DexFee[]
 }
 
-export type Fees = Array<Fee | TransferFee | DexFees>
+export type Fees = (Fee | TransferFee | DexFees)[]
 
 /**
  * Tx
@@ -332,8 +332,6 @@ export type Tx = {
    */
   proposalId: string | null
 }
-
-export type Txs = Tx[]
 
 export type TxSide = 'RECEIVE' | 'SEND'
 
@@ -519,8 +517,6 @@ export type Balance = {
   frozen: string
 }
 
-export type Balances = Balance[]
-
 export type Transfer = {
   code: number
   hash: string
@@ -528,13 +524,12 @@ export type Transfer = {
   ok: boolean
 }
 
-export type Transfers = Transfer[]
 /**
  * Result of  `bncClient.transfer(...)`
  * to transfer tokens from one address to another.
  * See https://github.com/binance-chain/javascript-sdk/blob/master/docs/api-docs/classes/bncclient.md#transfer
  * */
-export type TransferResult = { result?: Transfers }
+export type TransferResult = { result?: Transfer[] }
 
 export type Network = keyof typeof NETWORK_PREFIX_MAPPING
 
@@ -546,8 +541,8 @@ export type AminoWrapping<T> = {
 }
 
 export type StdTransaction = {
-  msg: Array<AminoWrapping<Msg>>
-  signatures: Array<StdSignature>
+  msg: AminoWrapping<Msg>[]
+  signatures: StdSignature[]
   memo: string
   source: number
   data?: Buffer | null | string

--- a/packages/xchain-bitcoin/__tests__/sochain-api.test.ts
+++ b/packages/xchain-bitcoin/__tests__/sochain-api.test.ts
@@ -3,7 +3,7 @@ import isTx1ConfirmedResponse from '../__mocks__/response/is-tx-confirmed/d5d4a0
 import unspentTxsResponse from '../__mocks__/response/unspent-txs/tb1q2pkall6rf6v6j0cvpady05xhy37erndvku08wp.json'
 import mockSochainApi from '../__mocks__/sochain'
 import * as sochain from '../src/sochain-api'
-import { BtcAddressUTXOs } from '../src/types/sochain-api-types'
+import { BtcAddressUTXO } from '../src/types/sochain-api-types'
 
 mockSochainApi.init()
 
@@ -14,7 +14,7 @@ describe('Sochain API Test', () => {
   it('getUnspentTxs', async () => {
     const address = 'tb1q2pkall6rf6v6j0cvpady05xhy37erndvku08wp'
 
-    const utxos: BtcAddressUTXOs = await sochain.getUnspentTxs({
+    const utxos: BtcAddressUTXO[] = await sochain.getUnspentTxs({
       sochainUrl,
       network,
       address,

--- a/packages/xchain-bitcoin/__tests__/utils.test.ts
+++ b/packages/xchain-bitcoin/__tests__/utils.test.ts
@@ -1,12 +1,12 @@
 import * as Bitcoin from 'bitcoinjs-lib'
 
 import mockSochainApi from '../__mocks__/sochain'
-import { UTXOs } from '../src/types/common'
+import { UTXO } from '../src/types/common'
 import * as Utils from '../src/utils'
 
 mockSochainApi.init()
 
-let utxos: UTXOs
+let utxos: UTXO[]
 
 describe.skip('Bitcoin Utils Test', () => {
   const witness = {
@@ -51,7 +51,7 @@ describe.skip('Bitcoin Utils Test', () => {
   })
   it('should fetch as many uxtos as are associated with an address', async () => {
     const address = '34xp4vRoCGJym3xR7yCVPFHoCNxv4Twseo'
-    const utxos: UTXOs = await Utils.scanUTXOs({
+    const utxos: UTXO[] = await Utils.scanUTXOs({
       sochainUrl: 'https://sochain.com/api/v2',
       network: 'mainnet',
       address,

--- a/packages/xchain-bitcoin/src/client.ts
+++ b/packages/xchain-bitcoin/src/client.ts
@@ -182,7 +182,7 @@ class Client extends BaseXChainClient implements BitcoinClient, XChainClient {
    * Get the BTC balance of a given address.
    *
    * @param {Address} the BTC address
-   * @returns {Array<Balance>} The BTC balance of the address.
+   * @returns {Balance[]} The BTC balance of the address.
    */
   async getBalance(address: Address): Promise<Balance[]> {
     return Utils.getBalance({

--- a/packages/xchain-bitcoin/src/sochain-api.ts
+++ b/packages/xchain-bitcoin/src/sochain-api.ts
@@ -5,7 +5,6 @@ import {
   AddressParams,
   BtcAddressDTO,
   BtcAddressUTXO,
-  BtcAddressUTXOs,
   BtcGetBalanceDTO,
   BtcUnspentTxsDTO,
   SochainResponse,
@@ -84,14 +83,14 @@ export const getBalance = async ({ sochainUrl, network, address }: AddressParams
  * @param {string} sochainUrl The sochain node url.
  * @param {string} network
  * @param {string} address
- * @returns {BtcAddressUTXOs}
+ * @returns {BtcAddressUTXO[]}
  */
 export const getUnspentTxs = async ({
   sochainUrl,
   network,
   address,
   startingFromTxId,
-}: AddressParams): Promise<BtcAddressUTXOs> => {
+}: AddressParams): Promise<BtcAddressUTXO[]> => {
   let resp = null
   if (startingFromTxId) {
     resp = await axios.get(`${sochainUrl}/get_tx_unspent/${toSochainNetwork(network)}/${address}/${startingFromTxId}`)
@@ -141,20 +140,20 @@ export const getIsTxConfirmed = async ({ sochainUrl, network, hash }: TxHashPara
  * @param {string} sochainUrl The sochain node url.
  * @param {string} network
  * @param {string} address
- * @returns {BtcAddressUTXOs}
+ * @returns {BtcAddressUTXO[]}
  */
 export const getConfirmedUnspentTxs = async ({
   sochainUrl,
   network,
   address,
-}: AddressParams): Promise<BtcAddressUTXOs> => {
+}: AddressParams): Promise<BtcAddressUTXO[]> => {
   const txs = await getUnspentTxs({
     sochainUrl,
     network,
     address,
   })
 
-  const confirmedUTXOs: BtcAddressUTXOs = []
+  const confirmedUTXOs: BtcAddressUTXO[] = []
 
   await Promise.all(
     txs.map(async (tx: BtcAddressUTXO) => {

--- a/packages/xchain-bitcoin/src/types/common.ts
+++ b/packages/xchain-bitcoin/src/types/common.ts
@@ -12,8 +12,6 @@ export type UTXO = {
   txHex: string
 }
 
-export type UTXOs = UTXO[]
-
 export type BroadcastTxParams = { network: Network; txHex: string; blockstreamUrl: string }
 
 // We might extract it into xchain-client later

--- a/packages/xchain-bitcoin/src/types/ledger.ts
+++ b/packages/xchain-bitcoin/src/types/ledger.ts
@@ -1,9 +1,9 @@
 import { Address, FeeRate, Network, TxParams } from '@xchainjs/xchain-client'
 
-import { UTXOs } from './common'
+import { UTXO } from './common'
 
 export type LedgerTxInfo = {
-  utxos: UTXOs
+  utxos: UTXO[]
   newTxHex: string
 }
 

--- a/packages/xchain-bitcoin/src/types/sochain-api-types.ts
+++ b/packages/xchain-bitcoin/src/types/sochain-api-types.ts
@@ -86,8 +86,6 @@ export type BtcUnspentTxsDTO = {
   txs: BtcAddressUTXO[]
 }
 
-export type BtcAddressUTXOs = BtcAddressUTXO[]
-
 export type BtcBroadcastTransfer = {
   network: string
   txid: string

--- a/packages/xchain-bitcoin/src/utils.ts
+++ b/packages/xchain-bitcoin/src/utils.ts
@@ -17,8 +17,8 @@ import * as blockStream from './blockstream-api'
 import { MIN_TX_FEE } from './const'
 import * as haskoinApi from './haskoin-api'
 import * as sochain from './sochain-api'
-import { BroadcastTxParams, UTXO, UTXOs } from './types/common'
-import { AddressParams, BtcAddressUTXOs, ScanUTXOParam } from './types/sochain-api-types'
+import { BroadcastTxParams, UTXO } from './types/common'
+import { AddressParams, BtcAddressUTXO, ScanUTXOParam } from './types/sochain-api-types'
 
 const TX_EMPTY_SIZE = 4 + 1 + 1 + 4 //10
 const TX_INPUT_BASE = 32 + 4 + 1 + 4 // 41
@@ -46,12 +46,12 @@ export const compileMemo = (memo: string): Buffer => {
 /**
  * Get the transaction fee.
  *
- * @param {UTXOs} inputs The UTXOs.
+ * @param {UTXO[]} inputs The UTXOs.
  * @param {FeeRate} feeRate The fee rate.
  * @param {Buffer} data The compiled memo (Optional).
  * @returns {number} The fee amount.
  */
-export const getFee = (inputs: UTXOs, feeRate: FeeRate, data: Buffer | null = null): number => {
+export const getFee = (inputs: UTXO[], feeRate: FeeRate, data: Buffer | null = null): number => {
   let sum =
     TX_EMPTY_SIZE +
     inputs.reduce((a, x) => a + inputBytes(x), 0) +
@@ -71,10 +71,10 @@ export const getFee = (inputs: UTXOs, feeRate: FeeRate, data: Buffer | null = nu
 /**
  * Get the average value of an array.
  *
- * @param {Array<number>} array
+ * @param {number[]} array
  * @returns {number} The average value.
  */
-export const arrayAverage = (array: Array<number>): number => {
+export const arrayAverage = (array: number[]): number => {
   let sum = 0
   array.forEach((value) => (sum += value))
   return sum / array.length
@@ -106,7 +106,7 @@ export const btcNetwork = (network: Network): Bitcoin.Network => {
  * @param {string} sochainUrl sochain Node URL.
  * @param {Network} network
  * @param {Address} address
- * @returns {Array<Balance>} The balances of the given address.
+ * @returns {Balance[]} The balances of the given address.
  */
 export const getBalance = async (params: AddressParams): Promise<Balance[]> => {
   const balance =
@@ -141,16 +141,16 @@ export const validateAddress = (address: Address, network: Network): boolean => 
  * @param {string} sochainUrl sochain Node URL.
  * @param {Network} network
  * @param {Address} address
- * @returns {Array<UTXO>} The UTXOs of the given address.
+ * @returns {UTXO[]} The UTXOs of the given address.
  */
 export const scanUTXOs = async ({
   sochainUrl,
   network,
   address,
   confirmedOnly = true, // default: scan only confirmed UTXOs
-}: ScanUTXOParam): Promise<UTXOs> => {
+}: ScanUTXOParam): Promise<UTXO[]> => {
   if (network === 'testnet') {
-    let utxos: BtcAddressUTXOs = []
+    let utxos: BtcAddressUTXO[] = []
 
     const addressParam: AddressParams = {
       sochainUrl,
@@ -220,7 +220,7 @@ export const buildTx = async ({
   network: Network
   sochainUrl: string
   spendPendingUTXO?: boolean
-}): Promise<{ psbt: Bitcoin.Psbt; utxos: UTXOs }> => {
+}): Promise<{ psbt: Bitcoin.Psbt; utxos: UTXO[] }> => {
   // search only confirmed UTXOs if pending UTXO is not allowed
   const confirmedOnly = !spendPendingUTXO
   const utxos = await scanUTXOs({ sochainUrl, network, address: sender, confirmedOnly })

--- a/packages/xchain-bitcoincash/src/client.ts
+++ b/packages/xchain-bitcoincash/src/client.ts
@@ -207,7 +207,7 @@ class Client extends BaseXChainClient implements BitcoinCashClient, XChainClient
    * Get the BCH balance of a given address.
    *
    * @param {Address} address By default, it will return the balance of the current wallet. (optional)
-   * @returns {Array<Balance>} The BCH balance of the address.
+   * @returns {Balance[]} The BCH balance of the address.
    *
    * @throws {"Invalid address"} Thrown if the given address is an invalid address.
    */

--- a/packages/xchain-bitcoincash/src/haskoin-api.ts
+++ b/packages/xchain-bitcoincash/src/haskoin-api.ts
@@ -75,7 +75,7 @@ export const getRawTransaction = async ({ haskoinUrl, txId }: TxHashParams): Pro
  * @param {string} haskoinUrl The haskoin API url.
  * @param {string} address The BCH address.
  * @param {TransactionsQueryParam} params The API query parameters.
- * @returns {Array<Transaction>}
+ * @returns {Transaction[]}
  *
  * @throws {"failed to query transactions"} thrown if failed to query transactions
  */
@@ -96,7 +96,7 @@ export const getTransactions = async ({
  *
  * @param {string} haskoinUrl The haskoin API url.
  * @param {string} address The BCH address.
- * @returns {Array<TxUnspent>}
+ * @returns {TxUnspent[]}
  *
  * @throws {"failed to query unspent transactions"} thrown if failed to query unspent transactions
  */

--- a/packages/xchain-bitcoincash/src/types/client-types.ts
+++ b/packages/xchain-bitcoincash/src/types/client-types.ts
@@ -30,8 +30,6 @@ export type UTXO = {
   txHex: string
 }
 
-export type UTXOs = UTXO[]
-
 export type GetChangeParams = {
   valueOut: number
   bchBalance: Balance

--- a/packages/xchain-bitcoincash/src/utils.ts
+++ b/packages/xchain-bitcoincash/src/utils.ts
@@ -15,7 +15,6 @@ import {
   TransactionInput,
   TransactionOutput,
   UTXO,
-  UTXOs,
 } from './types'
 import { Network as BCHNetwork, TransactionBuilder } from './types/bitcoincashjs-types'
 
@@ -66,7 +65,7 @@ export function getFee(inputs: number, feeRate: FeeRate, data: Buffer | null = n
  * Get the balances of an address.
  *
  * @param {AddressParams} params
- * @returns {Array<Balance>} The balances of the given address.
+ * @returns {Balance[]} The balances of the given address.
  */
 export const getBalance = async (params: AddressParams): Promise<Balance[]> => {
   const account = await getAccount(params)
@@ -199,11 +198,11 @@ export const validateAddress = (address: string, network: Network): boolean => {
  *
  * @param {string} haskoinUrl sochain Node URL.
  * @param {Address} address
- * @returns {Array<UTXO>} The UTXOs of the given address.
+ * @returns {UTXO[]} The UTXOs of the given address.
  */
-export const scanUTXOs = async (haskoinUrl: string, address: Address): Promise<UTXOs> => {
+export const scanUTXOs = async (haskoinUrl: string, address: Address): Promise<UTXO[]> => {
   const unspents = await getUnspentTransactions({ haskoinUrl, address })
-  const utxos: UTXOs = []
+  const utxos: UTXO[] = []
 
   for (const utxo of unspents || []) {
     utxos.push({
@@ -243,7 +242,7 @@ export const buildTx = async ({
   haskoinUrl: string
 }): Promise<{
   builder: TransactionBuilder
-  utxos: UTXOs
+  utxos: UTXO[]
 }> => {
   const recipientCashAddress = toCashAddress(recipient)
   if (!validateAddress(recipientCashAddress, network)) throw new Error('Invalid address')
@@ -304,7 +303,7 @@ export const buildTx = async ({
  * @param {UnspentOutput} utxos (optional)
  * @returns {BaseAmount} The calculated fees based on fee rate and the memo.
  */
-export const calcFee = (feeRate: FeeRate, memo?: string, utxos: UTXOs = []): BaseAmount => {
+export const calcFee = (feeRate: FeeRate, memo?: string, utxos: UTXO[] = []): BaseAmount => {
   const compiledMemo = memo ? compileMemo(memo) : null
   const fee = getFee(utxos.length, feeRate, compiledMemo)
   return baseAmount(fee)

--- a/packages/xchain-client/src/BaseXChainClient.ts
+++ b/packages/xchain-client/src/BaseXChainClient.ts
@@ -4,7 +4,7 @@ import axios from 'axios'
 
 import {
   Address,
-  Balances,
+  Balance,
   FeeRates,
   Fees,
   FeesParams,
@@ -133,7 +133,7 @@ export abstract class BaseXChainClient implements XChainClient {
   abstract getExplorerAddressUrl(address: string): string
   abstract getExplorerTxUrl(txID: string): string
   abstract validateAddress(address: string): boolean
-  abstract getBalance(address: string, assets?: Asset[]): Promise<Balances>
+  abstract getBalance(address: string, assets?: Asset[]): Promise<Balance[]>
   abstract getTransactions(params?: TxHistoryParams): Promise<TxsPage>
   abstract getTransactionData(txId: string, assetAddress?: string): Promise<Tx>
   abstract transfer(params: TxParams): Promise<string>

--- a/packages/xchain-client/src/types.ts
+++ b/packages/xchain-client/src/types.ts
@@ -9,8 +9,6 @@ export type Balance = {
   amount: BaseAmount
 }
 
-export type Balances = Balance[]
-
 export type TxType = 'transfer' | 'unknown'
 
 export type TxHash = string
@@ -34,11 +32,9 @@ export type Tx = {
   hash: string // Tx hash
 }
 
-export type Txs = Tx[]
-
 export type TxsPage = {
   total: number
-  txs: Txs
+  txs: Tx[]
 }
 
 export type TxHistoryParams = {
@@ -102,7 +98,7 @@ export interface XChainClient {
 
   setPhrase(phrase: string, walletIndex: number): Address
 
-  getBalance(address: Address, assets?: Asset[]): Promise<Balances>
+  getBalance(address: Address, assets?: Asset[]): Promise<Balance[]>
 
   getTransactions(params?: TxHistoryParams): Promise<TxsPage>
 

--- a/packages/xchain-cosmos/__tests__/util.test.ts
+++ b/packages/xchain-cosmos/__tests__/util.test.ts
@@ -108,7 +108,7 @@ describe('cosmos/util', () => {
     const from_address = 'cosmos16mzuy68a9xzqpsp88dt4f2tl0d49drhepn68fg'
     const to_address = 'cosmos16mzuy68a9xzqpsp88dt4f2tl0d49drhepn68fg'
 
-    const txs: Array<TxResponse> = [
+    const txs: TxResponse[] = [
       {
         height: 0,
         txhash: '',

--- a/packages/xchain-cosmos/src/client.ts
+++ b/packages/xchain-cosmos/src/client.ts
@@ -1,6 +1,6 @@
 import {
   Address,
-  Balances,
+  Balance,
   Fees,
   Network,
   Network as XChainNetwork,
@@ -235,9 +235,9 @@ class Client implements CosmosClient, XChainClient {
    *
    * @param {Address} address By default, it will return the balance of the current wallet. (optional)
    * @param {Asset} asset If not set, it will return all assets available. (optional)
-   * @returns {Array<Balance>} The balance of the address.
+   * @returns {Balance[]} The balance of the address.
    */
-  async getBalance(address: Address, assets?: Asset[]): Promise<Balances> {
+  async getBalance(address: Address, assets?: Asset[]): Promise<Balance[]> {
     const balances = await this.getSDKClient().getBalance(address)
     const mainAsset = this.getMainAsset()
 

--- a/packages/xchain-cosmos/src/cosmos/types.ts
+++ b/packages/xchain-cosmos/src/cosmos/types.ts
@@ -78,7 +78,7 @@ export type TxHistoryResponse = {
   page_number?: number
   page_total?: number
   limit?: number
-  txs?: Array<TxResponse>
+  txs?: TxResponse[]
 }
 
 export type APIQueryParam = {

--- a/packages/xchain-cosmos/src/util.ts
+++ b/packages/xchain-cosmos/src/util.ts
@@ -1,4 +1,4 @@
-import { Fees, TxFrom, TxTo, Txs } from '@xchainjs/xchain-client'
+import { Fees, Tx, TxFrom, TxTo } from '@xchainjs/xchain-client'
 import { Asset, assetToString, baseAmount } from '@xchainjs/xchain-util'
 import { Msg, codec } from 'cosmos-client'
 import { StdTx } from 'cosmos-client/x/auth'
@@ -59,11 +59,11 @@ export const getAsset = (denom: string): Asset | null => {
 /**
  * Parse transaction type
  *
- * @param {Array<TxResponse>} txs The transaction response from the node.
+ * @param {TxResponse[]} txs The transaction response from the node.
  * @param {Asset} mainAsset Current main asset which depends on the network.
- * @returns {Txs} The parsed transaction result.
+ * @returns {Tx[]} The parsed transaction result.
  */
-export const getTxsFromHistory = (txs: Array<TxResponse>, mainAsset: Asset): Txs => {
+export const getTxsFromHistory = (txs: TxResponse[], mainAsset: Asset): Tx[] => {
   return txs.reduce((acc, tx) => {
     let msgs: Msg[] = []
     if ((tx.tx as RawTxResponse).body === undefined) {
@@ -168,7 +168,7 @@ export const getTxsFromHistory = (txs: Array<TxResponse>, mainAsset: Asset): Txs
         hash: tx.txhash || '',
       },
     ]
-  }, [] as Txs)
+  }, [] as Tx[])
 }
 
 /**

--- a/packages/xchain-ethereum/src/client.ts
+++ b/packages/xchain-ethereum/src/client.ts
@@ -2,7 +2,7 @@ import { Provider, TransactionResponse } from '@ethersproject/abstract-provider'
 import { EtherscanProvider, getDefaultProvider } from '@ethersproject/providers'
 import {
   Address,
-  Balances,
+  Balance,
   BaseXChainClient,
   FeeOptionKey,
   Fees,
@@ -298,11 +298,11 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    * Get the ETH balance of a given address.
    *
    * @param {Address} address By default, it will return the balance of the current wallet. (optional)
-   * @returns {Array<Balances>} The all balance of the address.
+   * @returns {Balance[]} The all balance of the address.
    *
    * @throws {"Invalid asset"} throws when the give asset is an invalid one
    */
-  async getBalance(address: Address, assets?: Asset[]): Promise<Balances> {
+  async getBalance(address: Address, assets?: Asset[]): Promise<Balance[]> {
     const ethAddress = address || this.getAddress()
     // get ETH balance directly from provider
     const ethBalance: BigNumber = await this.getProvider().getBalance(ethAddress)
@@ -311,7 +311,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
     if (this.getNetwork() === 'mainnet') {
       // use ethplorerAPI for mainnet - ignore assets
       const account = await ethplorerAPI.getAddress(this.ethplorerUrl, address, this.ethplorerApiKey)
-      const balances: Balances = [
+      const balances: Balance[] = [
         {
           asset: AssetETH,
           amount: ethBalanceAmount,
@@ -484,7 +484,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    * @param {Address} contractAddress The contract address.
    * @param {ContractInterface} abi The contract ABI json.
    * @param {string} funcName The function to be called.
-   * @param {Array<any>} funcParams The parameters of the function.
+   * @param {any[]} funcParams The parameters of the function.
    * @returns {T} The result of the contract function call.
    *
    * @throws {"contractAddress must be provided"}
@@ -502,7 +502,7 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
    * @param {Address} contractAddress The contract address.
    * @param {ContractInterface} abi The contract ABI json.
    * @param {string} funcName The function to be called.
-   * @param {Array<any>} funcParams The parameters of the function.
+   * @param {any[]} funcParams The parameters of the function.
    * @param {number} walletIndex (optional) HD wallet index
    * @returns {BigNumber} The result of the contract function call.
    *

--- a/packages/xchain-ethereum/src/etherscan-api.ts
+++ b/packages/xchain-ethereum/src/etherscan-api.ts
@@ -1,4 +1,4 @@
-import { Txs } from '@xchainjs/xchain-client'
+import { Tx } from '@xchainjs/xchain-client'
 import { bnOrZero } from '@xchainjs/xchain-util'
 import axios from 'axios'
 import { BigNumberish } from 'ethers'
@@ -60,7 +60,7 @@ export const getTokenBalance = async ({
  * @param {string} address The address.
  * @param {TransactionHistoryParam} params The search options.
  * @param {string} apiKey The etherscan API key. (optional)
- * @returns {Array<ETHTransactionInfo>} The ETH transaction history
+ * @returns {ETHTransactionInfo[]} The ETH transaction history
  */
 export const getETHTransactionHistory = async ({
   baseUrl,
@@ -70,7 +70,7 @@ export const getETHTransactionHistory = async ({
   startblock,
   endblock,
   apiKey,
-}: TransactionHistoryParam & { baseUrl: string; apiKey?: string }): Promise<Txs> => {
+}: TransactionHistoryParam & { baseUrl: string; apiKey?: string }): Promise<Tx[]> => {
   let url = baseUrl + `/api?module=account&action=txlist&sort=desc` + getApiKeyQueryParameter(apiKey)
   if (address) url += `&address=${address}`
   if (offset) url += `&offset=${offset}`
@@ -96,7 +96,7 @@ export const getETHTransactionHistory = async ({
  * @param {string} address The address.
  * @param {TransactionHistoryParam} params The search options.
  * @param {string} apiKey The etherscan API key. (optional)
- * @returns {Array<Tx>} The token transaction history
+ * @returns {Tx[]} The token transaction history
  */
 export const getTokenTransactionHistory = async ({
   baseUrl,
@@ -107,7 +107,7 @@ export const getTokenTransactionHistory = async ({
   startblock,
   endblock,
   apiKey,
-}: TransactionHistoryParam & { baseUrl: string; apiKey?: string }): Promise<Txs> => {
+}: TransactionHistoryParam & { baseUrl: string; apiKey?: string }): Promise<Tx[]> => {
   let url = baseUrl + `/api?module=account&action=tokentx&sort=desc` + getApiKeyQueryParameter(apiKey)
   if (address) url += `&address=${address}`
   if (assetAddress) url += `&contractaddress=${assetAddress}`
@@ -124,5 +124,5 @@ export const getTokenTransactionHistory = async ({
     .reduce((acc, cur) => {
       const tx = getTxFromTokenTransaction(cur)
       return tx ? [...acc, tx] : acc
-    }, [] as Txs)
+    }, [] as Tx[])
 }

--- a/packages/xchain-ethereum/src/types/client-types.ts
+++ b/packages/xchain-ethereum/src/types/client-types.ts
@@ -64,7 +64,7 @@ export type CallParams = {
   contractAddress: Address
   abi: ethers.ContractInterface
   funcName: string
-  funcParams?: Array<unknown>
+  funcParams?: unknown[]
 }
 
 export type EstimateCallParams = Pick<CallParams, 'contractAddress' | 'abi' | 'funcName' | 'funcParams' | 'walletIndex'>

--- a/packages/xchain-ethereum/src/utils.ts
+++ b/packages/xchain-ethereum/src/utils.ts
@@ -1,4 +1,4 @@
-import { Balances, Fees, Network as XChainNetwork, Tx } from '@xchainjs/xchain-client'
+import { Balance, Fees, Network as XChainNetwork, Tx } from '@xchainjs/xchain-client'
 import {
   Asset,
   AssetETH,
@@ -350,11 +350,11 @@ export const getDecimal = async (asset: Asset, provider: providers.Provider): Pr
 /**
  * Get Token Balances
  *
- * @param {Array<TokenBalance>} tokenBalances
- * @returns {Array<Balance>} the parsed balances
+ * @param {TokenBalance[]} tokenBalances
+ * @returns {Balance[]} the parsed balances
  *
  */
-export const getTokenBalances = (tokenBalances: TokenBalance[]): Balances => {
+export const getTokenBalances = (tokenBalances: TokenBalance[]): Balance[] => {
   return tokenBalances.reduce((acc, cur) => {
     const { symbol, address: tokenAddress } = cur.tokenInfo
     if (validateSymbol(symbol) && validateAddress(tokenAddress) && cur?.tokenInfo?.decimals !== undefined) {
@@ -372,5 +372,5 @@ export const getTokenBalances = (tokenBalances: TokenBalance[]): Balances => {
     }
 
     return acc
-  }, [] as Balances)
+  }, [] as Balance[])
 }

--- a/packages/xchain-litecoin/__tests__/utils.test.ts
+++ b/packages/xchain-litecoin/__tests__/utils.test.ts
@@ -1,12 +1,12 @@
 import * as Litecoin from 'bitcoinjs-lib'
 
 import mockSochainApi from '../__mocks__/sochain'
-import { UTXOs } from '../src/types/common'
+import { UTXO } from '../src/types/common'
 import * as Utils from '../src/utils'
 
 mockSochainApi.init()
 
-let utxos: UTXOs
+let utxos: UTXO[]
 
 describe('Litecoin Utils Test', () => {
   const witness = {
@@ -51,7 +51,7 @@ describe('Litecoin Utils Test', () => {
   })
   it('should fetch as many uxtos as are associated with an address', async () => {
     const address = 'M8T1B2Z97gVdvmfkQcAtYbEepune1tzGua'
-    const utxos: UTXOs = await Utils.scanUTXOs({
+    const utxos: UTXO[] = await Utils.scanUTXOs({
       sochainUrl: 'https://sochain.com/api/v2',
       network: 'mainnet',
       address,

--- a/packages/xchain-litecoin/src/client.ts
+++ b/packages/xchain-litecoin/src/client.ts
@@ -192,7 +192,7 @@ class Client extends BaseXChainClient implements LitecoinClient, XChainClient {
    * Get the LTC balance of a given address.
    *
    * @param {Address} address By default, it will return the balance of the current wallet. (optional)
-   * @returns {Array<Balance>} The LTC balance of the address.
+   * @returns {Balance[]} The LTC balance of the address.
    */
   async getBalance(address: Address): Promise<Balance[]> {
     return Utils.getBalance({

--- a/packages/xchain-litecoin/src/sochain-api.ts
+++ b/packages/xchain-litecoin/src/sochain-api.ts
@@ -4,7 +4,7 @@ import axios from 'axios'
 import {
   AddressParams,
   LtcAddressDTO,
-  LtcAddressUTXOs,
+  LtcAddressUTXO,
   LtcGetBalanceDTO,
   LtcUnspentTxsDTO,
   SochainResponse,
@@ -82,14 +82,14 @@ export const getBalance = async ({ sochainUrl, network, address }: AddressParams
  * @param {string} sochainUrl The sochain node url.
  * @param {string} network
  * @param {string} address
- * @returns {LtcAddressUTXOs}
+ * @returns {LtcAddressUTXO[]}
  */
 export const getUnspentTxs = async ({
   sochainUrl,
   network,
   address,
   startingFromTxId,
-}: AddressParams): Promise<LtcAddressUTXOs> => {
+}: AddressParams): Promise<LtcAddressUTXO[]> => {
   let resp = null
   if (startingFromTxId) {
     resp = await axios.get(`${sochainUrl}/get_tx_unspent/${toSochainNetwork(network)}/${address}/${startingFromTxId}`)

--- a/packages/xchain-litecoin/src/types/common.ts
+++ b/packages/xchain-litecoin/src/types/common.ts
@@ -11,8 +11,6 @@ export type UTXO = {
   witnessUtxo: Witness
 }
 
-export type UTXOs = UTXO[]
-
 export type NodeAuth = {
   username: string
   password: string

--- a/packages/xchain-litecoin/src/types/ledger.ts
+++ b/packages/xchain-litecoin/src/types/ledger.ts
@@ -1,9 +1,9 @@
 import { Address, FeeRate, Network, TxParams } from '@xchainjs/xchain-client'
 
-import { UTXOs } from './common'
+import { UTXO } from './common'
 
 export type LedgerTxInfo = {
-  utxos: UTXOs
+  utxos: UTXO[]
   newTxHex: string
 }
 

--- a/packages/xchain-litecoin/src/types/sochain-api-types.ts
+++ b/packages/xchain-litecoin/src/types/sochain-api-types.ts
@@ -80,8 +80,6 @@ export type LtcUnspentTxsDTO = {
   txs: LtcAddressUTXO[]
 }
 
-export type LtcAddressUTXOs = LtcAddressUTXO[]
-
 export type LtcBroadcastTransfer = {
   network: string
   txid: string

--- a/packages/xchain-litecoin/src/utils.ts
+++ b/packages/xchain-litecoin/src/utils.ts
@@ -17,8 +17,8 @@ import accumulative from 'coinselect/accumulative'
 import { MIN_TX_FEE } from './const'
 import * as nodeApi from './node-api'
 import * as sochain from './sochain-api'
-import { BroadcastTxParams, UTXO, UTXOs } from './types/common'
-import { AddressParams, LtcAddressUTXOs } from './types/sochain-api-types'
+import { BroadcastTxParams, UTXO } from './types/common'
+import { AddressParams, LtcAddressUTXO } from './types/sochain-api-types'
 
 export const LTC_DECIMAL = 8
 
@@ -46,12 +46,12 @@ export const compileMemo = (memo: string): Buffer => {
 /**
  * Get the transaction fee.
  *
- * @param {UTXOs} inputs The UTXOs.
+ * @param {UTXO[]} inputs The UTXOs.
  * @param {FeeRate} feeRate The fee rate.
  * @param {Buffer} data The compiled memo (Optional).
  * @returns {number} The fee amount.
  */
-export function getFee(inputs: UTXOs, feeRate: FeeRate, data: Buffer | null = null): number {
+export function getFee(inputs: UTXO[], feeRate: FeeRate, data: Buffer | null = null): number {
   let sum =
     TX_EMPTY_SIZE +
     inputs.reduce(function (a, x) {
@@ -73,10 +73,10 @@ export function getFee(inputs: UTXOs, feeRate: FeeRate, data: Buffer | null = nu
 /**
  * Get the average value of an array.
  *
- * @param {Array<number>} array
+ * @param {number[]} array
  * @returns {number} The average value.
  */
-export function arrayAverage(array: Array<number>): number {
+export function arrayAverage(array: number[]): number {
   let sum = 0
   array.forEach((value) => (sum += value))
   return sum / array.length
@@ -106,7 +106,7 @@ export const ltcNetwork = (network: Network): Litecoin.Network => {
  * Get the balances of an address.
  *
  * @param {AddressParams} params
- * @returns {Array<Balance>} The balances of the given address.
+ * @returns {Balance[]} The balances of the given address.
  */
 export const getBalance = async (params: AddressParams): Promise<Balance[]> => {
   try {
@@ -142,10 +142,10 @@ export const validateAddress = (address: Address, network: Network): boolean => 
  * Scan UTXOs from sochain.
  *
  * @param {AddressParams} params
- * @returns {Array<UTXO>} The UTXOs of the given address.
+ * @returns {UTXO[]} The UTXOs of the given address.
  */
-export const scanUTXOs = async (params: AddressParams): Promise<UTXOs> => {
-  const utxos: LtcAddressUTXOs = await sochain.getUnspentTxs(params)
+export const scanUTXOs = async (params: AddressParams): Promise<UTXO[]> => {
+  const utxos: LtcAddressUTXO[] = await sochain.getUnspentTxs(params)
 
   return utxos.map(
     (utxo) =>
@@ -180,7 +180,7 @@ export const buildTx = async ({
   sender: Address
   network: Network
   sochainUrl: string
-}): Promise<{ psbt: Litecoin.Psbt; utxos: UTXOs }> => {
+}): Promise<{ psbt: Litecoin.Psbt; utxos: UTXO[] }> => {
   if (!validateAddress(recipient, network)) throw new Error('Invalid address')
 
   const utxos = await scanUTXOs({ sochainUrl, network, address: sender })

--- a/packages/xchain-polkadot/src/client.ts
+++ b/packages/xchain-polkadot/src/client.ts
@@ -3,7 +3,7 @@ import { KeyringPair } from '@polkadot/keyring/types'
 import { hexToU8a, isHex } from '@polkadot/util'
 import {
   Address,
-  Balances,
+  Balance,
   Fees,
   Network,
   RootDerivationPaths,
@@ -250,9 +250,9 @@ class Client implements PolkadotClient, XChainClient {
    * Get the DOT balance of a given address.
    *
    * @param {Address} address By default, it will return the balance of the current wallet. (optional)
-   * @returns {Array<Balance>} The DOT balance of the address.
+   * @returns {Balance[]} The DOT balance of the address.
    */
-  async getBalance(address: Address, assets?: Asset[]): Promise<Balances> {
+  async getBalance(address: Address, assets?: Asset[]): Promise<Balance[]> {
     const response: SubscanResponse<Account> = (
       await axios.post(`${this.getClientUrl()}/api/open/account`, { address: address || this.getAddress() })
     ).data

--- a/packages/xchain-polkadot/src/types/index.ts
+++ b/packages/xchain-polkadot/src/types/index.ts
@@ -42,11 +42,9 @@ export type Transfer = {
   to_account_display?: AccountDisplay
 }
 
-export type Transfers = Array<Transfer>
-
 export type TransfersResult = {
   count: number
-  transfers?: Array<Transfer> | null
+  transfers?: Transfer[] | null
 }
 
 export type ExtrinsicParam = {
@@ -84,9 +82,9 @@ export type Extrinsic = {
   nonce: number
   extrinsic_hash: string
   success: boolean
-  params: Array<ExtrinsicParam>
+  params: ExtrinsicParam[]
   transfer: Transfer
-  event: Array<ExtrinsicEvent>
+  event: ExtrinsicEvent[]
   fee: string
   error?: string | null
   finalized: true

--- a/packages/xchain-thorchain/src/client.ts
+++ b/packages/xchain-thorchain/src/client.ts
@@ -1,6 +1,6 @@
 import {
   Address,
-  Balances,
+  Balance,
   Fees,
   Network,
   RootDerivationPaths,
@@ -283,9 +283,9 @@ class Client implements ThorchainClient, XChainClient {
    *
    * @param {Address} address By default, it will return the balance of the current wallet. (optional)
    * @param {Asset} asset If not set, it will return all assets available. (optional)
-   * @returns {Array<Balance>} The balance of the address.
+   * @returns {Balance[]} The balance of the address.
    */
-  async getBalance(address: Address, assets?: Asset[]): Promise<Balances> {
+  async getBalance(address: Address, assets?: Asset[]): Promise<Balance[]> {
     const balances = await this.cosmosClient.getBalance(address)
     return balances
       .map((balance) => ({


### PR DESCRIPTION
This is based on #383.

This PR removes trivial array types (i.e. `export type Txs = Tx[]`). These exports add no value, clutter import sections, and don't serve as an effective extension point for a generic container because they refer to specific `Array<T>` types instead of something more generic like an `Iterable<T>`.

(This is a part of the changeset currently known as #376; I'm working on factoring out some of its parts that are separable concerns and make the diffs hard to read if all rolled into one thing.)