### PR TITLE
[xchain-bitcoincash] FIX: buildTx returns only used utxos

### DIFF
--- a/packages/xchain-bitcoincash/src/utils.ts
+++ b/packages/xchain-bitcoincash/src/utils.ts
@@ -298,7 +298,7 @@ export const buildTx = async ({
 
   return {
     builder: transactionBuilder,
-    utxos,
+    utxos: inputs,
   }
 }
 


### PR DESCRIPTION
### PROBLEM:

[`transfer`](https://github.com/xchainjs/xchainjs-lib/blob/master/packages/xchain-bitcoincash/src/client.ts#L289) method of xchain-bitcoincache client is not able sign list of utxos because some of them were filtered by [`buildTx`](https://github.com/xchainjs/xchainjs-lib/blob/master/packages/xchain-bitcoincash/src/utils.ts#L269), as the result [`No input at index: X`](https://github.com/bitcoinjs/bitcoinjs-lib/blob/239711bf4ef00651af92049bcdf88b12252b945c/ts_src/transaction_builder.ts#L1252) exception is thrown.

### SOLUTION:

Return only list of used inputs.