### PR TITLE
[xchain-bch] Handle Haskoins 500 error

### DIFF
--- a/packages/xchain-bitcoincash/CHANGELOG.md
+++ b/packages/xchain-bitcoincash/CHANGELOG.md
@@ -1,11 +1,16 @@
+# v.0.13.2 (2022-07-13)
+
+## Fix
+
+- Broadcast same tx several times to Haskoin in case of `500` error (similar to #492, but for BCH)
+
 # v.0.13.1 (2022-05-05)
 
 ## Update
 
 - Add `deposit` function to BitcoinCash `Client`
 - Update latest dependencies
-- Add tests for `deposit` 
-
+- Add tests for `deposit`
 
 # v.0.13.0 (2022-03-23)
 

--- a/packages/xchain-bitcoincash/package.json
+++ b/packages/xchain-bitcoincash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-bitcoincash",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Custom bitcoincash client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",
@@ -39,7 +39,7 @@
     "@psf/bitcoincashjs-lib": "^4.0.2",
     "@types/bchaddrjs": "0.4.0",
     "@types/uniqid": "^5.3.1",
-    "@xchainjs/xchain-client": "^0.11.2",
+    "@xchainjs/xchain-client": "^0.11.3",
     "@xchainjs/xchain-crypto": "^0.2.6",
     "@xchainjs/xchain-util": "^0.7.1",
     "axios": "^0.25.0",
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "@psf/bitcoincashjs-lib": "^4.0.2",
-    "@xchainjs/xchain-client": "^0.11.2",
+    "@xchainjs/xchain-client": "^0.11.3",
     "@xchainjs/xchain-crypto": "^0.2.6",
     "@xchainjs/xchain-util": "^0.7.1",
     "axios": "^0.25.0",

--- a/packages/xchain-bitcoincash/src/haskoin-api.ts
+++ b/packages/xchain-bitcoincash/src/haskoin-api.ts
@@ -1,5 +1,6 @@
-import { TxHash } from '@xchainjs/xchain-client/lib'
-import axios, { AxiosResponse } from 'axios'
+import { TxHash } from '@xchainjs/xchain-client'
+import { delay } from '@xchainjs/xchain-util'
+import axios, { AxiosError, AxiosResponse } from 'axios'
 
 import {
   AddressBalance,
@@ -136,14 +137,44 @@ export const getSuggestedFee = async (): Promise<number> => {
  *
  * @see https://app.swaggerhub.com/apis/eligecode/blockchain-api/0.0.1-oas3#/blockchain/sendTransaction
  *
+ * Note: Because of an Haskoin issue (@see https://github.com/haskoin/haskoin-store/issues/25),
+ * we need to broadcast same tx several times in case of `500` errors
+ * @see https://github.com/xchainjs/xchainjs-lib/issues/492
+ *
  * @param {BroadcastTxParams} params
  * @returns {TxHash} Transaction hash.
  */
-
 export const broadcastTx = async ({ txHex, haskoinUrl }: BroadcastTxParams): Promise<TxHash> => {
-  const {
-    data: { txid },
-  } = await axios.post<string, AxiosResponse<{ txid: string }>>(`${haskoinUrl}/transactions`, txHex)
+  const instance = axios.create()
 
-  return txid
+  const MAX = 5
+  let counter = 0
+
+  const onFullfilled = (res: AxiosResponse): AxiosResponse => res
+  const onRejected = async (error: AxiosError): Promise<AxiosResponse> => {
+    const config = error.config
+    if (counter < MAX && error.response?.status === 500) {
+      counter++
+      await delay(200 * counter)
+      return instance.request(config)
+    }
+    return Promise.reject(error)
+  }
+  // All logic for re-sending same tx is handled by Axios' response interceptor
+  // https://github.com/axios/axios#interceptors
+  const id = instance.interceptors.response.use(onFullfilled, onRejected)
+
+  const url = `${haskoinUrl}/transactions`
+  try {
+    const {
+      data: { txid },
+    } = await instance.post<string, AxiosResponse<{ txid: string }>>(url, txHex)
+    // clean up interceptor from axios instance
+    instance.interceptors.response.eject(id)
+    return txid
+  } catch (error: unknown) {
+    // clean up interceptor from axios instance
+    instance.interceptors.response.eject(id)
+    return Promise.reject(error)
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5568,6 +5568,18 @@ glob@7.1.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.0.5:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
@@ -7441,6 +7453,13 @@ minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -10725,6 +10744,14 @@ yaml@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
+
+yamljs@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/yamljs/-/yamljs-0.3.0.tgz#dc060bf267447b39f7304e9b2bfbe8b5a7ddb03b"
+  integrity sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==
+  dependencies:
+    argparse "^1.0.7"
+    glob "^7.0.5"
 
 yargs-parser@20.x, yargs-parser@^20.2.3:
   version "20.2.4"


### PR DESCRIPTION
Similar to #492 + #493, but for BCH.

Bump `xchain-bch@0.13.2` + update it dependencies for using latest `xchain-client@0.11.3"