### PR TITLE
A more type safety export of `{XYZ}Chain`

### DIFF
--- a/packages/xchain-avax/CHANGELOG.md
+++ b/packages/xchain-avax/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.1.4 (2023-01-19)
+
+## Update
+
+- Type safety `AVAXChain`
+
 # v.0.1.3 (2022-12-27)
 
 ## Add

--- a/packages/xchain-avax/package.json
+++ b/packages/xchain-avax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-avax",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Avax EVM client for XChainJS",
   "keywords": [
     "XChain",

--- a/packages/xchain-avax/src/const.ts
+++ b/packages/xchain-avax/src/const.ts
@@ -1,6 +1,6 @@
 import { Network } from '@xchainjs/xchain-client'
 import { EVMClientParams, EtherscanProvider, ExplorerProvider } from '@xchainjs/xchain-evm'
-import { Asset, Chain } from '@xchainjs/xchain-util'
+import { Asset } from '@xchainjs/xchain-util'
 import { BigNumber, ethers } from 'ethers'
 
 export const AVAX_DECIMAL = 8
@@ -14,7 +14,7 @@ export const AVAX_GAS_ASSET_DECIMAL = 18
  * Chain identifier for AVAX.
  *
  */
-export const AVAXChain: Chain = 'AVAX'
+export const AVAXChain = 'AVAX' as const
 
 /**
  * Base "chain" asset of Avalanche chain.

--- a/packages/xchain-binance/CHANGELOG.md
+++ b/packages/xchain-binance/CHANGELOG.md
@@ -1,8 +1,8 @@
-# v.5.6.6 (2022-12-27)
+# v.5.6.7 (2023-01-19)
 
-## Add
+## Update
 
-- Add `AssetBNB` and `BNBChain` definition
+- Type safety `BNBChain`
 
 ## Update
 

--- a/packages/xchain-binance/package.json
+++ b/packages/xchain-binance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-binance",
-  "version": "5.6.6",
+  "version": "5.6.7",
   "description": "Custom Binance client and utilities used by XChainJS clients",
   "keywords": [
     "BNB",

--- a/packages/xchain-binance/src/const.ts
+++ b/packages/xchain-binance/src/const.ts
@@ -1,10 +1,10 @@
-import { Asset, Chain } from '@xchainjs/xchain-util'
+import { Asset } from '@xchainjs/xchain-util'
 
 /**
  * Chain identifier for BNB.
  *
  */
-export const BNBChain: Chain = 'BNB'
+export const BNBChain = 'BNB' as const
 
 /**
  * Base "chain" asset of Binance chain.

--- a/packages/xchain-bitcoin/CHANGELOG.md
+++ b/packages/xchain-bitcoin/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.20.8 (2023-01-19)
+
+## Update
+
+- Type safety `BTCChain`
+
 # v.0.20.7 (2022-12-27)
 
 ## Add

--- a/packages/xchain-bitcoin/package.json
+++ b/packages/xchain-bitcoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-bitcoin",
-  "version": "0.20.7",
+  "version": "0.20.8",
   "description": "Custom Bitcoin client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",

--- a/packages/xchain-bitcoin/src/const.ts
+++ b/packages/xchain-bitcoin/src/const.ts
@@ -1,4 +1,4 @@
-import { Asset, Chain } from '@xchainjs/xchain-util'
+import { Asset } from '@xchainjs/xchain-util'
 
 /**
  * Minimum transaction fee
@@ -18,7 +18,7 @@ export const BTC_SATOSHI_SYMBOL = '⚡'
  * Chain identifier for Bitcoin mainnet
  *
  */
-export const BTCChain: Chain = 'BTC'
+export const BTCChain = 'BTC' as const
 
 /**
  * Base "chain" asset on bitcoin main net.

--- a/packages/xchain-bitcoincash/CHANGELOG.md
+++ b/packages/xchain-bitcoincash/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.15.7 (2023-01-19)
+
+## Update
+
+- Type safety `BCHChain`
+
 # v.0.15.6 (2022-12-27)
 
 ## Add

--- a/packages/xchain-bitcoincash/package.json
+++ b/packages/xchain-bitcoincash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-bitcoincash",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "description": "Custom bitcoincash client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",

--- a/packages/xchain-bitcoincash/src/const.ts
+++ b/packages/xchain-bitcoincash/src/const.ts
@@ -1,4 +1,4 @@
-import { Asset, Chain } from '@xchainjs/xchain-util'
+import { Asset } from '@xchainjs/xchain-util'
 
 export const LOWER_FEE_BOUND = 1
 export const UPPER_FEE_BOUND = 500
@@ -7,7 +7,7 @@ export const UPPER_FEE_BOUND = 500
  * Chain identifier for Bitcoin Cash
  *
  */
-export const BCHChain: Chain = 'BCH'
+export const BCHChain = 'BCH' as const
 
 /**
  * Base "chain" asset on bitcoincash main net.

--- a/packages/xchain-cosmos/CHANGELOG.md
+++ b/packages/xchain-cosmos/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.20.7 (2023-01-19)
+
+## Update
+
+- Type safety `GAIAChain`
+
 # v.0.20.6 (2022-12-27)
 
 ## Add

--- a/packages/xchain-cosmos/package.json
+++ b/packages/xchain-cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-cosmos",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "description": "Custom Cosmos client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",

--- a/packages/xchain-cosmos/src/const.ts
+++ b/packages/xchain-cosmos/src/const.ts
@@ -1,4 +1,4 @@
-import { Asset, Chain, baseAmount } from '@xchainjs/xchain-util'
+import { Asset, baseAmount } from '@xchainjs/xchain-util'
 
 /**
  * The decimal for cosmos chain.
@@ -23,7 +23,7 @@ export const DEFAULT_FEE = baseAmount(5000, COSMOS_DECIMAL)
  * Chain identifier for Cosmos chain
  *
  */
-export const GAIAChain: Chain = 'GAIA'
+export const GAIAChain = 'GAIA' as const
 /**
  * Base "chain" asset on cosmos main net.
  *

--- a/packages/xchain-doge/CHANGELOG.md
+++ b/packages/xchain-doge/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.5.7 (2023-01-19)
+
+## Update
+
+- Type safety `DOGEChain`
+
 # v.0.5.6 (2022-12-27)
 
 ## Add

--- a/packages/xchain-doge/package.json
+++ b/packages/xchain-doge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-doge",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Custom Doge client and utilities used by XChain clients",
   "keywords": [
     "Xchain",

--- a/packages/xchain-doge/src/const.ts
+++ b/packages/xchain-doge/src/const.ts
@@ -1,4 +1,4 @@
-import { Asset, Chain } from '@xchainjs/xchain-util'
+import { Asset } from '@xchainjs/xchain-util'
 
 /**
  * Minimum transaction fee
@@ -14,7 +14,7 @@ export const UPPER_FEE_BOUND = 20_000_000
  * Chain identifier for Dogecoin
  *
  */
-export const DOGEChain: Chain = 'DOGE'
+export const DOGEChain = 'DOGE' as const
 
 /**
  * Base "chain" asset on dogecoin

--- a/packages/xchain-ethereum/CHANGELOG.md
+++ b/packages/xchain-ethereum/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.27.7 (2023-01-19)
+
+## Update
+
+- Type safety `ETHChain`
+
 # v.0.27.6 (2022-12-27)
 
 ## Add

--- a/packages/xchain-ethereum/package.json
+++ b/packages/xchain-ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-ethereum",
-  "version": "0.27.6",
+  "version": "0.27.7",
   "description": "Ethereum client for XChainJS",
   "keywords": [
     "XChain",

--- a/packages/xchain-ethereum/src/const.ts
+++ b/packages/xchain-ethereum/src/const.ts
@@ -1,4 +1,4 @@
-import { Asset, Chain } from '@xchainjs/xchain-util'
+import { Asset } from '@xchainjs/xchain-util'
 import { ethers } from 'ethers'
 
 export const LOWER_FEE_BOUND = 2_000_000_000
@@ -23,7 +23,7 @@ export const MAX_APPROVAL: ethers.BigNumber = ethers.BigNumber.from(2).pow(256).
  * Chain identifier for Ethereum mainnet
  *
  */
-export const ETHChain: Chain = 'ETH'
+export const ETHChain = 'ETH' as const
 
 /**
  * Base "chain" asset on ethereum main net.

--- a/packages/xchain-litecoin/CHANGELOG.md
+++ b/packages/xchain-litecoin/CHANGELOG.md
@@ -1,4 +1,10 @@
-# v.10.8 (2022-12-27)
+# v.0.10.9 (2022-01-19)
+
+## Update
+
+- Type safety `LTCChain`
+
+# v.0.10.8 (2022-12-27)
 
 ## Add
 
@@ -8,26 +14,26 @@
 
 - Bump `xchain-client@13.5.0`
 
-# v.10.7 (2022-12-13)
+# v.0.10.7 (2022-12-13)
 
 ## Update
 
 - removed `customRequestHeaders`
 
-# v.10.6 (2022-11-24)
+# v.0.10.6 (2022-11-24)
 
 ## Update
 
 - Added `customRequestHeaders` to `BroadcastTxParams` & bump dependencies
 
-# v.10.5 (2022-10-27)
+# v.0.10.5 (2022-10-27)
 
 ## Update
 
 - removed Default username/password in Client constructor
 - do not send auth header if undefined
 
-# v.10.4 (2022-10-14)
+# v.0.10.4 (2022-10-14)
 
 ## Update
 

--- a/packages/xchain-litecoin/package.json
+++ b/packages/xchain-litecoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-litecoin",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "description": "Custom Litecoin client and utilities used by XChainJS clients",
   "keywords": [
     "XChain",

--- a/packages/xchain-litecoin/src/const.ts
+++ b/packages/xchain-litecoin/src/const.ts
@@ -1,4 +1,4 @@
-import { Asset, Chain } from '@xchainjs/xchain-util/lib'
+import { Asset } from '@xchainjs/xchain-util/lib'
 
 /**
  * Minimum transaction fee
@@ -14,7 +14,7 @@ export const LTC_DECIMAL = 8
  * Chain identifier for litecoin
  *
  */
-export const LTCChain: Chain = 'LTC'
+export const LTCChain = 'LTC' as const
 
 /**
  * Base "chain" asset on litecoin main net.

--- a/packages/xchain-mayachain/CHANGELOG.md
+++ b/packages/xchain-mayachain/CHANGELOG.md
@@ -1,3 +1,11 @@
-# v0.1.0 (2022-01-06)
+# v0.1.1 (2023-01-19)
+
+## Update
+
+- Type safety `MAYAChain`
+
+## Module Created
+
+# v0.1.0 (2023-01-06)
 
 ## Module Created

--- a/packages/xchain-mayachain/package.json
+++ b/packages/xchain-mayachain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-mayachain",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Custom Mayachain client and utilities used by XChainJS clients",
   "keywords": [
     "MAYAChain",

--- a/packages/xchain-mayachain/src/const.ts
+++ b/packages/xchain-mayachain/src/const.ts
@@ -1,5 +1,5 @@
 import { Network } from '@xchainjs/xchain-client/lib'
-import { Asset, Chain } from '@xchainjs/xchain-util/lib'
+import { Asset } from '@xchainjs/xchain-util/lib'
 
 import { ExplorerUrls } from './types'
 
@@ -31,10 +31,10 @@ export const defaultExplorerUrls: ExplorerUrls = {
 }
 
 /**
- * Chain identifier for Thorchain
+ * Chain identifier for MayaChain
  *
  */
-export const MAYAChain: Chain = 'MAYA'
+export const MAYAChain = 'MAYA' as const
 
 /**
  * Base "chain" asset on thorchain main net.

--- a/packages/xchain-thorchain/CHANGELOG.md
+++ b/packages/xchain-thorchain/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.0.27.8 (2023-01-19)
+
+## Update
+
+- Type safety `THORChain`
+
 # v.0.27.7 (2022-12-27)
 
 ## Add

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xchainjs/xchain-thorchain",
-  "version": "0.27.7",
+  "version": "0.27.8",
   "description": "Custom Thorchain client and utilities used by XChainJS clients",
   "keywords": [
     "THORChain",

--- a/packages/xchain-thorchain/src/const.ts
+++ b/packages/xchain-thorchain/src/const.ts
@@ -1,5 +1,5 @@
 import { Network } from '@xchainjs/xchain-client/lib'
-import { Asset, Chain } from '@xchainjs/xchain-util/lib'
+import { Asset } from '@xchainjs/xchain-util/lib'
 
 import { ExplorerUrls } from './types'
 
@@ -36,7 +36,7 @@ export const defaultExplorerUrls: ExplorerUrls = {
  * Chain identifier for Thorchain
  *
  */
-export const THORChain: Chain = 'THOR'
+export const THORChain = 'THOR' as const
 
 /**
  * Base "chain" asset for RUNE-67C on Binance test net.


### PR DESCRIPTION
## Background

In https://github.com/xchainjs/xchainjs-lib/pull/705 we lost type safety of Chain, but with this small change anyone can bring it back if needed.

## Fix
`as const` is a more type safety definition than `string`. Example (compare different type of `Chains` vs. `Chains2`) :

![Peek 2023-01-19 12-57](https://user-images.githubusercontent.com/61792675/213436866-9e4a20b2-526c-4dc5-b713-f1eba7f02cae.gif)

```ts
type Chain = string

const AVAXChain: Chain = 'AVAX'
const BTCChain: Chain = 'BTC'
const LTCChain: Chain = 'LTC'

const CHAINS = [AVAXChain, BTCChain, LTCChain] as const

type Chains = typeof CHAINS[number] // type Chains = string

// vs.

const AVAXChain2 = 'AVAX' as const
const BTCChain2 = 'BTC' as const
const LTCChain2 = 'LTC' as const

const CHAINS2 = [AVAXChain2, BTCChain2, LTCChain2] as const

type Chains2 = typeof CHAINS2[number] // type Chains2 = "AVAX" | "BTC" | "LTC"
```
## Extra
Bump packages.