### PR TITLE
[xchain-cosmos] Changes needed to support Ledger

### DIFF
--- a/packages/xchain-cosmos/CHANGELOG.md
+++ b/packages/xchain-cosmos/CHANGELOG.md
@@ -1,8 +1,16 @@
-# v.0.18.1 (2022-xx-xx)
+# v.0.19.0 (2022-xx-xx)
 
 ## Add
 
-- helper `getDefaultRootDerivationPaths`
+- Helpers `getDefaultRootDerivationPaths`. `getChainId`, `getChainIds`, `protoFee`, `protoMsgSend`, `protoTxBody`, `protoAuthInfo`
+
+## Breaking change
+
+- Helper `getDenom` supports `ATOM` only + returns `null` for all other assets
+- Remove `CosmosSDKClient.getUnsignedTxBody`
+- Rename `asset` -> `denom` in `TransferParams`
+- Change type of `amount` from `string` -> `BaseAmount` in `TransferParams`
+- Remove `account` param from `CosmosSDKClient.signAndBroadcast` in favour of `accountNumber`
 
 # v.0.18.0 (2022-06-22)
 

--- a/packages/xchain-cosmos/CHANGELOG.md
+++ b/packages/xchain-cosmos/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.18.1 (2022-xx-xx)
+
+## Add
+
+- helper `getDefaultRootDerivationPaths`
+
 # v.0.18.0 (2022-06-22)
 
 ## Add

--- a/packages/xchain-cosmos/__tests__/sdk-client.test.ts
+++ b/packages/xchain-cosmos/__tests__/sdk-client.test.ts
@@ -1,4 +1,5 @@
 import { proto } from '@cosmos-client/core'
+import { baseAmount } from '@xchainjs/xchain-util'
 import nock from 'nock'
 
 import { CosmosSDKClient } from '../src/cosmos/sdk-client'
@@ -334,8 +335,8 @@ describe('SDK Client Test', () => {
         privkey: cosmosTestnetClient.getPrivKeyFromMnemonic(cosmos_phrase, derivationPaths.cosmos.testnet + '0'),
         from: cosmos_testnet_address0,
         to: 'cosmos1gehrq0pr5d79q8nxnaenvqh09g56jafm82thjv',
-        amount: '10000',
-        asset: 'muon',
+        amount: baseAmount('10000'),
+        denom: 'muon',
         memo: 'transfer',
       })
 

--- a/packages/xchain-cosmos/package.json
+++ b/packages/xchain-cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-cosmos",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.1",
   "description": "Custom Cosmos client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",

--- a/packages/xchain-cosmos/src/client.ts
+++ b/packages/xchain-cosmos/src/client.ts
@@ -23,7 +23,14 @@ import { AssetAtom, COSMOS_DECIMAL, DEFAULT_FEE, DEFAULT_GAS_LIMIT } from './con
 import { CosmosSDKClient } from './cosmos/sdk-client'
 import { TxOfflineParams } from './cosmos/types'
 import { ChainIds, ClientUrls, CosmosClientParams } from './types'
-import { getAsset, getDefaultChainIds, getDefaultClientUrls, getDenom, getTxsFromHistory } from './util'
+import {
+  getAsset,
+  getDefaultChainIds,
+  getDefaultClientUrls,
+  getDefaultRootDerivationPaths,
+  getDenom,
+  getTxsFromHistory,
+} from './util'
 
 /**
  * Interface for custom Cosmos client
@@ -55,11 +62,7 @@ class Client extends BaseXChainClient implements CosmosClient, XChainClient {
     phrase,
     clientUrls,
     chainIds,
-    rootDerivationPaths = {
-      [Network.Mainnet]: `44'/118'/0'/0/`,
-      [Network.Testnet]: `44'/118'/0'/0/`,
-      [Network.Stagenet]: `44'/118'/0'/0/`,
-    },
+    rootDerivationPaths = getDefaultRootDerivationPaths(),
   }: XChainClientParams & CosmosClientParams) {
     super(Chain.Cosmos, { network, rootDerivationPaths, phrase })
 

--- a/packages/xchain-cosmos/src/cosmos/types.ts
+++ b/packages/xchain-cosmos/src/cosmos/types.ts
@@ -1,6 +1,6 @@
 import { proto } from '@cosmos-client/core'
-import { TxParams } from '@xchainjs/xchain-client'
-import { BaseAmount } from '@xchainjs/xchain-util/lib'
+import { Address, TxParams } from '@xchainjs/xchain-client'
+import { BaseAmount } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 
 export type CosmosSDKClientParams = {
@@ -23,17 +23,17 @@ export type SearchTxParams = {
 export type UnsignedTxParams = {
   from: string
   to: string
-  amount: string
-  asset: string
+  amount: BaseAmount
+  denom: string
   memo?: string
 }
 
 export type TransferParams = {
   privkey: proto.cosmos.crypto.secp256k1.PrivKey
-  from: string
-  to: string
-  amount: string
-  asset: string
+  from: Address
+  to: Address
+  amount: BaseAmount
+  denom: string
   memo?: string
   fee?: proto.cosmos.tx.v1beta1.Fee
 }

--- a/packages/xchain-cosmos/src/util.ts
+++ b/packages/xchain-cosmos/src/util.ts
@@ -1,5 +1,5 @@
 import { proto } from '@cosmos-client/core'
-import { FeeType, Fees, Network, Tx, TxFrom, TxTo, TxType } from '@xchainjs/xchain-client'
+import { FeeType, Fees, Network, RootDerivationPaths, Tx, TxFrom, TxTo, TxType } from '@xchainjs/xchain-client'
 import { Asset, BaseAmount, CosmosChain, baseAmount, eqAsset } from '@xchainjs/xchain-util'
 
 import { AssetAtom, COSMOS_DECIMAL } from './const'
@@ -230,3 +230,9 @@ export const getDefaultChainIds = (): ChainIds => {
     [Network.Mainnet]: mainChainId,
   }
 }
+
+export const getDefaultRootDerivationPaths = (): RootDerivationPaths => ({
+  [Network.Mainnet]: `44'/118'/0'/0/`,
+  [Network.Testnet]: `44'/118'/0'/0/`,
+  [Network.Stagenet]: `44'/118'/0'/0/`,
+})

--- a/packages/xchain-cosmos/src/util.ts
+++ b/packages/xchain-cosmos/src/util.ts
@@ -1,10 +1,14 @@
-import { proto } from '@cosmos-client/core'
+import { cosmosclient, proto } from '@cosmos-client/core'
+import { cosmos } from '@cosmos-client/core/cjs/proto'
 import { FeeType, Fees, Network, RootDerivationPaths, Tx, TxFrom, TxTo, TxType } from '@xchainjs/xchain-client'
 import { Asset, BaseAmount, CosmosChain, baseAmount, eqAsset } from '@xchainjs/xchain-util'
+import axios from 'axios'
+import BigNumber from 'bignumber.js'
+import Long from 'long'
 
-import { AssetAtom, COSMOS_DECIMAL } from './const'
-import { APIQueryParam, TxResponse } from './cosmos/types'
-import { ChainIds, ClientUrls as ClientUrls } from './types'
+import { AssetAtom, COSMOS_DECIMAL, DEFAULT_GAS_LIMIT } from './const'
+import { APIQueryParam, TxResponse, UnsignedTxParams } from './cosmos/types'
+import { ChainId, ChainIds, ClientUrls as ClientUrls } from './types'
 
 /**
  * Type guard for MsgSend
@@ -28,14 +32,14 @@ export const isMsgMultiSend = (msg: unknown): msg is proto.cosmos.bank.v1beta1.M
   (msg as proto.cosmos.bank.v1beta1.MsgMultiSend)?.outputs !== undefined
 
 /**
- * Get denomination from Asset
+ * Get denomination from Asset - currently `ATOM` supported only
  *
  * @param {Asset} asset
  * @returns {string} The denomination of the given asset.
  */
-export const getDenom = (asset: Asset): string => {
+export const getDenom = (asset: Asset): string | null => {
   if (eqAsset(asset, AssetAtom)) return 'uatom'
-  return asset.symbol
+  return null
 }
 
 /**
@@ -236,3 +240,104 @@ export const getDefaultRootDerivationPaths = (): RootDerivationPaths => ({
   [Network.Testnet]: `44'/118'/0'/0/`,
   [Network.Stagenet]: `44'/118'/0'/0/`,
 })
+
+export const protoFee = ({
+  denom,
+  amount,
+  gasLimit = new BigNumber(DEFAULT_GAS_LIMIT),
+}: {
+  denom: string
+  amount: BaseAmount
+  gasLimit?: BigNumber
+}): proto.cosmos.tx.v1beta1.Fee =>
+  new proto.cosmos.tx.v1beta1.Fee({
+    amount: [
+      {
+        denom,
+        amount: amount.amount().toFixed(0),
+      },
+    ],
+    gas_limit: Long.fromString(gasLimit.toFixed(0)),
+  })
+
+export const protoMsgSend = ({
+  from,
+  to,
+  amount,
+  denom,
+}: {
+  from: string
+  to: string
+  amount: BaseAmount
+  denom: string
+}): proto.cosmos.bank.v1beta1.MsgSend =>
+  new proto.cosmos.bank.v1beta1.MsgSend({
+    from_address: from,
+    to_address: to,
+    amount: [
+      {
+        amount: amount.amount().toFixed(0),
+        denom,
+      },
+    ],
+  })
+
+export const protoTxBody = ({ from, to, amount, denom, memo }: UnsignedTxParams): proto.cosmos.tx.v1beta1.TxBody => {
+  const msg = protoMsgSend({ from, to, amount, denom })
+
+  return new proto.cosmos.tx.v1beta1.TxBody({
+    messages: [cosmosclient.codec.instanceToProtoAny(msg)],
+    memo,
+  })
+}
+
+export const protoAuthInfo = ({
+  pubKey,
+  sequence,
+  mode,
+  fee,
+}: {
+  pubKey: cosmosclient.PubKey
+  sequence: Long.Long
+  mode: proto.cosmos.tx.signing.v1beta1.SignMode
+  fee?: cosmos.tx.v1beta1.IFee
+}): proto.cosmos.tx.v1beta1.AuthInfo =>
+  new proto.cosmos.tx.v1beta1.AuthInfo({
+    signer_infos: [
+      {
+        public_key: cosmosclient.codec.instanceToProtoAny(pubKey),
+        mode_info: {
+          single: {
+            mode,
+          },
+        },
+        sequence,
+      },
+    ],
+    fee,
+  })
+
+/**
+ * Helper to get Cosmos' chain id
+ * @param {string} url API url
+ */
+export const getChainId = async (url: string): Promise<ChainId> => {
+  const { data } = await axios.get<{ node_info: { network: string } }>(`${url}/node_info`)
+  return data?.node_info?.network || Promise.reject('Could not parse chain id')
+}
+
+/**
+ * Helper to get Cosmos' chain id for all networks
+ * @param {ClientUrl} urls urls (use `getDefaultClientUrl()` if you don't need to use custom urls)
+ */
+export const getChainIds = async (urls: ClientUrls): Promise<ChainIds> => {
+  return Promise.all([
+    getChainId(urls[Network.Testnet]),
+    getChainId(urls[Network.Stagenet]),
+    getChainId(urls[Network.Mainnet]),
+  ]).then(([testnetId, stagenetId, mainnetId]) => ({
+    testnet: testnetId,
+    stagenet: stagenetId,
+    mainnet: mainnetId,
+  }))
+}

--- a/packages/xchain-thorchain/CHANGELOG.md
+++ b/packages/xchain-thorchain/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.25.3 (2022-xx-xx)
+
+## Update
+
+- Latest "xchain-cosmos@0.19.0"
+
 # v0.25.2 (2022-06-22)
 
 ## Update

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-thorchain",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "Custom Thorchain client and utilities used by XChainJS clients",
   "keywords": [
     "THORChain",
@@ -37,7 +37,7 @@
     "@cosmos-client/core": "^0.45.10",
     "@types/big.js": "^6.0.0",
     "@xchainjs/xchain-client": "^0.11.1",
-    "@xchainjs/xchain-cosmos": "^0.18.0-alpha.2",
+    "@xchainjs/xchain-cosmos": "^0.19.0-alpha.1",
     "@xchainjs/xchain-crypto": "^0.2.4",
     "@xchainjs/xchain-util": "^0.5.1",
     "axios": "^0.25.0",
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "@cosmos-client/core": "^0.45.10",
     "@xchainjs/xchain-client": "^0.11.1",
-    "@xchainjs/xchain-cosmos": "^0.18.0",
+    "@xchainjs/xchain-cosmos": "^0.19.0-alpha.1",
     "@xchainjs/xchain-crypto": "^0.2.4",
     "@xchainjs/xchain-util": "^0.5.1",
     "axios": "^0.25.0",

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-thorchain",
-  "version": "0.25.3",
+  "version": "0.25.3-alpha.1",
   "description": "Custom Thorchain client and utilities used by XChainJS clients",
   "keywords": [
     "THORChain",

--- a/packages/xchain-thorchain/src/client.ts
+++ b/packages/xchain-thorchain/src/client.ts
@@ -484,7 +484,8 @@ class Client extends BaseXChainClient implements ThorchainClient, XChainClient {
     })
 
     const account = await this.getCosmosClient().getAccount(fromAddressAcc)
-    const accountSequence = account.sequence || Long.ZERO
+    const { account_number: accountNumber } = account
+    if (!accountNumber) throw Error(`Deposit failed - could not get account number ${accountNumber}`)
 
     const txBuilder = buildUnsignedTx({
       cosmosSdk: this.getCosmosClient().sdk,
@@ -494,7 +495,7 @@ class Client extends BaseXChainClient implements ThorchainClient, XChainClient {
       sequence: account.sequence || Long.ZERO,
     })
 
-    const txHash = await this.getCosmosClient().signAndBroadcast(txBuilder, privKey, accountSequence)
+    const txHash = await this.getCosmosClient().signAndBroadcast(txBuilder, privKey, accountNumber)
 
     if (!txHash) throw Error(`Invalid transaction hash: ${txHash}`)
 
@@ -555,17 +556,18 @@ class Client extends BaseXChainClient implements ThorchainClient, XChainClient {
       nodeUrl: this.getClientUrl().node,
     })
     const account = await this.getCosmosClient().getAccount(accAddress)
-    const accountSequence = account.sequence || Long.ZERO
+    const { account_number: accountNumber } = account
+    if (!accountNumber) throw Error(`Deposit failed - could not get account number ${accountNumber}`)
 
     const txBuilder = buildUnsignedTx({
       cosmosSdk: this.getCosmosClient().sdk,
       txBody: txBody,
       gasLimit: Long.fromString(gasLimit.toString()),
       signerPubkey: cosmosclient.codec.instanceToProtoAny(signerPubkey),
-      sequence: accountSequence,
+      sequence: account.sequence || Long.ZERO,
     })
 
-    const txHash = await this.cosmosClient.signAndBroadcast(txBuilder, privKey, accountSequence)
+    const txHash = await this.cosmosClient.signAndBroadcast(txBuilder, privKey, accountNumber)
 
     if (!txHash) throw Error(`Invalid transaction hash: ${txHash}`)
 

--- a/packages/xchain-thorchain/src/client.ts
+++ b/packages/xchain-thorchain/src/client.ts
@@ -484,6 +484,7 @@ class Client extends BaseXChainClient implements ThorchainClient, XChainClient {
     })
 
     const account = await this.getCosmosClient().getAccount(fromAddressAcc)
+    const accountSequence = account.sequence || Long.ZERO
 
     const txBuilder = buildUnsignedTx({
       cosmosSdk: this.getCosmosClient().sdk,
@@ -493,7 +494,7 @@ class Client extends BaseXChainClient implements ThorchainClient, XChainClient {
       sequence: account.sequence || Long.ZERO,
     })
 
-    const txHash = await this.getCosmosClient().signAndBroadcast(txBuilder, privKey, account)
+    const txHash = await this.getCosmosClient().signAndBroadcast(txBuilder, privKey, accountSequence)
 
     if (!txHash) throw Error(`Invalid transaction hash: ${txHash}`)
 
@@ -564,7 +565,7 @@ class Client extends BaseXChainClient implements ThorchainClient, XChainClient {
       sequence: accountSequence,
     })
 
-    const txHash = await this.cosmosClient.signAndBroadcast(txBuilder, privKey, account)
+    const txHash = await this.cosmosClient.signAndBroadcast(txBuilder, privKey, accountSequence)
 
     if (!txHash) throw Error(`Invalid transaction hash: ${txHash}`)
 


### PR DESCRIPTION
# xchain-cosmos

## Add
- [x] Helpers `getDefaultRootDerivationPaths`. `getChainId`, `getChainIds`, `protoFee`, `protoMsgSend`, `protoTxBody`, `protoAuthInfo`

## Breaking change
- [x] Helper `getDenom` supports `ATOM` only + returns `null` for all other assets
- [x] Remove `CosmosSDKClient.getUnsignedTxBody`
- [x] Rename `asset` -> `denom` in `TransferParams`
- [x] Change type of `amount` from `string` -> `BaseAmount` in `TransferParams`
- [x] Remove `account` param from `CosmosSDKClient.signAndBroadcast` in favour of `accountNumber`

## Update
- [x] Bump `xchain-cosmos@0.19.0-alpha.1`

# xchain-thorchain
 - [x] Bump `xchain-thorchain@0.21.3-alpha.1`