### PR TITLE
xchain-util/haven

### DIFF
--- a/packages/xchain-util/src/chain.test.ts
+++ b/packages/xchain-util/src/chain.test.ts
@@ -10,6 +10,7 @@ describe('chain', () => {
     expect(isChain('GAIA')).toBeTruthy()
     expect(isChain('POLKA')).toBeTruthy()
     expect(isChain('LTC')).toBeTruthy()
+    expect(isChain('XHV')).toBeTruthy()
     expect(isChain('')).toBeFalsy()
     expect(isChain('invalid')).toBeFalsy()
   })
@@ -43,6 +44,9 @@ describe('chain', () => {
     })
     it('returns string for LUNA', () => {
       expect(chainToString(Chain.Terra)).toEqual('Terra')
+    })
+    it('returns string for XHV', () => {
+      expect(chainToString(Chain.Haven)).toEqual('Haven')
     })
   })
 })

--- a/packages/xchain-util/src/chain.ts
+++ b/packages/xchain-util/src/chain.ts
@@ -9,6 +9,7 @@ export enum Chain {
   Litecoin = 'LTC',
   Terra = 'TERRA',
   Doge = 'DOGE',
+  Haven = 'XHV',
 }
 
 export const BNBChain = Chain.Binance
@@ -21,6 +22,7 @@ export const BCHChain = Chain.BitcoinCash
 export const LTCChain = Chain.Litecoin
 export const TerraChain = Chain.Terra
 export const DOGEChain = Chain.Doge
+export const HavenChain = Chain.Haven
 
 /**
  * Type guard to check whether string  is based on type `Chain`
@@ -52,5 +54,6 @@ export const chainToString: ((chainId: Chain) => string) & Record<Chain, string>
     [Chain.Polkadot]: 'Polkadot',
     [Chain.Terra]: 'Terra',
     [Chain.Doge]: 'Dogecoin',
+    [Chain.Haven]: 'Haven',
   },
 )


### PR DESCRIPTION
This PR adds Haven to xchain-utils ( to enum Chain ). Tests are passing. 
Needed for further haven integration as it is imported into the local client package for haven.