### PR TITLE
Unrequire phrase

### DIFF
--- a/packages/xchain-binance/__tests__/client.test.ts
+++ b/packages/xchain-binance/__tests__/client.test.ts
@@ -114,6 +114,14 @@ describe('BinanceClient Test', () => {
     expect(bnbClientEmptyTest_path1.getAddress(1)).toEqual(testnetaddress_path1)
   })
 
+  it('should not throw on a client without a phrase', () => {
+    expect(() => {
+      new BinanceClient({
+        network: Network.Testnet,
+      })
+    }).not.toThrow()
+  })
+
   it('throws an error passing an invalid phrase', async () => {
     expect(() => {
       new BinanceClient({ phrase: 'invalid phrase', network: 'mainnet' as Network })

--- a/packages/xchain-bitcoin/__tests__/client.test.ts
+++ b/packages/xchain-bitcoin/__tests__/client.test.ts
@@ -50,6 +50,14 @@ describe('BitcoinClient Test', () => {
     expect(result).toEqual(addyOnePath0)
   })
 
+  it('should not throw on a client without a phrase', () => {
+    expect(() => {
+      new Client({
+        network: Network.Testnet,
+      })
+    }).not.toThrow()
+  })
+
   it('should throw an error for setting a bad phrase', () => {
     expect(() => btcClient.setPhrase('cat')).toThrow()
   })

--- a/packages/xchain-bitcoincash/__tests__/client.test.ts
+++ b/packages/xchain-bitcoincash/__tests__/client.test.ts
@@ -28,6 +28,14 @@ describe('BCHClient Test', () => {
   const mainnet_address_path0 = 'qp4kjpk684c3d9qjk5a37vl2xn86wxl0f5j2ru0daj'
   const mainnet_address_path1 = 'qr4jrkhu3usuk8ghv60m7pg9eywuc79yqvd0wxt2lm'
 
+  it('should not throw on a client without a phrase', () => {
+    expect(() => {
+      new Client({
+        network: Network.Testnet,
+      })
+    }).not.toThrow()
+  })
+
   it('set phrase should return correct address', () => {
     bchClient.setNetwork(Network.Testnet)
     expect(bchClient.setPhrase(phrase)).toEqual(testnet_address_path0)

--- a/packages/xchain-cosmos/__tests__/client.test.ts
+++ b/packages/xchain-cosmos/__tests__/client.test.ts
@@ -105,6 +105,14 @@ describe('Client Test', () => {
     }).toThrow()
   })
 
+  it('should not throw on a client without a phrase', () => {
+    expect(() => {
+      new Client({
+        network: Network.Testnet,
+      })
+    }).not.toThrow()
+  })
+
   it('should have right address', async () => {
     expect(cosmosClient.getAddress()).toEqual(address0_testnet)
   })

--- a/packages/xchain-doge/__tests__/client.test.ts
+++ b/packages/xchain-doge/__tests__/client.test.ts
@@ -44,6 +44,14 @@ describe('DogecoinClient Test', () => {
     expect(dogeClient.setPhrase(phraseOne)).toBeUndefined
   })
 
+  it('should not throw on a client without a phrase', () => {
+    expect(() => {
+      new Client({
+        network: Network.Testnet,
+      })
+    }).not.toThrow()
+  })
+
   it('should purge phrase and utxos', async () => {
     dogeClient.purgeClient()
     expect(() => dogeClient.getAddress()).toThrow('Phrase must be provided')

--- a/packages/xchain-ethereum/CHANGELOG.md
+++ b/packages/xchain-ethereum/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.24.0 (2022-04-20)
+
+## Fix
+
+- Make phrase optional on Client ([#550](https://github.com/xchainjs/xchainjs-lib/pull/550))
+
 # v.0.23.3 (2022-02-04)
 
 ## Update

--- a/packages/xchain-ethereum/package.json
+++ b/packages/xchain-ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-ethereum",
-  "version": "0.23.3",
+  "version": "0.24.0",
   "description": "Ethereum client for XChainJS",
   "keywords": [
     "XChain",

--- a/packages/xchain-litecoin/__tests__/client.test.ts
+++ b/packages/xchain-litecoin/__tests__/client.test.ts
@@ -50,6 +50,14 @@ describe('LitecoinClient Test', () => {
     expect(ltcClient.setPhrase(phraseOne)).toBeUndefined
   })
 
+  it('should not throw on a client without a phrase', () => {
+    expect(() => {
+      new Client({
+        network: Network.Testnet,
+      })
+    }).not.toThrow()
+  })
+
   it('should validate the right address', () => {
     ltcClient.setNetwork(Network.Testnet)
     ltcClient.setPhrase(phraseOne)

--- a/packages/xchain-polkadot/__tests__/client.test.ts
+++ b/packages/xchain-polkadot/__tests__/client.test.ts
@@ -42,6 +42,14 @@ describe('Client Test', () => {
     }).toThrow()
   })
 
+  it('should not throw on a client without a phrase', () => {
+    expect(() => {
+      new Client({
+        network: Network.Testnet,
+      })
+    }).not.toThrow()
+  })
+
   it('should have right address', async () => {
     expect(polkadotClient.getAddress()).toEqual(testnet_address)
 

--- a/packages/xchain-terra/__tests__/client.test.ts
+++ b/packages/xchain-terra/__tests__/client.test.ts
@@ -128,6 +128,14 @@ describe('Client Test', () => {
     }).toThrow()
   })
 
+  it('should not throw on a client without a phrase', () => {
+    expect(() => {
+      new Client({
+        network: Network.Testnet,
+      })
+    }).not.toThrow()
+  })
+
   it('should have right address', async () => {
     expect(terraClient.getAddress()).toEqual(testnet_address_path0)
 

--- a/packages/xchain-thorchain/__tests__/client.test.ts
+++ b/packages/xchain-thorchain/__tests__/client.test.ts
@@ -176,6 +176,15 @@ describe('Client Test', () => {
     }).toThrow()
   })
 
+  it('should not throw on a client without a phrase', () => {
+    expect(() => {
+      new Client({
+        network: Network.Testnet,
+        chainIds,
+      })
+    }).not.toThrow()
+  })
+
   it('should have right address', async () => {
     expect(thorClient.getAddress()).toEqual(testnet_address_path0)
 


### PR DESCRIPTION
Phrases in the ethereum client should not be required to create a client. 
![client error](https://user-images.githubusercontent.com/96449412/162805069-54a764c6-057d-40bc-838f-ac6519afdc71.png)

The eth client is the only client where phrase is not optional. `purgeClient()` should remove the phrase. Methods that require a phrase should throw errors if it is not present. 

I've added tests to the other clients to ensure they work the same way. 

I believe this supersedes of #374 

Close #374


 