### PR TITLE
[xchain-cosmos] Misc. updates to support ATOM - part 1

### DIFF
--- a/packages/xchain-cosmos/CHANGELOG.md
+++ b/packages/xchain-cosmos/CHANGELOG.md
@@ -1,3 +1,26 @@
+# v.0.17.1-alpha.1 (2022-xx-xx)
+
+## Add
+
+- const `DEFAULT_GAS_LIMIT`
+- const `DEFAULT_FEE`
+- Optional parameter `gasLimit` in `transfer` and `transferOffline`
+- Params `clientUrls`, `chainIds` for constructor
+- Helper `getDefaultClientUrls`
+- Helper `getDefaultChainIds`
+- Setter `setNetwork`
+
+## Fix
+
+- `getFees` returns values based on `DEFAULT_FEE`
+- Initial one instance of `CosmosSDKClient` only depending on network
+- Support IBC assets in `getBalances` (#596)
+- Get IBC assets from denom in `getAsset`
+
+## Update
+
+- Move all `const` into `const.ts`
+
 # v.0.17.0 (2022-03-23)
 
 ## Update

--- a/packages/xchain-cosmos/CHANGELOG.md
+++ b/packages/xchain-cosmos/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v.0.17.1-alpha.1 (2022-xx-xx)
+# v.0.18.0-alpha.1 (2022-06-20)
 
 ## Add
 
@@ -19,7 +19,13 @@
 
 ## Update
 
-- Move all `const` into `const.ts`
+- Result of `getTxsFromHistory` is filtered by given asset
+- Move misc. constants into `const.ts`
+
+## Breaking change
+
+- Remove deprecated `AssetMuon`
+- Remove deprecated `Client.getMainAsset`
 
 # v.0.17.0 (2022-03-23)
 

--- a/packages/xchain-cosmos/__tests__/client.test.ts
+++ b/packages/xchain-cosmos/__tests__/client.test.ts
@@ -78,7 +78,7 @@ describe('Client Test', () => {
   const address1_testnet = 'cosmos1924f27fujxqnkt74u4d3ke3sfygugv9qp29hmk'
 
   beforeEach(() => {
-    cosmosClient = new Client({ phrase, network: 'testnet' as Network })
+    cosmosClient = new Client({ phrase, network: Network.Testnet })
   })
 
   afterEach(() => {
@@ -86,22 +86,22 @@ describe('Client Test', () => {
   })
 
   it('should start with empty wallet', async () => {
-    const cosmosClientEmptyMain = new Client({ phrase, network: 'mainnet' as Network })
+    const cosmosClientEmptyMain = new Client({ phrase, network: Network.Mainnet })
     expect(cosmosClientEmptyMain.getAddress()).toEqual(address0_mainnet)
     expect(cosmosClientEmptyMain.getAddress(1)).toEqual(address1_mainnet)
 
-    const cosmosClientEmptyTest = new Client({ phrase, network: 'testnet' as Network })
+    const cosmosClientEmptyTest = new Client({ phrase, network: Network.Testnet })
     expect(cosmosClientEmptyTest.getAddress()).toEqual(address0_testnet)
     expect(cosmosClientEmptyTest.getAddress(1)).toEqual(address1_testnet)
   })
 
   it('throws an error passing an invalid phrase', async () => {
     expect(() => {
-      new Client({ phrase: 'invalid phrase', network: 'mainnet' as Network })
+      new Client({ phrase: 'invalid phrase', network: Network.Mainnet })
     }).toThrow()
 
     expect(() => {
-      new Client({ phrase: 'invalid phrase', network: 'testnet' as Network })
+      new Client({ phrase: 'invalid phrase', network: Network.Testnet })
     }).toThrow()
   })
 
@@ -118,8 +118,8 @@ describe('Client Test', () => {
   })
 
   it('should update net', async () => {
-    const client = new Client({ phrase, network: 'mainnet' as Network })
-    client.setNetwork('testnet' as Network)
+    const client = new Client({ phrase, network: Network.Mainnet })
+    client.setNetwork(Network.Testnet)
     expect(client.getNetwork()).toEqual('testnet')
 
     const address = client.getAddress()
@@ -129,12 +129,12 @@ describe('Client Test', () => {
   it('should init, should have right prefix', async () => {
     expect(cosmosClient.validateAddress(cosmosClient.getAddress())).toEqual(true)
 
-    cosmosClient.setNetwork('mainnet' as Network)
+    cosmosClient.setNetwork(Network.Mainnet)
     expect(cosmosClient.validateAddress(cosmosClient.getAddress())).toEqual(true)
   })
 
   it('has no balances', async () => {
-    cosmosClient.setNetwork('mainnet' as Network)
+    cosmosClient.setNetwork(Network.Mainnet)
 
     mockAccountsBalance(getClientUrl(cosmosClient), address0_mainnet, {
       balances: [],
@@ -148,19 +148,20 @@ describe('Client Test', () => {
     mockAccountsBalance(getClientUrl(cosmosClient), 'cosmos1gehrq0pr5d79q8nxnaenvqh09g56jafm82thjv', {
       balances: [
         new proto.cosmos.base.v1beta1.Coin({
-          denom: 'muon',
+          denom: 'umuon',
           amount: '75000000',
         }),
       ],
     })
     const balances = await cosmosClient.getBalance('cosmos1gehrq0pr5d79q8nxnaenvqh09g56jafm82thjv')
+
     const expected = balances[0].amount.amount().isEqualTo(baseAmount(75000000, 6).amount())
     expect(expected).toBeTruthy()
     expect(balances[0].asset).toEqual(AssetMuon)
   })
 
   it('has an empty tx history', async () => {
-    cosmosClient.setNetwork('mainnet' as Network)
+    cosmosClient.setNetwork(Network.Mainnet)
 
     const expected: TxsPage = {
       total: 0,
@@ -222,7 +223,7 @@ describe('Client Test', () => {
     let transactions = await cosmosClient.getTransactions({ address: 'cosmos1xvt4e7xd0j9dwv2w83g50tpcltsl90h52003e2' })
     expect(transactions.total).toBeGreaterThan(0)
 
-    cosmosClient.setNetwork('mainnet' as Network)
+    cosmosClient.setNetwork(Network.Mainnet)
     const msgSend2 = new proto.cosmos.bank.v1beta1.MsgSend({
       from_address: 'cosmos1pjkpqxmvz47a5aw40l98fyktlg7k6hd9heq95z',
       to_address: 'cosmos155svs6sgxe55rnvs6ghprtqu0mh69kehrn0dqr',
@@ -301,7 +302,7 @@ describe('Client Test', () => {
   })
 
   it('get transaction data', async () => {
-    cosmosClient.setNetwork('mainnet' as Network)
+    cosmosClient.setNetwork(Network.Mainnet)
 
     const msgSend = new proto.cosmos.bank.v1beta1.MsgSend({
       from_address: 'cosmos1pjkpqxmvz47a5aw40l98fyktlg7k6hd9heq95z',
@@ -346,7 +347,7 @@ describe('Client Test', () => {
     // Client created with network === 'testnet'
     expect(cosmosClient.getExplorerUrl()).toEqual('https://explorer.theta-testnet.polypore.xyz')
 
-    cosmosClient.setNetwork('mainnet' as Network)
+    cosmosClient.setNetwork(Network.Mainnet)
     expect(cosmosClient.getExplorerUrl()).toEqual('https://cosmos.bigdipper.live')
   })
 
@@ -355,7 +356,7 @@ describe('Client Test', () => {
       'https://explorer.theta-testnet.polypore.xyz/account/anotherTestAddressHere',
     )
 
-    cosmosClient.setNetwork('mainnet' as Network)
+    cosmosClient.setNetwork(Network.Mainnet)
     expect(cosmosClient.getExplorerAddressUrl('testAddressHere')).toEqual(
       'https://cosmos.bigdipper.live/account/testAddressHere',
     )
@@ -366,7 +367,7 @@ describe('Client Test', () => {
       'https://explorer.theta-testnet.polypore.xyz/transactions/anotherTestTxHere',
     )
 
-    cosmosClient.setNetwork('mainnet' as Network)
+    cosmosClient.setNetwork(Network.Mainnet)
     expect(cosmosClient.getExplorerTxUrl('testTxHere')).toEqual('https://cosmos.bigdipper.live/transactions/testTxHere')
   })
 })

--- a/packages/xchain-cosmos/__tests__/client.test.ts
+++ b/packages/xchain-cosmos/__tests__/client.test.ts
@@ -4,8 +4,8 @@ import { BaseAmount, baseAmount } from '@xchainjs/xchain-util'
 import nock from 'nock'
 
 import { Client } from '../src/client'
+import { AssetAtom } from '../src/const'
 import { GetTxByHashResponse, TxHistoryResponse } from '../src/cosmos/types'
-import { AssetMuon } from '../src/types'
 
 const getClientUrl = (client: Client): string => {
   return client.getNetwork() === Network.Testnet
@@ -148,7 +148,7 @@ describe('Client Test', () => {
     mockAccountsBalance(getClientUrl(cosmosClient), 'cosmos1gehrq0pr5d79q8nxnaenvqh09g56jafm82thjv', {
       balances: [
         new proto.cosmos.base.v1beta1.Coin({
-          denom: 'umuon',
+          denom: 'uatom',
           amount: '75000000',
         }),
       ],
@@ -157,7 +157,7 @@ describe('Client Test', () => {
 
     const expected = balances[0].amount.amount().isEqualTo(baseAmount(75000000, 6).amount())
     expect(expected).toBeTruthy()
-    expect(balances[0].asset).toEqual(AssetMuon)
+    expect(balances[0].asset).toEqual(AssetAtom)
   })
 
   it('has an empty tx history', async () => {
@@ -187,7 +187,7 @@ describe('Client Test', () => {
       to_address: 'cosmos155svs6sgxe55rnvs6ghprtqu0mh69kehrn0dqr',
       amount: [
         {
-          denom: 'umuon',
+          denom: 'uatom',
           amount: '4318994970',
         },
       ],
@@ -292,7 +292,7 @@ describe('Client Test', () => {
     assertTxsPost(getClientUrl(cosmosClient), expected_txsPost_result)
 
     const result = await cosmosClient.transfer({
-      asset: AssetMuon,
+      asset: AssetAtom,
       recipient: to_address,
       amount: send_amount,
       memo,

--- a/packages/xchain-cosmos/__tests__/util.test.ts
+++ b/packages/xchain-cosmos/__tests__/util.test.ts
@@ -1,8 +1,8 @@
 import { cosmosclient, proto } from '@cosmos-client/core'
 import { baseAmount, eqAsset } from '@xchainjs/xchain-util'
 
+import { AssetAtom } from '../src/const'
 import { APIQueryParam, RawTxResponse, TxResponse } from '../src/cosmos/types'
-import { AssetAtom, AssetMuon } from '../src/types'
 import { getAsset, getDenom, getQueryString, getTxsFromHistory, isMsgMultiSend, isMsgSend } from '../src/util'
 
 describe('cosmos/util', () => {
@@ -76,19 +76,9 @@ describe('cosmos/util', () => {
       it('get denom for AssetAtom', () => {
         expect(getDenom(AssetAtom)).toEqual('uatom')
       })
-
-      it('get denom for AssetMuon', () => {
-        expect(getDenom(AssetMuon)).toEqual('umuon')
-      })
     })
 
     describe('getAsset', () => {
-      it('get asset for umuon', () => {
-        const asset = getAsset('umuon')
-        const result = asset !== null && eqAsset(asset, AssetMuon)
-        expect(result).toBeTruthy()
-      })
-
       it('get asset for uatom', () => {
         const asset = getAsset('uatom')
         const result = asset !== null && eqAsset(asset, AssetAtom)
@@ -99,7 +89,7 @@ describe('cosmos/util', () => {
         // see https://github.com/bitsongofficial/docs.bitsong.io/blob/main/relayer.md#official-bitsong-ibc-channels
         const denom = 'ibc/E7D5E9D0E9BF8B7354929A817DD28D4D017E745F638954764AA88522A7A409EC'
         const asset = getAsset(denom)
-        const expected = { ...AssetAtom, symbol: denom.toUpperCase(), ticker: '' }
+        const expected = { ...AssetAtom, symbol: denom, ticker: '' }
         expect(asset !== null && eqAsset(asset, expected)).toBeTruthy()
       })
     })

--- a/packages/xchain-cosmos/__tests__/util.test.ts
+++ b/packages/xchain-cosmos/__tests__/util.test.ts
@@ -1,5 +1,5 @@
 import { cosmosclient, proto } from '@cosmos-client/core'
-import { baseAmount } from '@xchainjs/xchain-util'
+import { baseAmount, eqAsset } from '@xchainjs/xchain-util'
 
 import { APIQueryParam, RawTxResponse, TxResponse } from '../src/cosmos/types'
 import { AssetAtom, AssetMuon } from '../src/types'
@@ -84,15 +84,23 @@ describe('cosmos/util', () => {
 
     describe('getAsset', () => {
       it('get asset for umuon', () => {
-        expect(getAsset('umuon')).toEqual(AssetMuon)
+        const asset = getAsset('umuon')
+        const result = asset !== null && eqAsset(asset, AssetMuon)
+        expect(result).toBeTruthy()
       })
 
       it('get asset for uatom', () => {
-        expect(getAsset('uatom')).toEqual(AssetAtom)
+        const asset = getAsset('uatom')
+        const result = asset !== null && eqAsset(asset, AssetAtom)
+        expect(result).toBeTruthy()
       })
 
-      it('get asset for unknown', () => {
-        expect(getAsset('unknown')).toBeNull()
+      it('get asset for ibc asset (BTSG - Bitsong)', () => {
+        // see https://github.com/bitsongofficial/docs.bitsong.io/blob/main/relayer.md#official-bitsong-ibc-channels
+        const denom = 'ibc/E7D5E9D0E9BF8B7354929A817DD28D4D017E745F638954764AA88522A7A409EC'
+        const asset = getAsset(denom)
+        const expected = { ...AssetAtom, symbol: denom.toUpperCase(), ticker: '' }
+        expect(asset !== null && eqAsset(asset, expected)).toBeTruthy()
       })
     })
   })

--- a/packages/xchain-cosmos/package.json
+++ b/packages/xchain-cosmos/package.json
@@ -32,9 +32,9 @@
     "prepublishOnly": "yarn build"
   },
   "devDependencies": {
-    "@xchainjs/xchain-client": "^0.11.1",
-    "@xchainjs/xchain-crypto": "^0.2.4",
-    "@xchainjs/xchain-util": "^0.5.1",
+    "@xchainjs/xchain-client": "^0.11.3",
+    "@xchainjs/xchain-crypto": "^0.2.6",
+    "@xchainjs/xchain-util": "^0.7.1",
     "@cosmos-client/core": "^0.45.1",
     "axios": "^0.25.0",
     "nock": "^13.0.5"
@@ -43,9 +43,9 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@xchainjs/xchain-client": "^0.11.1",
-    "@xchainjs/xchain-crypto": "^0.2.4",
-    "@xchainjs/xchain-util": "^0.5.1",
+    "@xchainjs/xchain-client": "^0.11.3",
+    "@xchainjs/xchain-crypto": "^0.2.6",
+    "@xchainjs/xchain-util": "^0.7.1",
     "@cosmos-client/core": "^0.45.1",
     "axios": "^0.25.0"
   }

--- a/packages/xchain-cosmos/package.json
+++ b/packages/xchain-cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-cosmos",
-  "version": "0.17.0",
+  "version": "0.18.0-alpha.1",
   "description": "Custom Cosmos client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",

--- a/packages/xchain-cosmos/src/client.ts
+++ b/packages/xchain-cosmos/src/client.ts
@@ -1,4 +1,4 @@
-import { proto } from '@cosmos-client/core'
+import { cosmosclient, proto } from '@cosmos-client/core'
 import {
   Address,
   Balance,
@@ -13,13 +13,16 @@ import {
   TxsPage,
   XChainClient,
   XChainClientParams,
+  singleFee,
 } from '@xchainjs/xchain-client'
-import { Asset, Chain, assetToString, baseAmount } from '@xchainjs/xchain-util'
+import { Asset, Chain, baseAmount, eqAsset } from '@xchainjs/xchain-util'
+import BigNumber from 'bignumber.js'
 
+import { DECIMAL, DEFAULT_FEE, DEFAULT_GAS_LIMIT } from './const'
 import { CosmosSDKClient } from './cosmos/sdk-client'
 import { TxOfflineParams } from './cosmos/types'
-import { AssetAtom, AssetMuon } from './types'
-import { DECIMAL, getAsset, getDenom, getTxsFromHistory } from './util'
+import { AssetAtom, AssetMuon, ChainIds, ClientUrls, CosmosClientParams } from './types'
+import { getAsset, getDefaultChainIds, getDefaultClientUrls, getDenom, getTxsFromHistory } from './util'
 
 /**
  * Interface for custom Cosmos client
@@ -29,20 +32,13 @@ export interface CosmosClient {
   getSDKClient(): CosmosSDKClient
 }
 
-const MAINNET_SDK = new CosmosSDKClient({
-  server: 'https://api.cosmos.network',
-  chainId: 'cosmoshub-4',
-})
-const TESTNET_SDK = new CosmosSDKClient({
-  server: 'https://rest.sentry-02.theta-testnet.polypore.xyz',
-  chainId: 'theta-testnet-001',
-})
-
 /**
  * Custom Cosmos client
  */
 class Client extends BaseXChainClient implements CosmosClient, XChainClient {
-  private sdkClients: Map<Network, CosmosSDKClient> = new Map<Network, CosmosSDKClient>()
+  private sdkClient: CosmosSDKClient
+  private clientUrls: ClientUrls
+  private chainIds: ChainIds
 
   /**
    * Constructor
@@ -57,15 +53,40 @@ class Client extends BaseXChainClient implements CosmosClient, XChainClient {
   constructor({
     network = Network.Testnet,
     phrase,
+    clientUrls,
+    chainIds,
     rootDerivationPaths = {
       [Network.Mainnet]: `44'/118'/0'/0/`,
       [Network.Testnet]: `44'/118'/0'/0/`,
       [Network.Stagenet]: `44'/118'/0'/0/`,
     },
-  }: XChainClientParams) {
+  }: XChainClientParams & CosmosClientParams) {
     super(Chain.Cosmos, { network, rootDerivationPaths, phrase })
-    this.sdkClients.set(Network.Testnet, TESTNET_SDK)
-    this.sdkClients.set(Network.Mainnet, MAINNET_SDK)
+
+    this.clientUrls = clientUrls || getDefaultClientUrls()
+    this.chainIds = chainIds || getDefaultChainIds()
+
+    this.sdkClient = new CosmosSDKClient({
+      server: this.clientUrls[network],
+      chainId: this.chainIds[network],
+    })
+  }
+
+  /**
+   * Updates current network.
+   *
+   * @param {Network} network
+   * @returns {void}
+   */
+  setNetwork(network: Network): void {
+    // dirty check to avoid using and re-creation of same data
+    if (network === this.network) return
+
+    super.setNetwork(network)
+    this.sdkClient = new CosmosSDKClient({
+      server: this.clientUrls[network],
+      chainId: this.chainIds[network],
+    })
   }
 
   /**
@@ -119,7 +140,7 @@ class Client extends BaseXChainClient implements CosmosClient, XChainClient {
   }
 
   getSDKClient(): CosmosSDKClient {
-    return this.sdkClients.get(this.network) || TESTNET_SDK
+    return this.sdkClient
   }
 
   /**
@@ -168,19 +189,16 @@ class Client extends BaseXChainClient implements CosmosClient, XChainClient {
    * @returns {Balance[]} The balance of the address.
    */
   async getBalance(address: Address, assets?: Asset[]): Promise<Balance[]> {
-    const balances = await this.getSDKClient().getBalance(address)
-    const mainAsset = this.getMainAsset()
+    const coins = await this.getSDKClient().getBalance(address)
+
+    const balances = coins
+      .reduce((acc: Balance[], { denom, amount }) => {
+        const asset = getAsset(denom)
+        return asset ? [...acc, { asset, amount: baseAmount(amount || '0', DECIMAL) }] : acc
+      }, [])
+      .filter(({ asset: balanceAsset }) => !assets || assets.filter((asset) => eqAsset(balanceAsset, asset)).length)
 
     return balances
-      .map((balance) => {
-        return {
-          asset: (balance.denom && getAsset(balance.denom)) || mainAsset,
-          amount: baseAmount(balance.amount, DECIMAL),
-        }
-      })
-      .filter(
-        (balance) => !assets || assets.filter((asset) => assetToString(balance.asset) === assetToString(asset)).length,
-      )
   }
 
   /**
@@ -238,10 +256,23 @@ class Client extends BaseXChainClient implements CosmosClient, XChainClient {
    * @param {TxParams} params The transfer options.
    * @returns {TxHash} The transaction hash.
    */
-  async transfer({ walletIndex, asset, amount, recipient, memo }: TxParams): Promise<TxHash> {
+  async transfer({
+    walletIndex,
+    asset,
+    amount,
+    recipient,
+    memo,
+    gasLimit = new BigNumber(DEFAULT_GAS_LIMIT),
+  }: TxParams & { gasLimit?: BigNumber }): Promise<TxHash> {
     const fromAddressIndex = walletIndex || 0
 
     const mainAsset = this.getMainAsset()
+
+    const fee = new proto.cosmos.tx.v1beta1.Fee({
+      amount: [],
+      gas_limit: cosmosclient.Long.fromString(gasLimit.toFixed(0)),
+    })
+
     return this.getSDKClient().transfer({
       privkey: this.getPrivateKey(fromAddressIndex),
       from: this.getAddress(fromAddressIndex),
@@ -249,6 +280,7 @@ class Client extends BaseXChainClient implements CosmosClient, XChainClient {
       amount: amount.amount().toString(),
       asset: getDenom(asset || mainAsset),
       memo,
+      fee,
     })
   }
 
@@ -266,10 +298,15 @@ class Client extends BaseXChainClient implements CosmosClient, XChainClient {
     memo,
     from_account_number,
     from_sequence,
+    gasLimit = new BigNumber(DEFAULT_GAS_LIMIT),
   }: TxOfflineParams): Promise<string> {
     const fromAddressIndex = walletIndex || 0
 
-    const mainAsset = this.getMainAsset()
+    const fee = new proto.cosmos.tx.v1beta1.Fee({
+      amount: [],
+      gas_limit: cosmosclient.Long.fromString(gasLimit.toFixed(0)),
+    })
+
     return await this.getSDKClient().transferSignedOffline({
       privkey: this.getPrivateKey(fromAddressIndex),
       from: this.getAddress(fromAddressIndex),
@@ -277,24 +314,19 @@ class Client extends BaseXChainClient implements CosmosClient, XChainClient {
       from_sequence,
       to: recipient,
       amount: amount.amount().toString(),
-      asset: getDenom(asset || mainAsset),
+      asset: getDenom(asset || this.getMainAsset()),
       memo,
+      fee,
     })
   }
 
   /**
-   * Get the current fee.
+   * Returns (default) fees.
    *
-   * @returns {Fees} The current fee.
+   * @returns {Fees} Current fees
    */
   async getFees(): Promise<Fees> {
-    // there is no fixed fee, we set fee amount when creating a transaction.
-    return {
-      type: FeeType.FlatFee,
-      fast: baseAmount(750, DECIMAL),
-      fastest: baseAmount(2500, DECIMAL),
-      average: baseAmount(0, DECIMAL),
-    }
+    return singleFee(FeeType.FlatFee, DEFAULT_FEE)
   }
 }
 

--- a/packages/xchain-cosmos/src/const.ts
+++ b/packages/xchain-cosmos/src/const.ts
@@ -1,0 +1,20 @@
+import { baseAmount } from '@xchainjs/xchain-util'
+
+/**
+ * The decimal for cosmos chain.
+ */
+export const DECIMAL = 6
+
+/**
+ * Default gas limit
+ * As same as definition in Cosmosstation's web wallet
+ * @see https://github.com/cosmostation/web-wallet-ts-react/blob/4d78718b613defbd6c92079b33aa8ce9f86d597c/src/constants/chain.ts#L76
+ */
+export const DEFAULT_GAS_LIMIT = '200000'
+
+/**
+ * Default fee
+ * As same as definition in Cosmosstation's web wallet
+ * @see https://github.com/cosmostation/web-wallet-ts-react/blob/4d78718b613defbd6c92079b33aa8ce9f86d597c/src/constants/chain.ts#L66
+ */
+export const DEFAULT_FEE = baseAmount(5000, DECIMAL)

--- a/packages/xchain-cosmos/src/const.ts
+++ b/packages/xchain-cosmos/src/const.ts
@@ -1,9 +1,11 @@
-import { baseAmount } from '@xchainjs/xchain-util'
+import { Asset, Chain, baseAmount } from '@xchainjs/xchain-util'
 
 /**
  * The decimal for cosmos chain.
  */
 export const DECIMAL = 6
+
+export const AssetAtom: Asset = { chain: Chain.Cosmos, symbol: 'ATOM', ticker: 'ATOM', synth: false }
 
 /**
  * Default gas limit

--- a/packages/xchain-cosmos/src/cosmos/sdk-client.ts
+++ b/packages/xchain-cosmos/src/cosmos/sdk-client.ts
@@ -124,7 +124,6 @@ export class CosmosSDKClient {
           !!amount && !!denom ? [...acc, new proto.cosmos.base.v1beta1.Coin({ amount, denom })] : acc,
         [],
       ) || []
-    console.log('SDK getBalance() balances ', balances)
     return balances
   }
 

--- a/packages/xchain-cosmos/src/cosmos/types.ts
+++ b/packages/xchain-cosmos/src/cosmos/types.ts
@@ -1,5 +1,6 @@
 import { proto } from '@cosmos-client/core'
 import { TxParams } from '@xchainjs/xchain-client'
+import BigNumber from 'bignumber.js'
 
 export type CosmosSDKClientParams = {
   server: string
@@ -44,6 +45,7 @@ export type TransferOfflineParams = TransferParams & {
 export type TxOfflineParams = TxParams & {
   from_account_number: string
   from_sequence: string
+  gasLimit?: BigNumber
 }
 
 export type BaseAccountResponse = {

--- a/packages/xchain-cosmos/src/index.ts
+++ b/packages/xchain-cosmos/src/index.ts
@@ -1,4 +1,5 @@
+export * from './types'
+export * from './const'
+export * from './util'
 export * from './cosmos'
 export * from './client'
-export * from './types'
-export * from './util'

--- a/packages/xchain-cosmos/src/types/client-types.ts
+++ b/packages/xchain-cosmos/src/types/client-types.ts
@@ -1,8 +1,4 @@
 import { Network } from '@xchainjs/xchain-client'
-import { Asset, Chain } from '@xchainjs/xchain-util'
-
-export const AssetAtom: Asset = { chain: Chain.Cosmos, symbol: 'ATOM', ticker: 'ATOM', synth: false }
-export const AssetMuon: Asset = { chain: Chain.Cosmos, symbol: 'MUON', ticker: 'MUON', synth: false }
 
 export type ClientUrls = Record<Network, string>
 

--- a/packages/xchain-cosmos/src/types/client-types.ts
+++ b/packages/xchain-cosmos/src/types/client-types.ts
@@ -1,4 +1,23 @@
+import { Network } from '@xchainjs/xchain-client'
 import { Asset, Chain } from '@xchainjs/xchain-util'
 
 export const AssetAtom: Asset = { chain: Chain.Cosmos, symbol: 'ATOM', ticker: 'ATOM', synth: false }
 export const AssetMuon: Asset = { chain: Chain.Cosmos, symbol: 'MUON', ticker: 'MUON', synth: false }
+
+export type ClientUrls = Record<Network, string>
+
+export type ExplorerUrl = Record<Network, string>
+
+export type ExplorerUrls = {
+  root: ExplorerUrl
+  tx: ExplorerUrl
+  address: ExplorerUrl
+}
+
+export type ChainId = string
+export type ChainIds = Record<Network, ChainId>
+
+export type CosmosClientParams = {
+  clientUrls?: ClientUrls
+  chainIds?: ChainIds
+}


### PR DESCRIPTION
Note: PR continues changes started in #597 (thx to @towanTG)

## Add

- [x] const `DEFAULT_GAS_LIMIT`
- [x] const `DEFAULT_FEE`
- [x] Optional parameter `gasLimit` in `transfer` and `transferOffline`
- [x] Params `clientUrls`, `chainIds` for constructor
- [x] Helper `getDefaultClientUrls`
- [x] Helper `getDefaultChainIds`
- [x] Setter `setNetwork`

## Fix
- [x] `getFees` returns values based on `DEFAULT_FEE`
- [x] Initial one instance of `CosmosSDKClient` only depending on network
- [x] Support IBC assets in `getBalances` (#596)
- [x] Get IBC assets from denom in `getAsset`

## Breaking change
- [x] Remove deprecated `AssetMuon`
- [x] Remove deprecated `Client.getMainAsset`

## Update

- [x] Result of `getTxsFromHistory` is filtered by given asset
- [x] Move misc. constants into `const.ts`
- [x] Bump `xchain-cosmos@0.18.0-alpha.1`