### PR TITLE
[xchain-cosmos|thorchain] Misc. updates - mostly to support ATOM - part 2

### DIFF
--- a/packages/xchain-cosmos/CHANGELOG.md
+++ b/packages/xchain-cosmos/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v.0.18.0-alpha.1 (2022-06-20)
+# v.0.18.0 (2022-xx-xx)
 
 ## Add
 
@@ -12,20 +12,25 @@
 
 ## Fix
 
-- `getFees` returns values based on `DEFAULT_FEE`
+- `getFees` checks chain fees provided by `inbound_addresses` first, before using `DEFAULT_FEE`
 - Initial one instance of `CosmosSDKClient` only depending on network
 - Support IBC assets in `getBalances` (#596)
 - Get IBC assets from denom in `getAsset`
+- Order txs in `getTxsFromHistory` to have latest txs on top
+- Fix `RawTxResponse` type
 
 ## Update
 
 - Result of `getTxsFromHistory` is filtered by given asset
 - Move misc. constants into `const.ts`
+- `getTxsFromHistory` checks `MsgSend` txs only and ignores `MsgMultiSend` txs from now
+- Latest `@cosmos-client/core@0.45.10`
 
 ## Breaking change
 
 - Remove deprecated `AssetMuon`
 - Remove deprecated `Client.getMainAsset`
+- Remove deprecated `BaseAccountResponse`
 
 # v.0.17.0 (2022-03-23)
 

--- a/packages/xchain-cosmos/__tests__/client.test.ts
+++ b/packages/xchain-cosmos/__tests__/client.test.ts
@@ -1,4 +1,4 @@
-import { cosmosclient, proto } from '@cosmos-client/core'
+import { proto } from '@cosmos-client/core'
 import { Network, TxsPage } from '@xchainjs/xchain-client'
 import { BaseAmount, baseAmount } from '@xchainjs/xchain-util'
 import nock from 'nock'
@@ -192,7 +192,6 @@ describe('Client Test', () => {
         },
       ],
     })
-    const encodedMsg = cosmosclient.codec.packCosmosAny(msgSend)
 
     assertTxHstory(getClientUrl(cosmosClient), 'cosmos1xvt4e7xd0j9dwv2w83g50tpcltsl90h52003e2', {
       pagination: {
@@ -211,8 +210,7 @@ describe('Client Test', () => {
           gas_used: '148996',
           tx: {
             body: {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              messages: [encodedMsg as any],
+              messages: [msgSend],
             },
           },
           timestamp: '2020-09-25T06:09:15Z',
@@ -234,7 +232,6 @@ describe('Client Test', () => {
         },
       ],
     })
-    const encodedMsg2 = cosmosclient.codec.packCosmosAny(msgSend2)
     assertTxHstory(getClientUrl(cosmosClient), 'cosmos1pjkpqxmvz47a5aw40l98fyktlg7k6hd9heq95z', {
       pagination: {
         total: '1',
@@ -252,8 +249,7 @@ describe('Client Test', () => {
           gas_used: '148996',
           tx: {
             body: {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              messages: [encodedMsg2 as any],
+              messages: [msgSend2],
             },
           },
           timestamp: '2020-09-25T06:09:15Z',
@@ -314,7 +310,6 @@ describe('Client Test', () => {
         },
       ],
     })
-    const encodedMsg = cosmosclient.codec.packCosmosAny(msgSend)
 
     assertTxHashGet(getClientUrl(cosmosClient), '19BFC1E8EBB10AA1EC6B82E380C6F5FD349D367737EA8D55ADB4A24F0F7D1066', {
       tx_response: {
@@ -326,8 +321,7 @@ describe('Client Test', () => {
         gas_used: '148996',
         tx: {
           body: {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            messages: [encodedMsg as any],
+            messages: [msgSend],
           },
         },
         timestamp: '2020-09-25T06:09:15Z',

--- a/packages/xchain-cosmos/__tests__/sdk-client.test.ts
+++ b/packages/xchain-cosmos/__tests__/sdk-client.test.ts
@@ -1,4 +1,4 @@
-import { cosmosclient, proto } from '@cosmos-client/core'
+import { proto } from '@cosmos-client/core'
 import nock from 'nock'
 
 import { CosmosSDKClient } from '../src/cosmos/sdk-client'
@@ -227,7 +227,7 @@ describe('SDK Client Test', () => {
         },
       ],
     })
-    const encodedMsg = cosmosclient.codec.packAnyFromCosmosJSON(msgSend)
+
     assertTxHstory(cosmosTestnetClient.server, 'cosmos1xvt4e7xd0j9dwv2w83g50tpcltsl90h52003e2', {
       pagination: {
         total: '1',
@@ -245,7 +245,7 @@ describe('SDK Client Test', () => {
           gas_used: '148996',
           tx: {
             body: {
-              messages: [encodedMsg],
+              messages: [msgSend],
             },
           },
           timestamp: '2020-09-25T06:09:15Z',
@@ -277,7 +277,7 @@ describe('SDK Client Test', () => {
         },
       ],
     })
-    const encodedMsg2 = cosmosclient.codec.packAnyFromCosmosJSON(msgSend2)
+
     assertTxHstory(thorTestnetClient.server, thor_testnet_address0, {
       pagination: {
         total: '1',
@@ -295,7 +295,7 @@ describe('SDK Client Test', () => {
           gas_used: '148996',
           tx: {
             body: {
-              messages: [encodedMsg2],
+              messages: [msgSend2],
             },
           },
           timestamp: '2020-09-25T06:09:15Z',
@@ -370,7 +370,7 @@ describe('SDK Client Test', () => {
         },
       ],
     })
-    const encodedMsg = cosmosclient.codec.packAnyFromCosmosJSON(msgSend)
+
     assertTxHashGet(cosmosMainnetClient.server, '19BFC1E8EBB10AA1EC6B82E380C6F5FD349D367737EA8D55ADB4A24F0F7D1066', {
       tx_response: {
         height: 45582,
@@ -381,7 +381,7 @@ describe('SDK Client Test', () => {
         gas_used: '148996',
         tx: {
           body: {
-            messages: [encodedMsg],
+            messages: [msgSend],
           },
         },
         timestamp: '2020-09-25T06:09:15Z',
@@ -401,7 +401,7 @@ describe('SDK Client Test', () => {
         },
       ],
     })
-    const encodedMsg2 = cosmosclient.codec.packAnyFromCosmosJSON(msgSend2)
+
     const txHashData: TxResponse = {
       height: 1047,
       txhash: '19BFC1E8EBB10AA1EC6B82E380C6F5FD349D367737EA8D55ADB4A24F0F7D1066',
@@ -411,7 +411,7 @@ describe('SDK Client Test', () => {
       gas_used: '148996',
       tx: {
         body: {
-          messages: [encodedMsg2],
+          messages: [msgSend2],
         },
       },
       timestamp: '2020-09-25T06:09:15Z',

--- a/packages/xchain-cosmos/__tests__/util.test.ts
+++ b/packages/xchain-cosmos/__tests__/util.test.ts
@@ -1,4 +1,4 @@
-import { cosmosclient, proto } from '@cosmos-client/core'
+import { proto } from '@cosmos-client/core'
 import { baseAmount, eqAsset } from '@xchainjs/xchain-util'
 
 import { AssetAtom } from '../src/const'
@@ -108,7 +108,6 @@ describe('cosmos/util', () => {
         },
       ],
     })
-    const encodedMsg = cosmosclient.codec.packAnyFromCosmosJSON(msgSend)
     const txs: TxResponse[] = [
       {
         height: 0,
@@ -119,7 +118,7 @@ describe('cosmos/util', () => {
         gas_used: '35000',
         tx: {
           body: {
-            messages: [encodedMsg, encodedMsg],
+            messages: [msgSend, msgSend],
           },
         } as RawTxResponse,
         timestamp: new Date().toString(),

--- a/packages/xchain-cosmos/package.json
+++ b/packages/xchain-cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-cosmos",
-  "version": "0.18.0-alpha.1",
+  "version": "0.18.0-alpha.2",
   "description": "Custom Cosmos client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",
@@ -35,7 +35,7 @@
     "@xchainjs/xchain-client": "^0.11.3",
     "@xchainjs/xchain-crypto": "^0.2.6",
     "@xchainjs/xchain-util": "^0.7.1",
-    "@cosmos-client/core": "^0.45.1",
+    "@cosmos-client/core": "^0.45.10",
     "axios": "^0.25.0",
     "nock": "^13.0.5"
   },
@@ -46,7 +46,7 @@
     "@xchainjs/xchain-client": "^0.11.3",
     "@xchainjs/xchain-crypto": "^0.2.6",
     "@xchainjs/xchain-util": "^0.7.1",
-    "@cosmos-client/core": "^0.45.1",
+    "@cosmos-client/core": "^0.45.10",
     "axios": "^0.25.0"
   }
 }

--- a/packages/xchain-cosmos/src/cosmos/types.ts
+++ b/packages/xchain-cosmos/src/cosmos/types.ts
@@ -1,5 +1,6 @@
 import { proto } from '@cosmos-client/core'
 import { TxParams } from '@xchainjs/xchain-client'
+import { BaseAmount } from '@xchainjs/xchain-util/lib'
 import BigNumber from 'bignumber.js'
 
 export type CosmosSDKClientParams = {
@@ -46,16 +47,12 @@ export type TxOfflineParams = TxParams & {
   from_account_number: string
   from_sequence: string
   gasLimit?: BigNumber
-}
-
-export type BaseAccountResponse = {
-  type?: string
-  value?: proto.cosmos.auth.v1beta1.BaseAccount
+  feeAmount?: BaseAmount
 }
 
 export type RawTxResponse = {
   body: {
-    messages: proto.cosmos.bank.v1beta1.MsgSend[]
+    messages: proto.cosmos.bank.v1beta1.IMsgSend[]
   }
 }
 

--- a/packages/xchain-thorchain/CHANGELOG.md
+++ b/packages/xchain-thorchain/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v0.25.2 (2022-xx-xx)
+
+## Update
+
+- Latest `@cosmos-client/core@0.45.10`
+- Latest "xchain-cosmos@0.18.0-alpha.2"
+
+## Fix
+
+- Fix `setNetwork` to create new instance of SDK client
+
 # v0.25.1 (2022-06-17)
 
 ## Fix

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -34,10 +34,10 @@
     "generate:ThorchainMsgs": "./genMsgs.sh"
   },
   "devDependencies": {
-    "@cosmos-client/core": "^0.45.1",
+    "@cosmos-client/core": "^0.45.10",
     "@types/big.js": "^6.0.0",
     "@xchainjs/xchain-client": "^0.11.1",
-    "@xchainjs/xchain-cosmos": "^0.17.0",
+    "@xchainjs/xchain-cosmos": "^0.18.0-alpha.1",
     "@xchainjs/xchain-crypto": "^0.2.4",
     "@xchainjs/xchain-util": "^0.5.1",
     "axios": "^0.25.0",
@@ -48,9 +48,9 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@cosmos-client/core": "^0.45.1",
+    "@cosmos-client/core": "^0.45.10",
     "@xchainjs/xchain-client": "^0.11.1",
-    "@xchainjs/xchain-cosmos": "^0.17.0",
+    "@xchainjs/xchain-cosmos": "^0.18.0-alpha.1",
     "@xchainjs/xchain-crypto": "^0.2.4",
     "@xchainjs/xchain-util": "^0.5.1",
     "axios": "^0.25.0",

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-thorchain",
-  "version": "0.25.1",
+  "version": "0.25.2-alpha.1",
   "description": "Custom Thorchain client and utilities used by XChainJS clients",
   "keywords": [
     "THORChain",
@@ -37,7 +37,7 @@
     "@cosmos-client/core": "^0.45.10",
     "@types/big.js": "^6.0.0",
     "@xchainjs/xchain-client": "^0.11.1",
-    "@xchainjs/xchain-cosmos": "^0.18.0-alpha.1",
+    "@xchainjs/xchain-cosmos": "^0.18.0-alpha.2",
     "@xchainjs/xchain-crypto": "^0.2.4",
     "@xchainjs/xchain-util": "^0.5.1",
     "axios": "^0.25.0",
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "@cosmos-client/core": "^0.45.10",
     "@xchainjs/xchain-client": "^0.11.1",
-    "@xchainjs/xchain-cosmos": "^0.18.0-alpha.1",
+    "@xchainjs/xchain-cosmos": "^0.18.0-alpha.2",
     "@xchainjs/xchain-crypto": "^0.2.4",
     "@xchainjs/xchain-util": "^0.5.1",
     "axios": "^0.25.0",

--- a/packages/xchain-thorchain/src/types/client-types.ts
+++ b/packages/xchain-thorchain/src/types/client-types.ts
@@ -1,7 +1,7 @@
-import { cosmosclient } from '@cosmos-client/core'
 import { Network, Tx, TxParams } from '@xchainjs/xchain-client'
 import { Asset, BaseAmount } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
+import Long from 'long'
 
 export type NodeUrl = {
   node: string
@@ -47,8 +47,8 @@ export type TxOfflineParams = TxParams & {
    * Optional: It can be ignored if asset to send from is RUNE
    */
   fromAssetBalance?: BaseAmount
-  fromAccountNumber: cosmosclient.Long.Long
-  fromSequence: cosmosclient.Long.Long
+  fromAccountNumber: Long
+  fromSequence: Long
   gasLimit?: BigNumber
 }
 

--- a/packages/xchain-thorchain/src/util.ts
+++ b/packages/xchain-thorchain/src/util.ts
@@ -14,6 +14,7 @@ import {
 } from '@xchainjs/xchain-util'
 import axios from 'axios'
 import * as bech32Buffer from 'bech32-buffer'
+import Long from 'long'
 
 import { ChainId, ChainIds, ClientUrl, ExplorerUrl, ExplorerUrls, NodeInfoResponse, TxData } from './types'
 import { MsgNativeTx } from './types/messages'
@@ -213,8 +214,8 @@ export const buildUnsignedTx = ({
   cosmosSdk: cosmosclient.CosmosSDK
   txBody: proto.cosmos.tx.v1beta1.TxBody
   signerPubkey: proto.google.protobuf.Any
-  sequence: cosmosclient.Long.Long
-  gasLimit?: cosmosclient.Long.Long
+  sequence: Long
+  gasLimit?: Long
 }): cosmosclient.TxBuilder => {
   const authInfo = new proto.cosmos.tx.v1beta1.AuthInfo({
     signer_infos: [
@@ -255,15 +256,15 @@ export const getEstimatedGas = async ({
   cosmosSDKClient: CosmosSDKClient
   txBody: proto.cosmos.tx.v1beta1.TxBody
   privKey: proto.cosmos.crypto.secp256k1.PrivKey
-  accountNumber: cosmosclient.Long.Long
-  accountSequence: cosmosclient.Long.Long
+  accountNumber: Long
+  accountSequence: Long
   multiplier?: number
-}): Promise<cosmosclient.Long.Long | undefined> => {
+}): Promise<Long | undefined> => {
   const pubKey = privKey.pubKey()
   const txBuilder = buildUnsignedTx({
     cosmosSdk: cosmosSDKClient.sdk,
     txBody: txBody,
-    signerPubkey: cosmosclient.codec.packAny(pubKey),
+    signerPubkey: cosmosclient.codec.instanceToProtoAny(pubKey),
     sequence: accountSequence,
   })
 
@@ -278,7 +279,7 @@ export const getEstimatedGas = async ({
     throw new Error('Could not get data of estimated gas')
   }
 
-  return cosmosclient.Long.fromString(estimatedGas).multiply(multiplier || DEFAULT_GAS_ADJUSTMENT)
+  return Long.fromString(estimatedGas).multiply(multiplier || DEFAULT_GAS_ADJUSTMENT)
 }
 /**
  * Structure a MsgDeposit
@@ -317,7 +318,7 @@ export const buildDepositTx = async ({
   const depositMsg = types.types.MsgDeposit.fromObject(msgDepositObj)
 
   return new proto.cosmos.tx.v1beta1.TxBody({
-    messages: [cosmosclient.codec.packAny(depositMsg)],
+    messages: [cosmosclient.codec.instanceToProtoAny(depositMsg)],
     memo: msgNativeTx.memo,
   })
 }
@@ -372,7 +373,7 @@ export const buildTransferTx = async ({
   const transferMsg = types.types.MsgSend.fromObject(transferObj)
 
   return new proto.cosmos.tx.v1beta1.TxBody({
-    messages: [cosmosclient.codec.packAny(transferMsg)],
+    messages: [cosmosclient.codec.instanceToProtoAny(transferMsg)],
     memo,
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -332,10 +332,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@cosmos-client/core@^0.45.1":
-  version "0.45.1"
-  resolved "https://registry.yarnpkg.com/@cosmos-client/core/-/core-0.45.1.tgz#c57dbf861b7300203616362207fde24c58de6f32"
-  integrity sha512-AAf+UBwzcJvMpOFy6bBUGlF+wiGko32yekYtC/J3fxnC/NyAsOsqzPDLxgat6lveOfYESRdZslw78UMbKz7oQA==
+"@cosmos-client/core@^0.45.10":
+  version "0.45.10"
+  resolved "https://registry.yarnpkg.com/@cosmos-client/core/-/core-0.45.10.tgz#6cafc367b3392760fbe0580c76b43e5a72afb413"
+  integrity sha512-9VHGkCz3uomX5gZM0ToDHzzDAVY/vqccgLvjjrZnMZmKeog70pHw+cPtOyrcX1TZIoQKSsLqUbV6ccdB/p/fWA==
   dependencies:
     axios "^0.23.0"
     bech32 "^1.1.4"


### PR DESCRIPTION
# xchain-cosmos

- [x] Fix `getFees` to check chain fees provided by `inbound_addresses` first, before using `DEFAULT_FEE`
- [x] Fix order of txs in `getTxsFromHistory` to have latest txs on top
- [x] Add optional `feeAmount` to `transfer` / `transferOffline` to override fee
- [x] Fix `RawTxResponse` type
- [x] `getTxsFromHistory` checks `MsgSend` txs only and ignores `MsgMultiSend` txs
- [x] Latest `@cosmos-client/core@0.45.10`
- [x] Bump `v0.18.0-alpha.2`


# xchain-thorchain

- [x] - Latest `@cosmos-client/core@0.45.10`
- [x] Latest "xchain-cosmos@0.18.0-alpha.2"
- [x] Fix `setNetwork` to create new instance of SDK client
- [x] Bump `v0.25.2-alpha.1`