### PR TITLE
[xchain-ethereum] Fix `estimateGasPrices`

### DIFF
--- a/packages/xchain-ethereum/__tests__/client.mainnet.test.ts
+++ b/packages/xchain-ethereum/__tests__/client.mainnet.test.ts
@@ -51,8 +51,8 @@ describe('Client Test', () => {
 
     const { fast, fastest, average } = await ethClient.estimateGasPrices()
 
-    expect(fast.amount().toString()).toEqual('60000000000')
-    expect(fastest.amount().toString()).toEqual('450000000000')
+    expect(fast.amount().toString()).toEqual('30000000000')
+    expect(fastest.amount().toString()).toEqual('150000000000')
     expect(average.amount().toString()).toEqual('15000000000')
   })
 

--- a/packages/xchain-ethereum/__tests__/client.testnet.test.ts
+++ b/packages/xchain-ethereum/__tests__/client.testnet.test.ts
@@ -229,8 +229,8 @@ describe('Client Test', () => {
 
     const { fast, fastest, average } = await ethClient.estimateGasPrices()
 
-    expect(fast.amount().toString()).toEqual('60000000000')
-    expect(fastest.amount().toString()).toEqual('450000000000')
+    expect(fast.amount().toString()).toEqual('30000000000')
+    expect(fastest.amount().toString()).toEqual('150000000000')
     expect(average.amount().toString()).toEqual('15000000000')
   })
 
@@ -454,7 +454,7 @@ describe('Client Test', () => {
       ropstenInfuraUrl,
       ropstenAlchemyUrl,
       'eth_sendRawTransaction',
-      '0xfa8f7c124948dbb47f300f56d26a9810217a932db5a8eae2b9d68809e56b3937',
+      '0x4479b2af29590d5ad1b591ddfbb479dba37a5857c2a250b41c16bb2cecb7d08c',
     )
     mock_thornode_inbound_addresses_success(thornodeApiUrl, [
       {
@@ -486,7 +486,7 @@ describe('Client Test', () => {
       gasLimit: gasFee.gasLimit,
       gasPrice: gasFee.gasPrices.fastest,
     })
-    expect(txHash).toEqual('0xfa8f7c124948dbb47f300f56d26a9810217a932db5a8eae2b9d68809e56b3937')
+    expect(txHash).toEqual('0x4479b2af29590d5ad1b591ddfbb479dba37a5857c2a250b41c16bb2cecb7d08c')
   })
 
   it('estimate gas for eth transfer', async () => {

--- a/packages/xchain-ethereum/package.json
+++ b/packages/xchain-ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-ethereum",
-  "version": "0.25.0-alpha.2",
+  "version": "0.25.0-alpha.3",
   "description": "Ethereum client for XChainJS",
   "keywords": [
     "XChain",

--- a/packages/xchain-ethereum/src/client.ts
+++ b/packages/xchain-ethereum/src/client.ts
@@ -836,12 +836,10 @@ export default class Client extends BaseXChainClient implements XChainClient, Et
       // @see https://gitlab.com/thorchain/thornode/-/blob/develop/x/thorchain/querier.go#L416-420
       // To have all values in `BaseAmount`, they needs to be converted into `wei` (1 gwei = 1,000,000,000 wei = 1e9)
       const ratesInGwei: FeeRates = standardFeeRates(await this.getFeeRateFromThorchain())
-      // Note 2:
-      // `Fast` + `Fastest` needs to be increased by 2x or 3x (similar to `utils.estimateDefaultFeesWithGasPricesAndLimits`)
       return {
         [FeeOption.Average]: baseAmount(ratesInGwei[FeeOption.Average] * 10 ** 9, ETH_DECIMAL),
-        [FeeOption.Fast]: baseAmount(ratesInGwei[FeeOption.Fast] * 10 ** 9, ETH_DECIMAL).times(2),
-        [FeeOption.Fastest]: baseAmount(ratesInGwei[FeeOption.Fastest] * 10 ** 9, ETH_DECIMAL).times(3),
+        [FeeOption.Fast]: baseAmount(ratesInGwei[FeeOption.Fast] * 10 ** 9, ETH_DECIMAL),
+        [FeeOption.Fastest]: baseAmount(ratesInGwei[FeeOption.Fastest] * 10 ** 9, ETH_DECIMAL),
       }
     } catch (error) {}
     //should only get here if thor fails


### PR DESCRIPTION
No need to multiply fee rates. It's already done in `standardFeeRates` of `xchain-client` ([code](https://github.com/xchainjs/xchainjs-lib/blob/723608214ce512deab80cdb64d64e74b859fefee/packages/xchain-client/src/feeRates.ts#L7-L13)). This bug was  introduced in #582 as part of `xchain-ethereum@0.25.alpha.1` _(my bad)_.

Bump `xchain-ethereum@0.25.alpha.3`