### PR TITLE
[xchain-thorchain] Increase DEFAULT_GAS_VALUE to 4000000

### DIFF
--- a/packages/xchain-thorchain/CHANGELOG.md
+++ b/packages/xchain-thorchain/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.24.1 (2022-04-23)
+
+## Fix
+
+- Increase `DEFAULT_GAS_VALUE` to `4000000` (before `3000000`)
+
 # v0.24.0 (2022-03-23)
 
 ## Update

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-thorchain",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Custom Thorchain client and utilities used by XChainJS clients",
   "keywords": [
     "THORChain",

--- a/packages/xchain-thorchain/src/util.ts
+++ b/packages/xchain-thorchain/src/util.ts
@@ -20,7 +20,7 @@ import { MsgNativeTx } from './types/messages'
 import types from './types/proto/MsgCompiled'
 
 export const DECIMAL = 8
-export const DEFAULT_GAS_VALUE = '3000000'
+export const DEFAULT_GAS_VALUE = '4000000'
 export const DEPOSIT_GAS_VALUE = '500000000'
 export const MAX_TX_COUNT = 100
 


### PR DESCRIPTION
Discussion at Discord https://discord.com/channels/838986635756044328/967336653075132448

Note: It should be a temporary workaround only. As suggested in https://discord.com/channels/838986635756044328/967336653075132448/967365186774257664 another (better) fix using `gas: auto` / `gasAdjustment: 1.5` is needed in long term -> :eyes:   [ [xchain-thorchain] Another try to use gas: auto + gasAdjustment: 1.5 (or higher) #556 ](https://github.com/xchainjs/xchainjs-lib/issues/556)