### PR TITLE
Bump xchain-client@v.0.11.3

### DIFF
--- a/packages/xchain-client/CHANGELOG.md
+++ b/packages/xchain-client/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.11.3 (2022-05-24)
+
+## Update
+
+- Add tx fee bounds b76d430
+
 # v.0.11.2 (2022-05-05)
 
 ## Update

--- a/packages/xchain-client/package.json
+++ b/packages/xchain-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-client",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "license": "MIT",
   "main": "lib/index",
   "types": "lib/index",


### PR DESCRIPTION
to include fee bounds (b76d430) - still missing in 0.11.2