### PR TITLE
xchain-thorchain: Register codecs on client init

### DIFF
--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-thorchain",
-  "version": "0.24.0-alpha.1",
+  "version": "0.24.0-alpha.2",
   "description": "Custom Thorchain client and utilities used by XChainJS clients",
   "keywords": [
     "THORChain",

--- a/packages/xchain-thorchain/src/client.ts
+++ b/packages/xchain-thorchain/src/client.ts
@@ -59,7 +59,8 @@ import {
   getExplorerTxUrl,
   getPrefix,
   isAssetRuneNative,
-  registerCodecs
+  registerDepositCodecs,
+  registerSendCodecs,
 } from './util'
 
 /**
@@ -110,7 +111,8 @@ class Client extends BaseXChainClient implements ThorchainClient, XChainClient {
     this.explorerUrls = explorerUrls || getDefaultExplorerUrls()
     this.chainIds = chainIds
 
-    registerCodecs()
+    registerSendCodecs()
+    registerDepositCodecs()
 
     this.cosmosClient = new CosmosSDKClient({
       server: this.getClientUrl().node,

--- a/packages/xchain-thorchain/src/client.ts
+++ b/packages/xchain-thorchain/src/client.ts
@@ -59,8 +59,7 @@ import {
   getExplorerTxUrl,
   getPrefix,
   isAssetRuneNative,
-  registerDespositCodecs,
-  registerSendCodecs,
+  registerCodecs
 } from './util'
 
 /**
@@ -110,6 +109,8 @@ class Client extends BaseXChainClient implements ThorchainClient, XChainClient {
     this.clientUrl = clientUrl || getDefaultClientUrl()
     this.explorerUrls = explorerUrls || getDefaultExplorerUrls()
     this.chainIds = chainIds
+
+    registerCodecs()
 
     this.cosmosClient = new CosmosSDKClient({
       server: this.getClientUrl().node,
@@ -421,7 +422,6 @@ class Client extends BaseXChainClient implements ThorchainClient, XChainClient {
    * @throws {"failed to broadcast transaction"} Thrown if failed to broadcast transaction.
    */
   async deposit({ walletIndex = 0, asset = AssetRuneNative, amount, memo }: DepositParam): Promise<TxHash> {
-    await registerDespositCodecs()
     const balances = await this.getBalance(this.getAddress(walletIndex))
     const runeBalance: BaseAmount =
       balances.filter(({ asset }) => isAssetRuneNative(asset))[0]?.amount ?? baseAmount(0, DECIMAL)
@@ -484,7 +484,6 @@ class Client extends BaseXChainClient implements ThorchainClient, XChainClient {
    * @returns {TxHash} The transaction hash.
    */
   async transfer({ walletIndex = 0, asset = AssetRuneNative, amount, recipient, memo }: TxParams): Promise<TxHash> {
-    await registerSendCodecs()
     const balances = await this.getBalance(this.getAddress(walletIndex))
     const runeBalance: BaseAmount =
       balances.filter(({ asset }) => isAssetRuneNative(asset))[0]?.amount ?? baseAmount(0, DECIMAL)

--- a/packages/xchain-thorchain/src/util.ts
+++ b/packages/xchain-thorchain/src/util.ts
@@ -86,9 +86,17 @@ export const getPrefix = (network: Network) => {
   }
 }
 
-// Register types for encoding custom Thorchain messages
-export const registerCodecs = (): void => {
+/**
+ * Register type for encoding `MsgDeposit` messages
+ */
+export const registerDepositCodecs = () => {
   cosmosclient.codec.register('/types.MsgDeposit', types.types.MsgDeposit)
+}
+
+/**
+ * Register type for encoding `MsgSend` messages
+ */
+export const registerSendCodecs = () => {
   cosmosclient.codec.register('/types.MsgSend', types.types.MsgSend)
 }
 

--- a/packages/xchain-thorchain/src/util.ts
+++ b/packages/xchain-thorchain/src/util.ts
@@ -86,21 +86,9 @@ export const getPrefix = (network: Network) => {
   }
 }
 
-/**
- * Register Codecs based on the prefix.
- *
- * @param {string} prefix
- */
-export const registerDespositCodecs = async (): Promise<void> => {
+// Register types for encoding custom Thorchain messages
+export const registerCodecs = (): void => {
   cosmosclient.codec.register('/types.MsgDeposit', types.types.MsgDeposit)
-}
-
-/**
- * Register Codecs based on the prefix.
- *
- * @param {string} prefix
- */
-export const registerSendCodecs = async (): Promise<void> => {
   cosmosclient.codec.register('/types.MsgSend', types.types.MsgSend)
 }
 


### PR DESCRIPTION
Register types for encoding thorchain's custom messages on client init so they will always be available, even if you don't use the built in `deposit` and `transfer` functions