### PR TITLE
Resolve: [xchain-tc] Make chainId configurable

### DIFF
--- a/packages/xchain-thorchain/CHANGELOG.md
+++ b/packages/xchain-thorchain/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v0.22.0 (2022-02-06)
+
+## Add
+
+- Option to pass `ChainIds` into constructor
+- getter / setter for `chainId` in `Client`
+
+## Breaking change
+
+- `buildDepositTx` needs `chainId` to be passed - all params are set as object
+- Remove `enum ChainId` + `getChainId` + `isChainId` from `utils`
+
 # v0.21.2 (2022-02-04)
 
 ## Fix

--- a/packages/xchain-thorchain/__tests__/client.test.ts
+++ b/packages/xchain-thorchain/__tests__/client.test.ts
@@ -169,13 +169,13 @@ describe('Client Test', () => {
   })
 
   it('should init, should have right prefix', async () => {
-    expect(thorClient.validateAddress(thorClient.getAddress())).toEqual(true)
+    expect(thorClient.validateAddress(thorClient.getAddress())).toBeTruthy()
 
     thorClient.setNetwork(Network.Mainnet)
-    expect(thorClient.validateAddress(thorClient.getAddress())).toEqual(true)
+    expect(thorClient.validateAddress(thorClient.getAddress())).toBeTruthy()
 
     thorClient.setNetwork(Network.Stagenet)
-    expect(thorClient.validateAddress(thorClient.getAddress())).toEqual(true)
+    expect(thorClient.validateAddress(thorClient.getAddress())).toBeTruthy()
   })
 
   it('should have right client url', async () => {
@@ -207,6 +207,62 @@ describe('Client Test', () => {
   it('returns private key', async () => {
     const privKey = thorClient.getPrivKey()
     expect(privKey.toBase64()).toEqual('CHCbyYWorMZVRFtfJzt72DigvZeRNi3jo2c3hGEQ46I=')
+  })
+
+  describe('chainId', () => {
+    it('get chainId (testnet by default for testnetClient)', () => {
+      const chainId = thorClient.getChainId()
+      expect(chainId).toEqual('thorchain-v1')
+    })
+    it('update chainId (testnet by default for testnetClient)', () => {
+      thorClient.setChainId('another-testnet-id')
+      const chainId = thorClient.getChainId()
+      expect(chainId).toEqual('another-testnet-id')
+    })
+    it('update chainId for testnet', () => {
+      thorClient.setChainId('another-testnet-id', Network.Testnet)
+      const chainId = thorClient.getChainId(Network.Testnet)
+      expect(chainId).toEqual('another-testnet-id')
+    })
+    it('get default chainId for stagenet', () => {
+      const chainId = thorClient.getChainId(Network.Stagenet)
+      expect(chainId).toEqual('thorchain-stagenet')
+    })
+    it('update chainId for stagenet', () => {
+      thorClient.setChainId('another-stagenet-id', Network.Stagenet)
+      const chainId = thorClient.getChainId(Network.Stagenet)
+      expect(chainId).toEqual('another-stagenet-id')
+    })
+    it('get default chainId for mainnet', () => {
+      const chainId = thorClient.getChainId(Network.Mainnet)
+      expect(chainId).toEqual('thorchain')
+    })
+    it('update chainId for mainnet', () => {
+      thorClient.setChainId('another-mainnet-id', Network.Mainnet)
+      const chainId = thorClient.getChainId(Network.Mainnet)
+      expect(chainId).toEqual('another-mainnet-id')
+    })
+
+    it('set chainId by initialization of client', () => {
+      const chainIds = {
+        [Network.Mainnet]: 'mainnet-id',
+        [Network.Stagenet]: 'stagenet-id',
+        [Network.Testnet]: 'testnet-id',
+      }
+      const client = new Client({ phrase, network: Network.Testnet, chainIds })
+      // chainId for testnet by default
+      let chainId = client.getChainId()
+      expect(chainId).toEqual('testnet-id')
+      // ask testnet
+      chainId = client.getChainId(Network.Testnet)
+      expect(chainId).toEqual('testnet-id')
+      // ask for mainnet
+      chainId = client.getChainId(Network.Mainnet)
+      expect(chainId).toEqual('mainnet-id')
+      // ask for stagenet
+      chainId = client.getChainId(Network.Stagenet)
+      expect(chainId).toEqual('stagenet-id')
+    })
   })
 
   it('returns public key', async () => {
@@ -466,7 +522,7 @@ describe('Client Test', () => {
     })
     mockTendermintNodeInfo(thorClient.getClientUrl().node, {
       default_node_info: {
-        network: 'thorchain',
+        network: 'thorchain-v1',
       },
     })
     assertTxsPost(thorClient.getClientUrl().node, '', expected_txsPost_result)

--- a/packages/xchain-thorchain/__tests__/util.test.ts
+++ b/packages/xchain-thorchain/__tests__/util.test.ts
@@ -3,7 +3,6 @@ import { AssetBNB, AssetETH, AssetRuneNative, assetAmount, assetToBase } from '@
 
 import {
   assetFromDenom,
-  getChainId,
   getDefaultExplorerUrls,
   getDenom,
   getDepositTxDataFromLogs,
@@ -14,7 +13,6 @@ import {
   getTxType,
   isAssetRuneNative,
   isBroadcastSuccess,
-  isChainId,
 } from '../src/util'
 
 describe('thorchain/util', () => {
@@ -158,34 +156,6 @@ describe('thorchain/util', () => {
       expect(
         getExplorerTxUrl({ urls: getDefaultExplorerUrls(), network: 'mainnet' as Network, txID: 'txhash' }),
       ).toEqual('https://viewblock.io/thorchain/tx/txhash')
-    })
-  })
-
-  describe('isChainId', () => {
-    it('mainnet', () => {
-      expect(isChainId('thorchain')).toBeTruthy()
-    })
-    it('stagenet', () => {
-      expect(isChainId('thorchain-stagenet')).toBeTruthy()
-    })
-    it('testnet', () => {
-      expect(isChainId('thorchain-v1')).toBeTruthy()
-    })
-    it('unknown', () => {
-      expect(isChainId('thorchain-unknown')).toBeFalsy()
-      expect(isChainId('aynthing')).toBeFalsy()
-    })
-  })
-
-  describe('getChainId', () => {
-    it('mainnet', () => {
-      expect(getChainId(Network.Mainnet)).toEqual('thorchain')
-    })
-    it('stagenet', () => {
-      expect(getChainId(Network.Stagenet)).toEqual('thorchain-stagenet')
-    })
-    it('testnet', () => {
-      expect(getChainId(Network.Testnet)).toEqual('thorchain-v1')
     })
   })
 })

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-thorchain",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "description": "Custom Thorchain client and utilities used by XChainJS clients",
   "keywords": [
     "THORChain",

--- a/packages/xchain-thorchain/src/types/client-types.ts
+++ b/packages/xchain-thorchain/src/types/client-types.ts
@@ -16,9 +16,13 @@ export type ExplorerUrls = {
 
 export type ExplorerUrl = Record<Network, string>
 
+export type ChainId = string
+export type ChainIds = Record<Network, ChainId>
+
 export type ThorchainClientParams = {
   clientUrl?: ClientUrl
   explorerUrls?: ExplorerUrls
+  chainIds?: ChainIds
 }
 
 export type DepositParam = {


### PR DESCRIPTION
- [x] Option to pass `ChainIds` into constructor
- [x] getter / setter for `chainId` in `Client`
- [x] `buildDepositTx` needs `chainId` to be passed - all params are set as object
- [x] Remove `enum ChainId` + `getChainId` + `isChainId` from `utils`
- [x] Prepare/bump 0.22.0

Close #487