### PR TITLE
[xchain-doge] Fix maximum fee rate

### DIFF
--- a/packages/xchain-doge/CHANGELOG.md
+++ b/packages/xchain-doge/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.5.1 (2022-09-27)
+
+## Fix
+
+- Increase value for `setMaximumFeeRate` to reflect current fees
+
 # v.0.5.0 (2022-09-05)
 
 ## Update

--- a/packages/xchain-doge/package.json
+++ b/packages/xchain-doge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-doge",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Custom Doge client and utilities used by XChain clients",
   "keywords": [
     "Xchain",

--- a/packages/xchain-doge/src/utils.ts
+++ b/packages/xchain-doge/src/utils.ts
@@ -252,8 +252,10 @@ export const buildTx = async ({
 
   const psbt = new Dogecoin.Psbt({ network: dogeNetwork(network) }) // Network-specific
   // TODO: Doge recommended fees is greater than the recommended by Bitcoinjs-lib (for BTC),
-  //       so we need to increase the maximum fee rate. Currently, the fast rate fee is near ~650000sats/byte
-  psbt.setMaximumFeeRate(650000)
+  //       so we need to increase the maximum fee rate. Currently, the fast rate fee is near ~750000sats/byte
+  // https://thornode.ninerealms.com/thorchain/inbound_addresses?height=7526662 (09-27-2022)
+  // For now we increase it by 10x
+  psbt.setMaximumFeeRate(7500000)
   const params = { sochainUrl, network, address: sender }
 
   for (const utxo of inputs) {


### PR DESCRIPTION
`setMaximumFeeRate` needs to be increased to cover current fees of [750000sats/byte](https://thornode.ninerealms.com/thorchain/inbound_addresses?height=7526662). Bug was reported in Discord `#asgardex-desktop` https://discord.com/channels/838986635756044328/839002220942721024/1024199604192952340

Before: `650000 sats/byte`
Now: `7500000 sats/byte` (10x of current fee rate)

Comparing to
- xchain-thorswap: `650000000` ([code](https://github.com/thorswap/thorswap-xchainjs/blob/main/packages/xchain-doge/src/utils.ts#L214))
- THORWallet-xchainjs `5500000` ([code](https://github.com/THORWallet/THORWallet-xchainjs/blob/master/packages/xchain-doge/src/utils.ts#L172))
