### PR TITLE
Fix synth notation

### DIFF
--- a/packages/xchain-thorchain/src/client.ts
+++ b/packages/xchain-thorchain/src/client.ts
@@ -18,7 +18,7 @@ import {
 } from '@xchainjs/xchain-client'
 import { CosmosSDKClient, RPCTxResult, TxOfflineParams } from '@xchainjs/xchain-cosmos'
 import * as xchainCrypto from '@xchainjs/xchain-crypto'
-import { Asset, AssetRuneNative, assetFromString, baseAmount } from '@xchainjs/xchain-util'
+import { Asset, AssetRuneNative, assetFromString, assetToString, baseAmount } from '@xchainjs/xchain-util'
 import axios from 'axios'
 import { AccAddress, PrivKey, PubKey, codec } from 'cosmos-client'
 import { StdTx } from 'cosmos-client/x/auth'
@@ -445,7 +445,7 @@ class Client implements ThorchainClient, XChainClient {
     const msgNativeTx = msgNativeTxFromJson({
       coins: [
         {
-          asset: getDenomWithChain(asset),
+          asset: assetToString(asset) === assetToString(AssetRuneNative)? getDenomWithChain(asset): getDenom(asset),
           amount: amount.amount().toString(),
         },
       ],
@@ -483,7 +483,7 @@ class Client implements ThorchainClient, XChainClient {
       from: this.getAddress(walletIndex),
       to: recipient,
       amount: amount.amount().toString(),
-      asset: getDenom(asset),
+      asset: assetToString(asset) === assetToString(AssetRuneNative)? getDenomWithChain(asset): getDenom(asset),
       memo,
       fee: {
         amount: [],
@@ -531,7 +531,7 @@ class Client implements ThorchainClient, XChainClient {
       from_sequence,
       to: recipient,
       amount: amount.amount().toString(),
-      asset: getDenom(asset),
+      asset: assetToString(asset) === assetToString(AssetRuneNative)? getDenomWithChain(asset): getDenom(asset),
       memo,
       fee: {
         amount: [],


### PR DESCRIPTION
This patch fixes the asset notation for synthetic assets. While native assets are denoted `<Network>.<Symbol>`, synth assets are denoted `<Network>/<Symbol>`.
Synths are expected to be described as CryptoAsset like: `{network: 'THOR', ticker: 'eth/usdt', symbol: 'eth/usdt-0xbeef' }`.

This patch only concerns about the notation, not about other aspects of the client (like sufficient balance check).