### PR TITLE
[xchain-thorchain] Increase gas limit to 3000000

### DIFF
--- a/packages/xchain-thorchain/CHANGELOG.md
+++ b/packages/xchain-thorchain/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.22.1 (2022-02-16)
+
+## Fix
+
+- Increase limit for `DEFAULT_GAS_VALUE` from 2000000 to 3000000 to accommodate recent increases in gas used that go above the old limit
+
 # v0.22.0 (2022-02-06)
 
 ## Add

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-thorchain",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Custom Thorchain client and utilities used by XChainJS clients",
   "keywords": [
     "THORChain",

--- a/packages/xchain-thorchain/src/util.ts
+++ b/packages/xchain-thorchain/src/util.ts
@@ -19,7 +19,7 @@ import { ChainId, ClientUrl, ExplorerUrl, ExplorerUrls, TxData } from './types'
 import { MsgNativeTx, ThorchainDepositResponse } from './types/messages'
 
 export const DECIMAL = 8
-export const DEFAULT_GAS_VALUE = '2000000'
+export const DEFAULT_GAS_VALUE = '3000000'
 export const DEPOSIT_GAS_VALUE = '500000000'
 export const MAX_TX_COUNT = 100
 


### PR DESCRIPTION
# Issue
We recently started seeing send and message txs fail because the gasUsed is slightly above the 2000000 limit starting from about yesterday. This increases the limit constant for TC transactions.