### PR TITLE
[xchain-terra] Fix `coinsToBalances`

### DIFF
--- a/packages/xchain-terra/CHANGELOG.md
+++ b/packages/xchain-terra/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.1.1 (2022-04-27)
+
+## Fix
+
+- `coinsToBalances` adds `null` for invalid `Asset`s #559
+
 # v.0.1.0 (2022-04-19)
 
 Official release - includes everything from `v.0.1.0-alpha.1` to `v.0.1.0-alpha.8`

--- a/packages/xchain-terra/__tests__/util.test.ts
+++ b/packages/xchain-terra/__tests__/util.test.ts
@@ -1,10 +1,11 @@
-import { LCDClient } from '@terra-money/terra.js'
+import { Coin, Coins, LCDClient } from '@terra-money/terra.js'
 import { Network } from '@xchainjs/xchain-client'
 import { AssetBTC, TerraChain } from '@xchainjs/xchain-util'
 
 import mockTerraApi from '../__mocks__/terra'
 import { AssetLUNA, AssetLUNASynth, AssetUST, AssetUSTSynth } from '../src/const'
 import {
+  coinsToBalances,
   getAccount,
   getGasPriceByAsset,
   getTerraNativeAsset,
@@ -101,6 +102,39 @@ describe('terra/util', () => {
       expect(sequence).toEqual(5)
       expect(number).toEqual(198482)
       expect(publicKey?.address()).toEqual(address)
+    })
+  })
+
+  describe('coinsToBalances', () => {
+    it('includes native Terra assets', async () => {
+      const coinA: Coin = new Coin('uusd', 1)
+      const coinB: Coin = new Coin('uluna', 2)
+      const coins = new Coins([coinA, coinB])
+      const result = coinsToBalances(coins)
+      expect(result).toHaveLength(2)
+      const b0 = result[0]
+      expect(b0.asset).toEqual(AssetLUNA)
+      expect(b0.amount.amount().toNumber()).toEqual(2)
+      const b1 = result[1]
+      expect(b1.asset).toEqual(AssetUST)
+      expect(b1.amount.amount().toNumber()).toEqual(1)
+    })
+
+    it('ingore non-native or invalid assets', async () => {
+      const coinA: Coin = new Coin('invalid', 1)
+      const coinB: Coin = new Coin('uluna', 2)
+      const coins = new Coins([coinA, coinB])
+      const result = coinsToBalances(coins)
+      expect(result).toHaveLength(1)
+      const b0 = result[0]
+      expect(b0.asset).toEqual(AssetLUNA)
+      expect(b0.amount.amount().toNumber()).toEqual(2)
+    })
+
+    it('accepts empty list', async () => {
+      const coins = new Coins([])
+      const result = coinsToBalances(coins)
+      expect(result).toHaveLength(0)
     })
   })
 })

--- a/packages/xchain-terra/package.json
+++ b/packages/xchain-terra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-terra",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Custom Terra client and utilities used by XChainJS clients",
   "keywords": [
     "THORChain",

--- a/packages/xchain-terra/src/util.ts
+++ b/packages/xchain-terra/src/util.ts
@@ -1,5 +1,5 @@
-import { Coins, CreateTxOptions, LCDClient, MsgSend } from '@terra-money/terra.js'
-import { Address, Network } from '@xchainjs/xchain-client'
+import { Coin, Coins, CreateTxOptions, LCDClient, MsgSend } from '@terra-money/terra.js'
+import { Address, Balance, Network } from '@xchainjs/xchain-client'
 import type { RootDerivationPaths } from '@xchainjs/xchain-client'
 import { Asset, BaseAmount, assetToString, baseAmount, bn, bnOrZero, eqAsset } from '@xchainjs/xchain-util'
 import axios from 'axios'
@@ -301,3 +301,15 @@ export const getEstimatedFee = async ({
 
   return { amount: fee, asset: feeAsset, gasLimit: estimatedGas }
 }
+
+export const coinsToBalances = (coins: Coins): Balance[] =>
+  coins.toArray().reduce<Balance[]>((acc, curr: Coin) => {
+    const asset = getTerraNativeAsset(curr.denom)
+    if (!!asset) {
+      acc.push({
+        asset,
+        amount: baseAmount(curr.amount.toFixed(), TERRA_DECIMAL),
+      })
+    }
+    return acc
+  }, [])


### PR DESCRIPTION
to ignore non-native Terra or invalid assets. Bump `xchain-terra@0.1.1`.

Fixes #559