### PR TITLE
Few updates for xchain-terra

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,10 +4,7 @@
     "ecmaVersion": 2018,
     "sourceType": "module"
   },
-  "plugins": [
-    "prettier",
-    "ordered-imports"
-  ],
+  "plugins": ["prettier", "ordered-imports"],
   "extends": [
     "plugin:@typescript-eslint/recommended",
     "prettier/@typescript-eslint",
@@ -29,16 +26,13 @@
       }
     ],
     "@typescript-eslint/no-var-requires": "off",
-    "no-duplicate-imports": "error",
+    "@typescript-eslint/no-duplicate-imports": "error",
     "no-undef": "off",
     "ordered-imports/ordered-imports": [
       "error",
       {
         "symbols-first": false,
-        "declaration-ordering": [
-          "source",
-          "lowercase-last"
-        ],
+        "declaration-ordering": ["source", "lowercase-last"],
         "specifier-ordering": "lowercase-last",
         "group-ordering": [
           {

--- a/packages/xchain-terra/CHANGELOG.md
+++ b/packages/xchain-terra/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v.0.1.0-alpha.4 (2022-xx-xx)
+
+## Add
+
+- Helper `getDefaultClientConfig`
+- Helper `getTerraChains`
+- Helper `getDefaultRootDerivationPaths`
+
+## Breaking change
+
+- Extract client related types from `client` to `types/client` (incl. some renaming)
+
 # v.0.1.0-alpha.3 (2022-03-28)
 
 ## FIX

--- a/packages/xchain-terra/CHANGELOG.md
+++ b/packages/xchain-terra/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v.0.1.0-alpha.4 (2022-xx-xx)
+# v.0.1.0-alpha.4 (2022-04-02)
 
 ## Add
 
@@ -6,9 +6,14 @@
 - Helper `getTerraChains`
 - Helper `getDefaultRootDerivationPaths`
 
+## Fix
+
+- Fix destructering of default config in `Client` constructor to override values properly
+
 ## Breaking change
 
 - Extract client related types from `client` to `types/client` (incl. some renaming)
+- Rename `ChainID` -> `chainID` in `ClientParams`
 
 # v.0.1.0-alpha.3 (2022-03-28)
 

--- a/packages/xchain-terra/src/client.ts
+++ b/packages/xchain-terra/src/client.ts
@@ -33,17 +33,27 @@ class Client extends BaseXChainClient implements XChainClient {
     explorerAddressURL,
     explorerTxURL,
     cosmosAPIURL,
-    ChainID,
+    chainID,
   }: XChainClientParams & ClientParams) {
     super(Chain.Terra, { network, rootDerivationPaths, phrase })
+    const defaultClientConfigs = getDefaultClientConfig()
+    const defaultClientConfig = defaultClientConfigs[network]
     this.config = {
-      ...getDefaultClientConfig(),
-      ...{ explorerURL, explorerAddressURL, explorerTxURL, cosmosAPIURL, ChainID },
+      ...defaultClientConfigs,
+      // override default config of given network with given values
+      [network]: {
+        ...defaultClientConfig,
+        explorerURL: explorerURL || defaultClientConfig.explorerURL,
+        explorerAddressURL: explorerAddressURL || defaultClientConfig.explorerAddressURL,
+        explorerTxURL: explorerTxURL || defaultClientConfig.explorerTxURL,
+        cosmosAPIURL: cosmosAPIURL || defaultClientConfig.cosmosAPIURL,
+        chainID: chainID || defaultClientConfig.chainID,
+      },
     }
 
     this.lcdClient = new LCDClient({
-      URL: this.config[this.network].cosmosAPIURL,
-      chainID: this.config[this.network].ChainID,
+      URL: defaultClientConfig.cosmosAPIURL,
+      chainID: defaultClientConfig.chainID,
     })
   }
 
@@ -96,7 +106,7 @@ class Client extends BaseXChainClient implements XChainClient {
     super.setNetwork(network)
     this.lcdClient = new LCDClient({
       URL: this.config[this.network].cosmosAPIURL,
-      chainID: this.config[this.network].ChainID,
+      chainID: this.config[this.network].chainID,
     })
   }
   async getTransactions(params?: TxHistoryParams): Promise<TxsPage> {

--- a/packages/xchain-terra/src/index.ts
+++ b/packages/xchain-terra/src/index.ts
@@ -1,3 +1,4 @@
 export * from './client'
 export * from './const'
 export * from './util'
+export * from './types'

--- a/packages/xchain-terra/src/types/client.ts
+++ b/packages/xchain-terra/src/types/client.ts
@@ -16,7 +16,7 @@ export type ClientParams = {
   explorerAddressURL?: string
   explorerTxURL?: string
   cosmosAPIURL?: string
-  ChainID?: string
+  chainID?: string
 }
 
 export type ClientConfig = {
@@ -24,7 +24,7 @@ export type ClientConfig = {
   explorerAddressURL: string
   explorerTxURL: string
   cosmosAPIURL: string
-  ChainID: string
+  chainID: string
 }
 
 export type ClientConfigs = Record<Network, ClientConfig>

--- a/packages/xchain-terra/src/types/client.ts
+++ b/packages/xchain-terra/src/types/client.ts
@@ -1,0 +1,30 @@
+import type { Network } from '@xchainjs/xchain-client'
+
+export type SearchTxParams = {
+  messageAction?: string
+  messageSender?: string
+  transferSender?: string
+  transferRecipient?: string
+  page?: number
+  limit?: number
+  txMinHeight?: number
+  txMaxHeight?: number
+}
+
+export type ClientParams = {
+  explorerURL?: string
+  explorerAddressURL?: string
+  explorerTxURL?: string
+  cosmosAPIURL?: string
+  ChainID?: string
+}
+
+export type ClientConfig = {
+  explorerURL: string
+  explorerAddressURL: string
+  explorerTxURL: string
+  cosmosAPIURL: string
+  ChainID: string
+}
+
+export type ClientConfigs = Record<Network, ClientConfig>

--- a/packages/xchain-terra/src/types/index.ts
+++ b/packages/xchain-terra/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './client'
+export * from './terra'

--- a/packages/xchain-terra/src/types/terra.ts
+++ b/packages/xchain-terra/src/types/terra.ts
@@ -1,0 +1,27 @@
+import { Network } from '@xchainjs/xchain-client/lib'
+
+/**
+ * Chain types at Terra
+ */
+export type ChainType = 'mainnet' | 'testnet' | 'localterra'
+
+/**
+ * Chain definition
+ * Note: We are interested in `name`, `chainID`, `lcd` only
+ */
+export type Chain = {
+  chainID: string
+  lcd: string
+}
+
+/**
+ * Response of `https://assets.terra.money/chains.json`
+ * Code: https://github.com/terra-money/assets/blob/master/chains.json
+ */
+export type ChainsResponse = Record<ChainType, Chain>
+
+export type ChainId = string
+/**
+ * Parsed result of `ChainsResponse`
+ */
+export type ChainIds = Record<Network, ChainId>

--- a/packages/xchain-terra/src/util.ts
+++ b/packages/xchain-terra/src/util.ts
@@ -86,21 +86,21 @@ export const getDefaultClientConfig = (): Record<Network, ClientConfig> => ({
     explorerAddressURL: 'https://finder.terra.money/mainnet/address/',
     explorerTxURL: 'https://finder.terra.money/mainnet/tx/',
     cosmosAPIURL: 'https://fcd.terra.dev',
-    ChainID: 'columbus-5',
+    chainID: 'columbus-5',
   },
   [Network.Stagenet]: {
     explorerURL: 'https://finder.terra.money/mainnet',
     explorerAddressURL: 'https://finder.terra.money/mainnet/address/',
     explorerTxURL: 'https://finder.terra.money/mainnet/tx/',
     cosmosAPIURL: 'https://fcd.terra.dev',
-    ChainID: 'columbus-5',
+    chainID: 'columbus-5',
   },
   [Network.Testnet]: {
     explorerURL: 'https://finder.terra.money/testnet',
     explorerAddressURL: 'https://finder.terra.money/testnet/address/',
     explorerTxURL: 'https://finder.terra.money/testnet/tx/',
     cosmosAPIURL: 'https://bombay-fcd.terra.dev',
-    ChainID: 'bombay-12',
+    chainID: 'bombay-12',
   },
 })
 
@@ -129,13 +129,13 @@ export const getTerraChains = async (url = 'https://assets.terra.money'): Promis
  * Helper to merge `ChainIds` into given `ClientConfigs`
  */
 export const mergeChainIds = (chains: Terra.ChainIds, config: ClientConfigs): Record<Network, ClientConfig> => {
-  const mainnet: ClientConfig = { ...config.mainnet, ChainID: chains.mainnet }
+  const mainnet: ClientConfig = { ...config.mainnet, chainID: chains.mainnet }
   return {
     [Network.Mainnet]: mainnet,
     [Network.Stagenet]: mainnet,
     [Network.Testnet]: {
       ...config.mainnet,
-      ChainID: chains.testnet,
+      chainID: chains.testnet,
     },
   }
 }

--- a/packages/xchain-terra/src/util.ts
+++ b/packages/xchain-terra/src/util.ts
@@ -1,4 +1,11 @@
-import { Asset, Chain } from '@xchainjs/xchain-util/lib'
+import { Network } from '@xchainjs/xchain-client'
+import type { RootDerivationPaths } from '@xchainjs/xchain-client'
+import type { Asset } from '@xchainjs/xchain-util/lib'
+import { Chain } from '@xchainjs/xchain-util/lib'
+import axios from 'axios'
+
+import type { ClientConfig, ClientConfigs } from './types'
+import type * as Terra from './types/terra'
 
 export enum TerraNativeAsset {
   LUNA = 'LUNA',
@@ -66,3 +73,69 @@ export const isTerraAsset = ({ chain, symbol, ticker, synth }: Asset): boolean =
 
 export const getTerraMicroDenom = (assetDenom: string): string | null =>
   isTerraNativeAsset(assetDenom) ? DENOM_MAP[assetDenom] : null
+
+export const getDefaultRootDerivationPaths = (): RootDerivationPaths => ({
+  [Network.Mainnet]: "44'/330'/0'/0/",
+  [Network.Stagenet]: "44'/330'/0'/0/",
+  [Network.Testnet]: "44'/330'/0'/0/",
+})
+
+export const getDefaultClientConfig = (): Record<Network, ClientConfig> => ({
+  [Network.Mainnet]: {
+    explorerURL: 'https://finder.terra.money/mainnet',
+    explorerAddressURL: 'https://finder.terra.money/mainnet/address/',
+    explorerTxURL: 'https://finder.terra.money/mainnet/tx/',
+    cosmosAPIURL: 'https://fcd.terra.dev',
+    ChainID: 'columbus-5',
+  },
+  [Network.Stagenet]: {
+    explorerURL: 'https://finder.terra.money/mainnet',
+    explorerAddressURL: 'https://finder.terra.money/mainnet/address/',
+    explorerTxURL: 'https://finder.terra.money/mainnet/tx/',
+    cosmosAPIURL: 'https://fcd.terra.dev',
+    ChainID: 'columbus-5',
+  },
+  [Network.Testnet]: {
+    explorerURL: 'https://finder.terra.money/testnet',
+    explorerAddressURL: 'https://finder.terra.money/testnet/address/',
+    explorerTxURL: 'https://finder.terra.money/testnet/tx/',
+    cosmosAPIURL: 'https://bombay-fcd.terra.dev',
+    ChainID: 'bombay-12',
+  },
+})
+
+/**
+ * Helper to get chain definitions (chainId + lcd)
+ * @param {string} url API url (optional - default: https://assets.terra.money)
+ */
+export const getTerraChains = async (url = 'https://assets.terra.money'): Promise<Terra.ChainIds> => {
+  const endpoint = `${url}/chains.json`
+  try {
+    const { data } = await axios.get<Terra.ChainsResponse>(endpoint)
+    const mainnet: Terra.ChainId = data['mainnet'].chainID
+
+    const testnet: Terra.ChainId = data['testnet'].chainID
+    return {
+      testnet,
+      mainnet,
+      stagenet: mainnet,
+    }
+  } catch (error: unknown) {
+    return Promise.reject(`Could not parse Terra's chain definitions from ${endpoint} (Error: ${error}) `)
+  }
+}
+
+/**
+ * Helper to merge `ChainIds` into given `ClientConfigs`
+ */
+export const mergeChainIds = (chains: Terra.ChainIds, config: ClientConfigs): Record<Network, ClientConfig> => {
+  const mainnet: ClientConfig = { ...config.mainnet, ChainID: chains.mainnet }
+  return {
+    [Network.Mainnet]: mainnet,
+    [Network.Stagenet]: mainnet,
+    [Network.Testnet]: {
+      ...config.mainnet,
+      ChainID: chains.testnet,
+    },
+  }
+}


### PR DESCRIPTION
- [x] Helper `getDefaultClientConfig`
- [x] Helper `getTerraChains`
- [x] Helper `getDefaultRootDerivationPaths`
- [x] Extract client related types from `client` to `types/client` + some renaming
- [x] Fix destructering of default config in `Client`
- [x] Bump `xchain-terra@0.1.0-alpha.4`