### PR TITLE
[xchain-util] Support `UST` in `currencySymbolByAsset`

### DIFF
--- a/packages/xchain-util/CHANGELOG.md
+++ b/packages/xchain-util/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.6.1 (2022-04-04)
+
+### Fix
+
+- Support `UST` in `currencySymbolByAsset`
+
 # v.0.6.0 (2022-02-04)
 
 ### Breaking change

--- a/packages/xchain-util/package.json
+++ b/packages/xchain-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-util",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Helper utilities for XChain clients",
   "keywords": [
     "THORChain",

--- a/packages/xchain-util/src/asset.test.ts
+++ b/packages/xchain-util/src/asset.test.ts
@@ -22,7 +22,7 @@ import {
   isSynthAsset,
   isValidAsset,
 } from './asset'
-import { BNBChain, ETHChain } from './chain'
+import { BNBChain, ETHChain, TerraChain } from './chain'
 import { bn } from './index'
 import { Asset, Denomination } from './types'
 
@@ -394,13 +394,14 @@ describe('asset', () => {
     it('returns currency symbol for BTC', () => {
       expect(currencySymbolByAsset(AssetBTC)).toEqual('₿')
     })
-
     it('returns currency symbol for ETH', () => {
       expect(currencySymbolByAsset(AssetETH)).toEqual('Ξ')
     })
-
-    it('returns currency symbol for USD', () => {
+    it('returns $ for USD', () => {
       expect(currencySymbolByAsset({ chain: BNBChain, symbol: 'BUSD-BAF', ticker: 'BUSD', synth: false })).toEqual('$')
+    })
+    it('returns $ for UST', () => {
+      expect(currencySymbolByAsset({ chain: TerraChain, symbol: 'UST', ticker: 'UST', synth: false })).toEqual('$')
     })
     it('returns ticker as currency symbol for other assets', () => {
       expect(currencySymbolByAsset(AssetBNB)).toEqual('BNB')

--- a/packages/xchain-util/src/asset.ts
+++ b/packages/xchain-util/src/asset.ts
@@ -366,7 +366,7 @@ export const currencySymbolByAsset = ({ ticker }: Asset) => {
       return AssetCurrencySymbol.BTC
     case ticker === AssetETH.ticker:
       return AssetCurrencySymbol.ETH
-    case ticker.includes('USD'):
+    case ticker.includes('USD') || ticker.includes('UST'):
       return AssetCurrencySymbol.USD
     default:
       return ticker


### PR DESCRIPTION
+ bump xchain-util@0.6.1