### PR TITLE
1049 Add Trade Asset Support

### DIFF
--- a/packages/xchain-arbitrum/__e2e__/arbitrum.e2e.ts
+++ b/packages/xchain-arbitrum/__e2e__/arbitrum.e2e.ts
@@ -21,6 +21,7 @@ const MainnetUSDTAsset: Asset = {
   symbol: 'USDT-0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9',
   ticker: 'USDT',
   synth: false,
+  trade: false,
 }
 
 const TestnetUSDCAsset: Asset = {
@@ -28,6 +29,7 @@ const TestnetUSDCAsset: Asset = {
   symbol: 'USDC-0x179522635726710dd7d2035a81d856de4aa7836c',
   ticker: 'USDC',
   synth: false,
+  trade: false,
 }
 
 describe('Arbitrum', () => {

--- a/packages/xchain-arbitrum/src/const.ts
+++ b/packages/xchain-arbitrum/src/const.ts
@@ -11,7 +11,7 @@ export const LOWER_FEE_BOUND = 100_000_000
 export const UPPER_FEE_BOUND = 1_000_000_000
 export const ARB_GAS_ASSET_DECIMAL = 18
 export const ARBChain = 'ARB' as const
-export const AssetARB: Asset = { chain: ARBChain, symbol: 'ARB', ticker: 'ETH', synth: false }
+export const AssetARB: Asset = { chain: ARBChain, symbol: 'ARB', ticker: 'ETH', synth: false, trade: false }
 
 // Define JSON-RPC providers for mainnet and testnet
 const ARBITRUM_MAINNET_ETHERS_PROVIDER = new ethers.providers.JsonRpcProvider('https://arb1.arbitrum.io/rpc')

--- a/packages/xchain-avax/__e2e__/avax-client.e2e.ts
+++ b/packages/xchain-avax/__e2e__/avax-client.e2e.ts
@@ -15,6 +15,7 @@ const assetRIP: Asset = {
   symbol: `RIP-0x224695ba2a98e4a096a519b503336e06d9116e48`,
   ticker: `RIP`,
   synth: false,
+  trade: false,
 }
 
 const AVAX_ONLINE_PROVIDER_TESTNET = new CovalentProvider(

--- a/packages/xchain-avax/src/const.ts
+++ b/packages/xchain-avax/src/const.ts
@@ -11,7 +11,7 @@ export const LOWER_FEE_BOUND = 2_000_000_000
 export const UPPER_FEE_BOUND = 1_000_000_000_000
 export const AVAX_GAS_ASSET_DECIMAL = 18
 export const AVAXChain = 'AVAX' as const
-export const AssetAVAX: Asset = { chain: AVAXChain, symbol: 'AVAX', ticker: 'AVAX', synth: false }
+export const AssetAVAX: Asset = { chain: AVAXChain, symbol: 'AVAX', ticker: 'AVAX', synth: false, trade: false }
 
 // Define JSON-RPC providers for mainnet and testnet
 const AVALANCHE_MAINNET_ETHERS_PROVIDER = new ethers.providers.JsonRpcProvider('https://rpc.ankr.com/avalanche')

--- a/packages/xchain-binance/__tests__/client.test.ts
+++ b/packages/xchain-binance/__tests__/client.test.ts
@@ -214,7 +214,7 @@ describe('BinanceClient Test', () => {
       sequence: 5,
     })
 
-    const AssetRune: Asset = { chain: BNBChain, symbol: 'RUNE', ticker: 'RUNE', synth: false }
+    const AssetRune: Asset = { chain: BNBChain, symbol: 'RUNE', ticker: 'RUNE', synth: false, trade: false }
 
     const balances = await bnbClient.getBalance('tbnb1zd87q9dywg3nu7z38mxdcxpw8hssrfp9htcrvj', [AssetBNB, AssetRune])
 

--- a/packages/xchain-binance/src/const.ts
+++ b/packages/xchain-binance/src/const.ts
@@ -12,7 +12,7 @@ export const BNBChain = 'BNB' as const
  * This constant represents the base asset of the Binance Chain.
  * It includes information about the chain, symbol, ticker, and whether it's synthetic or not.
  */
-export const AssetBNB: Asset = { chain: BNBChain, symbol: 'BNB', ticker: 'BNB', synth: false }
+export const AssetBNB: Asset = { chain: BNBChain, symbol: 'BNB', ticker: 'BNB', synth: false, trade: false }
 
 /**
  * Asset Decimal.

--- a/packages/xchain-bitcoin/src/const.ts
+++ b/packages/xchain-bitcoin/src/const.ts
@@ -37,7 +37,7 @@ export const BTCChain = 'BTC' as const
 /**
  * Base "chain" asset on bitcoin main net.
  */
-export const AssetBTC: Asset = { chain: BTCChain, symbol: 'BTC', ticker: 'BTC', synth: false }
+export const AssetBTC: Asset = { chain: BTCChain, symbol: 'BTC', ticker: 'BTC', synth: false, trade: false }
 
 // Explorer providers for Bitcoin
 const BTC_MAINNET_EXPLORER = new ExplorerProvider(

--- a/packages/xchain-bitcoincash/src/const.ts
+++ b/packages/xchain-bitcoincash/src/const.ts
@@ -32,7 +32,7 @@ export const BCHChain = 'BCH' as const
  * Defined according to Thorchain's asset structure.
  * @see https://gitlab.com/thorchain/thornode/-/blob/master/common/asset.go#L12-24
  */
-export const AssetBCH: Asset = { chain: BCHChain, symbol: 'BCH', ticker: 'BCH', synth: false }
+export const AssetBCH: Asset = { chain: BCHChain, symbol: 'BCH', ticker: 'BCH', synth: false, trade: false }
 
 /**
  * Explorer provider URLs for Bitcoin Cash.

--- a/packages/xchain-bsc/__e2e__/bsc-client.e2e.ts
+++ b/packages/xchain-bsc/__e2e__/bsc-client.e2e.ts
@@ -12,6 +12,7 @@ const assetETH: Asset = {
   symbol: `ETH-0xd66c6b4f0be8ce5b39d52e0fd1344c389929b378`,
   ticker: `ETH`,
   synth: false,
+  trade: false,
 }
 
 const AssetBNB: Asset = {
@@ -19,6 +20,7 @@ const AssetBNB: Asset = {
   symbol: `BNB`,
   ticker: `BNB`,
   synth: false,
+  trade: false,
 }
 
 defaultBscParams.network = Network.Testnet

--- a/packages/xchain-bsc/src/const.ts
+++ b/packages/xchain-bsc/src/const.ts
@@ -34,6 +34,7 @@ export const AssetBSC: Asset = {
   symbol: 'BNB',
   ticker: 'BNB',
   synth: false,
+  trade: false,
 }
 
 // Ethers providers

--- a/packages/xchain-cosmos-sdk/__e2e__/cosmos-sdk-client.e2e.ts
+++ b/packages/xchain-cosmos-sdk/__e2e__/cosmos-sdk-client.e2e.ts
@@ -10,6 +10,7 @@ const AssetTokenKuji = {
   symbol: 'factory/kujira1ltvwg69sw3c5z99c6rr08hal7v0kdzfxz07yj5/demo',
   ticker: '',
   synth: false,
+  trade: false,
 }
 
 let xchainClient: Client
@@ -38,6 +39,7 @@ class CustomSdkClient extends Client {
       symbol: denom,
       ticker: '',
       synth: false,
+      trade: false,
     }
   }
   getExplorerUrl(): string {

--- a/packages/xchain-cosmos/__tests__/client.test.ts
+++ b/packages/xchain-cosmos/__tests__/client.test.ts
@@ -93,7 +93,7 @@ describe('Cosmos client', () => {
 
     it('Should get native asset', () => {
       const nativeAsset = client.getAssetInfo()
-      expect(nativeAsset.asset).toEqual({ chain: 'GAIA', symbol: 'ATOM', ticker: 'ATOM', synth: false })
+      expect(nativeAsset.asset).toEqual({ chain: 'GAIA', symbol: 'ATOM', ticker: 'ATOM', synth: false, trade: false })
       expect(nativeAsset.decimal).toBe(6)
     })
 

--- a/packages/xchain-cosmos/src/client.ts
+++ b/packages/xchain-cosmos/src/client.ts
@@ -111,6 +111,7 @@ export class Client extends CosmosSDKClient {
         // At the meantime ticker will be empty
         ticker: '',
         synth: false,
+        trade: false,
       }
     return null
   }

--- a/packages/xchain-cosmos/src/const.ts
+++ b/packages/xchain-cosmos/src/const.ts
@@ -33,7 +33,7 @@ export const GAIAChain = 'GAIA' as const
  * Based on the definition in Thorchain `common`.
  * @see https://gitlab.com/thorchain/thornode/-/blob/master/common/asset.go#L12-24
  */
-export const AssetATOM: Asset = { chain: GAIAChain, symbol: 'ATOM', ticker: 'ATOM', synth: false }
+export const AssetATOM: Asset = { chain: GAIAChain, symbol: 'ATOM', ticker: 'ATOM', synth: false, trade: false }
 
 /**
  * Denomination for the native Cosmos asset.

--- a/packages/xchain-dash/src/const.ts
+++ b/packages/xchain-dash/src/const.ts
@@ -45,7 +45,7 @@ export const DASHChain = 'DASH' as const
  * Definition based on Thorchain common asset.
  * @see https://gitlab.com/thorchain/thornode/-/blob/master/common/asset.go#L12-24
  */
-export const AssetDASH: Asset = { chain: DASHChain, symbol: 'DASH', ticker: 'DASH', synth: false }
+export const AssetDASH: Asset = { chain: DASHChain, symbol: 'DASH', ticker: 'DASH', synth: false, trade: false }
 
 /**
  * Explorer provider for Dash mainnet.

--- a/packages/xchain-doge/src/const.ts
+++ b/packages/xchain-doge/src/const.ts
@@ -43,7 +43,7 @@ export const DOGEChain = 'DOGE' as const
  * Base asset object for Dogecoin.
  * Represents the Dogecoin asset in various contexts.
  */
-export const AssetDOGE: Asset = { chain: DOGEChain, symbol: 'DOGE', ticker: 'DOGE', synth: false }
+export const AssetDOGE: Asset = { chain: DOGEChain, symbol: 'DOGE', ticker: 'DOGE', synth: false, trade: false }
 
 /**
  * Explorer provider for Dogecoin mainnet and testnet.

--- a/packages/xchain-ethereum/__e2e__/eth-client.e2e.ts
+++ b/packages/xchain-ethereum/__e2e__/eth-client.e2e.ts
@@ -12,6 +12,7 @@ const assetETH: Asset = {
   symbol: `ETH-0xd66c6b4f0be8ce5b39d52e0fd1344c389929b378`,
   ticker: `ETH`,
   synth: false,
+  trade: false,
 }
 
 const AssetBNB: Asset = {
@@ -19,6 +20,7 @@ const AssetBNB: Asset = {
   symbol: `ETH`,
   ticker: `ETH`,
   synth: false,
+  trade: false,
 }
 
 defaultEthParams.network = Network.Testnet
@@ -181,6 +183,7 @@ describe('xchain-evm (Eth) Integration Tests', () => {
           symbol: `ETH-${erc20Address}`,
           ticker: 'ETH',
           synth: false,
+          trade: false,
         },
         amount: assetToBase(assetAmount(0.1, 6)),
       })

--- a/packages/xchain-ethereum/src/const.ts
+++ b/packages/xchain-ethereum/src/const.ts
@@ -28,6 +28,7 @@ export const AssetETH: Asset = {
   symbol: 'ETH',
   ticker: 'ETH',
   synth: false,
+  trade: false,
 }
 
 // ===== Ethers providers =====

--- a/packages/xchain-evm-providers/__e2e__/covalent-provider.e2e.ts
+++ b/packages/xchain-evm-providers/__e2e__/covalent-provider.e2e.ts
@@ -8,7 +8,7 @@ jest.setTimeout(60000)
 describe('covalent Integration Tests (AVAX)', () => {
   // Define here to avoid cyclic dependency
   const AVAXChain = 'AVAX'
-  const AssetAVAX: Asset = { chain: AVAXChain, symbol: 'AVAX', ticker: 'AVAX', synth: false }
+  const AssetAVAX: Asset = { chain: AVAXChain, symbol: 'AVAX', ticker: 'AVAX', synth: false, trade: false }
   const avaxProvider = new CovalentProvider(process.env.COVALENT_API_KEY as string, AVAXChain, 43113, AssetAVAX, 18)
   it('should fetch one balance', async () => {
     const balances = await avaxProvider.getBalance('0xf32DA51880374201852057009c4c4d1e75949e09')
@@ -31,12 +31,14 @@ describe('covalent Integration Tests (AVAX)', () => {
         symbol: 'PGL-0x1acf1583bebdca21c8025e172d8e8f2817343d65',
         ticker: 'PGL',
         synth: false,
+        trade: false,
       },
       {
         chain: 'avalanche-testnet',
         symbol: 'PTP-0x22d4002028f537599be9f666d1c4fa138522f9c8',
         ticker: 'PTP',
         synth: false,
+        trade: false,
       },
     ])
     balances.forEach((bal) => {

--- a/packages/xchain-evm-providers/__e2e__/etherscan-provider.e2e.ts
+++ b/packages/xchain-evm-providers/__e2e__/etherscan-provider.e2e.ts
@@ -23,7 +23,7 @@ describe('etherscan Integration Tests (AVAX)', () => {
   )
   // Define here to avoid cyclic dependency
   const AVAXChain = 'AVAX'
-  const AssetAVAX: Asset = { chain: AVAXChain, symbol: 'AVAX', ticker: 'AVAX', synth: false }
+  const AssetAVAX: Asset = { chain: AVAXChain, symbol: 'AVAX', ticker: 'AVAX', synth: false, trade: false }
   const avaxProvider = new EtherscanProvider(
     AVALANCHE_TESTNET_ETHERS_PROVIDER,
     'https://api-testnet.snowtrace.io',
@@ -82,6 +82,7 @@ describe('etherscan Integration Tests (BSC)', () => {
     symbol: 'BNB',
     ticker: 'BNB',
     synth: false,
+    trade: false,
   }
   const provider = new EtherscanProvider(
     BSC_TESTNET_ETHERS_PROVIDER,
@@ -126,6 +127,7 @@ describe('etherscan Integration Tests (ETH)', () => {
     symbol: 'ETH',
     ticker: 'ETH',
     synth: false,
+    trade: false,
   }
   const provider = new EtherscanProvider(
     ETH_TESTNET_ETHERS_PROVIDER,

--- a/packages/xchain-evm-providers/__e2e__/routescan-provider.e2e.ts
+++ b/packages/xchain-evm-providers/__e2e__/routescan-provider.e2e.ts
@@ -12,7 +12,7 @@ describe('AVAX', () => {
   const rpcEndpint = 'https://api.avax.network/ext/bc/C/rpc'
   // Define here to avoid cyclic dependency
   const AVAXChain = 'AVAX'
-  const AssetAVAX: Asset = { chain: AVAXChain, symbol: 'AVAX', ticker: 'AVAX', synth: false }
+  const AssetAVAX: Asset = { chain: AVAXChain, symbol: 'AVAX', ticker: 'AVAX', synth: false, trade: false }
 
   const provider = new ethers.providers.JsonRpcProvider(rpcEndpint)
   const dataProvider = new RoutescanProvider(provider, 'https://api.routescan.io', 43114, AssetAVAX, 18)
@@ -58,6 +58,7 @@ describe('ETH', () => {
     symbol: 'ETH',
     ticker: 'ETH',
     synth: false,
+    trade: false,
   }
 
   const provider = new ethers.providers.JsonRpcProvider(rpcEndpint, 'homestead')

--- a/packages/xchain-evm-providers/src/providers/covalent/covalent-data-provider.ts
+++ b/packages/xchain-evm-providers/src/providers/covalent/covalent-data-provider.ts
@@ -21,7 +21,7 @@ import {
 } from './types'
 
 const AVAXChain: Chain = 'AVAX'
-const AssetAVAX: Asset = { chain: AVAXChain, symbol: 'AVAX', ticker: 'AVAX', synth: false }
+const AssetAVAX: Asset = { chain: AVAXChain, symbol: 'AVAX', ticker: 'AVAX', synth: false, trade: false }
 
 export class CovalentProvider implements EvmOnlineDataProvider {
   private baseUrl = 'https://api.covalenthq.com'
@@ -63,6 +63,7 @@ export class CovalentProvider implements EvmOnlineDataProvider {
           symbol,
           ticker: balance.contract_ticker_symbol,
           synth: false,
+          trade: false,
         },
         amount: baseAmount(balance.balance, balance.contract_decimals),
       })
@@ -123,6 +124,7 @@ export class CovalentProvider implements EvmOnlineDataProvider {
         symbol,
         ticker: transferEvent.sender_contract_ticker_symbol as string,
         synth: false,
+        trade: false,
       },
       from,
       to,

--- a/packages/xchain-evm-providers/src/providers/etherscan/etherscan-data-provider.ts
+++ b/packages/xchain-evm-providers/src/providers/etherscan/etherscan-data-provider.ts
@@ -92,6 +92,7 @@ export class EtherscanProvider implements EvmOnlineDataProvider {
       symbol: `${tokenTicker}-${contractAddress}`,
       ticker: tokenTicker,
       synth: false,
+      trade: false,
     }
 
     const contract: ethers.Contract = new ethers.Contract(contractAddress, erc20ABI, this.provider)

--- a/packages/xchain-evm/__tests__/avax/client.testnet.test.ts
+++ b/packages/xchain-evm/__tests__/avax/client.testnet.test.ts
@@ -12,7 +12,7 @@ import {
 import Client, { EVMClientParams } from '../../src/client'
 
 const AVAXChain: Chain = 'AVAX'
-const AssetAVAX: Asset = { chain: AVAXChain, symbol: 'AVAX', ticker: 'AVAX', synth: false }
+const AssetAVAX: Asset = { chain: AVAXChain, symbol: 'AVAX', ticker: 'AVAX', synth: false, trade: false }
 
 const phrase = 'canyon throw labor waste awful century ugly they found post source draft'
 const newPhrase = 'logic neutral rug brain pluck submit earth exit erode august remain ready'

--- a/packages/xchain-kujira/__e2e__/kujira-client.e2e.ts
+++ b/packages/xchain-kujira/__e2e__/kujira-client.e2e.ts
@@ -11,6 +11,7 @@ const AssetTokenKuji = {
   symbol: 'factory/kujira1ltvwg69sw3c5z99c6rr08hal7v0kdzfxz07yj5/demo',
   ticker: '',
   synth: false,
+  trade: false,
 }
 
 describe('Kujira client Integration Tests', () => {

--- a/packages/xchain-kujira/src/client.ts
+++ b/packages/xchain-kujira/src/client.ts
@@ -80,6 +80,7 @@ export class Client extends CosmosSdkClient {
       symbol: denom,
       ticker: '',
       synth: false,
+      trade: false,
     }
   }
   /**

--- a/packages/xchain-kujira/src/const.ts
+++ b/packages/xchain-kujira/src/const.ts
@@ -22,7 +22,7 @@ export const KUJIChain = 'KUJI' as const
 /**
  * Asset information for KUJI.
  */
-export const AssetKUJI: Asset = { chain: KUJIChain, symbol: 'KUJI', ticker: 'KUJI', synth: false }
+export const AssetKUJI: Asset = { chain: KUJIChain, symbol: 'KUJI', ticker: 'KUJI', synth: false, trade: false }
 
 /**
  * Denomination for USK asset.
@@ -32,7 +32,7 @@ export const USK_ASSET_DENOM = 'factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg
 /**
  * Asset information for USK.
  */
-export const AssetUSK: Asset = { chain: KUJIChain, symbol: 'USK', ticker: 'USK', synth: false }
+export const AssetUSK: Asset = { chain: KUJIChain, symbol: 'USK', ticker: 'USK', synth: false, trade: false }
 
 /**
  * Decimal places for USK asset.

--- a/packages/xchain-litecoin/src/const.ts
+++ b/packages/xchain-litecoin/src/const.ts
@@ -39,7 +39,7 @@ export const LTCChain = 'LTC' as const
  * Based on definition in Thorchain `common`.
  * @see https://gitlab.com/thorchain/thornode/-/blob/master/common/asset.go#L12-24
  */
-export const AssetLTC: Asset = { chain: LTCChain, symbol: 'LTC', ticker: 'LTC', synth: false }
+export const AssetLTC: Asset = { chain: LTCChain, symbol: 'LTC', ticker: 'LTC', synth: false, trade: false }
 
 const LTC_MAINNET_EXPLORER = new ExplorerProvider(
   'https://blockchair.com/litecoin/',

--- a/packages/xchain-mayachain/__tests__/client.test.ts
+++ b/packages/xchain-mayachain/__tests__/client.test.ts
@@ -92,12 +92,12 @@ describe('Mayachain client', () => {
 
     it('Should get native asset', () => {
       const nativeAsset = client.getAssetInfo()
-      expect(nativeAsset.asset).toEqual({ chain: 'MAYA', symbol: 'CACAO', ticker: 'CACAO', synth: false })
+      expect(nativeAsset.asset).toEqual({ chain: 'MAYA', symbol: 'CACAO', ticker: 'CACAO', synth: false, trade: false })
       expect(nativeAsset.decimal).toBe(10)
     })
 
     it('Should get denom for asset', () => {
-      const synthBNBAsset: Asset = { chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: true }
+      const synthBNBAsset: Asset = { chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: true, trade: false }
       expect(client.getDenom(synthBNBAsset)).toEqual('bnb/bnb')
       expect(client.getDenom(AssetCacao)).toEqual('cacao')
     })

--- a/packages/xchain-mayachain/src/const.ts
+++ b/packages/xchain-mayachain/src/const.ts
@@ -50,12 +50,12 @@ export const DEFAULT_FEE = baseAmount(5000000000, CACAO_DECIMAL)
  * Based on definition in mayachain `common`
  * @see https://gitlab.com/mayachain/mayanode
  */
-export const AssetCacao: Asset = { chain: MAYAChain, symbol: 'CACAO', ticker: 'CACAO', synth: false }
+export const AssetCacao: Asset = { chain: MAYAChain, symbol: 'CACAO', ticker: 'CACAO', synth: false, trade: false }
 
 /**
  * Maya asset.
  */
-export const AssetMaya: Asset = { chain: MAYAChain, symbol: 'MAYA', ticker: 'MAYA', synth: false }
+export const AssetMaya: Asset = { chain: MAYAChain, symbol: 'MAYA', ticker: 'MAYA', synth: false, trade: false }
 
 /**
  * Message type URL used to send transactions.

--- a/packages/xchain-mayachain/src/utils.ts
+++ b/packages/xchain-mayachain/src/utils.ts
@@ -1,5 +1,5 @@
 import { Network, RootDerivationPaths, TxHash } from '@xchainjs/xchain-client'
-import { Address, Asset, assetToString, eqAsset, isSynthAsset } from '@xchainjs/xchain-util'
+import { Address, Asset, assetToString, eqAsset, isSynthAsset, isTradeAsset } from '@xchainjs/xchain-util'
 import axios from 'axios'
 
 import { AssetCacao, AssetMaya, CACAO_DENOM, MAYA_DENOM } from './const'
@@ -83,6 +83,7 @@ export const getDenom = (asset: Asset) => {
   if (eqAsset(asset, AssetCacao)) return CACAO_DENOM
   if (eqAsset(asset, AssetMaya)) return MAYA_DENOM
   if (isSynthAsset(asset)) return assetToString(asset).toLowerCase()
+  if (isTradeAsset(asset)) return assetToString(asset).toLowerCase()
   return asset.symbol.toLowerCase()
 }
 

--- a/packages/xchain-thorchain-amm/__e2e__/thorchain-doSwap-e2e.ts
+++ b/packages/xchain-thorchain-amm/__e2e__/thorchain-doSwap-e2e.ts
@@ -53,12 +53,14 @@ const USDT: Asset = {
   symbol: 'USDT-0XA3910454BF2CB59B8B3A401589A3BACC5CA42306',
   ticker: 'USDT',
   synth: false,
+  trade: false,
 }
 const XRUNE: Asset = {
   chain: ETHChain,
   symbol: 'XRUNE-0X8626DB1A4F9F3E1002EEB9A4F3C6D391436FFC23',
   ticker: 'XRUNE',
   synth: false,
+  trade: false,
 }
 
 function print(estimate: TxDetails) {

--- a/packages/xchain-thorchain/__tests__/client.test.ts
+++ b/packages/xchain-thorchain/__tests__/client.test.ts
@@ -103,7 +103,13 @@ describe('Thorchain client', () => {
     })
     it('Should get asset for denom', () => {
       expect(client.assetFromDenom('rune')).toEqual(AssetRUNE)
-      expect(client.assetFromDenom('bnb/bnb')).toEqual({ chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: true, trade: false  })
+      expect(client.assetFromDenom('bnb/bnb')).toEqual({
+        chain: 'BNB',
+        symbol: 'BNB',
+        ticker: 'BNB',
+        synth: true,
+        trade: false,
+      })
     })
     it('should get asset decimals', async () => {
       expect(client.getAssetDecimals(AssetRUNE)).toBe(8)

--- a/packages/xchain-thorchain/__tests__/client.test.ts
+++ b/packages/xchain-thorchain/__tests__/client.test.ts
@@ -92,18 +92,18 @@ describe('Thorchain client', () => {
 
     it('Should get native asset', () => {
       const nativeAsset = client.getAssetInfo()
-      expect(nativeAsset.asset).toEqual({ chain: 'THOR', symbol: 'RUNE', ticker: 'RUNE', synth: false })
+      expect(nativeAsset.asset).toEqual({ chain: 'THOR', symbol: 'RUNE', ticker: 'RUNE', synth: false, trade: false })
       expect(nativeAsset.decimal).toBe(8)
     })
 
     it('Should get denom for asset', () => {
-      const synthBNBAsset: Asset = { chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: true }
+      const synthBNBAsset: Asset = { chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: true, trade: false }
       expect(client.getDenom(synthBNBAsset)).toEqual('bnb/bnb')
       expect(client.getDenom(AssetRUNE)).toEqual('rune')
     })
     it('Should get asset for denom', () => {
       expect(client.assetFromDenom('rune')).toEqual(AssetRUNE)
-      expect(client.assetFromDenom('bnb/bnb')).toEqual({ chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: true })
+      expect(client.assetFromDenom('bnb/bnb')).toEqual({ chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: true, trade: false  })
     })
     it('should get asset decimals', async () => {
       expect(client.getAssetDecimals(AssetRUNE)).toBe(8)

--- a/packages/xchain-thorchain/__tests__/util.test.ts
+++ b/packages/xchain-thorchain/__tests__/util.test.ts
@@ -1,7 +1,7 @@
 import { isAssetRuneNative as isAssetRune } from '..'
 describe('Utils', () => {
   it('Should validate Rune asset', () => {
-    expect(isAssetRune({ chain: 'THOR', symbol: 'RUNE', ticker: 'RUNE', synth: false })).toBeTruthy()
-    expect(isAssetRune({ chain: 'ARB', symbol: 'ARB', ticker: 'ETH', synth: false })).toBeFalsy()
+    expect(isAssetRune({ chain: 'THOR', symbol: 'RUNE', ticker: 'RUNE', synth: false, trade: false })).toBeTruthy()
+    expect(isAssetRune({ chain: 'ARB', symbol: 'ARB', ticker: 'ETH', synth: false, trade: false })).toBeFalsy()
   })
 })

--- a/packages/xchain-thorchain/src/const.ts
+++ b/packages/xchain-thorchain/src/const.ts
@@ -51,7 +51,7 @@ export const THORChain = 'THOR' as const
 /**
  * Native asset representation for RUNE in Thorchain
  */
-export const AssetRuneNative: Asset = { chain: THORChain, symbol: RUNE_TICKER, ticker: RUNE_TICKER, synth: false }
+export const AssetRuneNative: Asset = { chain: THORChain, symbol: RUNE_TICKER, ticker: RUNE_TICKER, synth: false, trade: false }
 
 /**
  * Message type URL used to make send transactions

--- a/packages/xchain-thorchain/src/const.ts
+++ b/packages/xchain-thorchain/src/const.ts
@@ -51,7 +51,13 @@ export const THORChain = 'THOR' as const
 /**
  * Native asset representation for RUNE in Thorchain
  */
-export const AssetRuneNative: Asset = { chain: THORChain, symbol: RUNE_TICKER, ticker: RUNE_TICKER, synth: false, trade: false }
+export const AssetRuneNative: Asset = {
+  chain: THORChain,
+  symbol: RUNE_TICKER,
+  ticker: RUNE_TICKER,
+  synth: false,
+  trade: false,
+}
 
 /**
  * Message type URL used to make send transactions

--- a/packages/xchain-util/src/asset.test.ts
+++ b/packages/xchain-util/src/asset.test.ts
@@ -15,6 +15,7 @@ import {
   isBaseAmount,
   isBigNumberValue,
   isSynthAsset,
+  isTradeAsset,
   isValidAsset,
 } from './asset'
 import { bn } from './index'
@@ -23,14 +24,14 @@ import { Asset, Denomination } from './types'
 const BNBChain = 'BNB'
 const ETHChain = 'ETH'
 
-const AssetBNB: Asset = { chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: false }
-const AssetBTC: Asset = { chain: 'BTC', symbol: 'BTC', ticker: 'BTC', synth: false }
+const AssetBNB: Asset = { chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: false, trade: false }
+const AssetBTC: Asset = { chain: 'BTC', symbol: 'BTC', ticker: 'BTC', synth: false, trade: false }
 
 const RUNE_TICKER = 'RUNE'
-const AssetETH: Asset = { chain: 'ETH', symbol: 'ETH', ticker: 'ETH', synth: false }
-const AssetRune67C: Asset = { chain: 'BNB', symbol: 'RUNE-67C', ticker: RUNE_TICKER, synth: false }
-const AssetRuneB1A: Asset = { chain: 'BNB', symbol: 'RUNE-B1A', ticker: RUNE_TICKER, synth: false }
-const AssetRuneNative: Asset = { chain: 'THOR', symbol: RUNE_TICKER, ticker: RUNE_TICKER, synth: false }
+const AssetETH: Asset = { chain: 'ETH', symbol: 'ETH', ticker: 'ETH', synth: false, trade: false }
+const AssetRune67C: Asset = { chain: 'BNB', symbol: 'RUNE-67C', ticker: RUNE_TICKER, synth: false, trade: false }
+const AssetRuneB1A: Asset = { chain: 'BNB', symbol: 'RUNE-B1A', ticker: RUNE_TICKER, synth: false, trade: false }
+const AssetRuneNative: Asset = { chain: 'THOR', symbol: RUNE_TICKER, ticker: RUNE_TICKER, synth: false, trade: false }
 
 describe('asset', () => {
   describe('isBigNumberValue', () => {
@@ -286,39 +287,40 @@ describe('asset', () => {
         symbol: 'RUNE-B1A',
         ticker: 'RUNE',
         synth: false,
+        trade: false,
       })
     })
     it('RUNE', () => {
       const result = assetFromString('BNB.RUNE')
-      expect(result).toEqual({ chain: 'BNB', symbol: 'RUNE', ticker: 'RUNE', synth: false })
+      expect(result).toEqual({ chain: 'BNB', symbol: 'RUNE', ticker: 'RUNE', synth: false, trade: false})
     })
     it('BTCB', () => {
       const result = assetFromString('BNB.BTCB-123')
-      expect(result).toEqual({ chain: 'BNB', symbol: 'BTCB-123', ticker: 'BTCB', synth: false })
+      expect(result).toEqual({ chain: 'BNB', symbol: 'BTCB-123', ticker: 'BTCB', synth: false, trade: false})
     })
     it('WBTC', () => {
       const result = assetFromString('ETH.WBTC')
-      expect(result).toEqual({ chain: 'ETH', symbol: 'WBTC', ticker: 'WBTC', synth: false })
+      expect(result).toEqual({ chain: 'ETH', symbol: 'WBTC', ticker: 'WBTC', synth: false, trade: false})
     })
     it('ETH', () => {
       const result = assetFromString('ETH.ETH')
-      expect(result).toEqual({ chain: 'ETH', symbol: 'ETH', ticker: 'ETH', synth: false })
+      expect(result).toEqual({ chain: 'ETH', symbol: 'ETH', ticker: 'ETH', synth: false, trade: false})
     })
     it('BCH', () => {
       const result = assetFromString('BCH.BCH')
-      expect(result).toEqual({ chain: 'BCH', symbol: 'BCH', ticker: 'BCH', synth: false })
+      expect(result).toEqual({ chain: 'BCH', symbol: 'BCH', ticker: 'BCH', synth: false, trade: false})
     })
     it('synth BCH/BCH', () => {
       const result = assetFromString('BCH/BCH')
-      expect(result).toEqual({ chain: 'BCH', symbol: 'BCH', ticker: 'BCH', synth: true })
+      expect(result).toEqual({ chain: 'BCH', symbol: 'BCH', ticker: 'BCH', synth: true, trade: false })
     })
     it('synth ETH/ETH', () => {
       const result = assetFromString('ETH/ETH')
-      expect(result).toEqual({ chain: 'ETH', symbol: 'ETH', ticker: 'ETH', synth: true })
+      expect(result).toEqual({ chain: 'ETH', symbol: 'ETH', ticker: 'ETH', synth: true, trade: false })
     })
     it('synth BNB/BNB', () => {
       const result = assetFromString('BNB/BNB')
-      expect(result).toEqual({ chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: true })
+      expect(result).toEqual({ chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: true, trade: false })
     })
     it('null for chain only', () => {
       const result = assetFromString('BNB')
@@ -342,55 +344,64 @@ describe('asset', () => {
     })
     it('null for invalid chain', () => {
       const result = assetFromString('invalid.BNB.BNB')
-      expect(result).toEqual({ chain: 'invalid', symbol: 'BNB', synth: false, ticker: 'BNB' })
+      expect(result).toEqual({ chain: 'invalid', symbol: 'BNB', synth: false, ticker: 'BNB', trade: false})
     })
   })
 
   describe('assetToString', () => {
     it('RUNE', () => {
-      const asset: Asset = { chain: 'BNB', symbol: 'RUNE-B1A', ticker: 'RUNE', synth: false }
+      const asset: Asset = { chain: 'BNB', symbol: 'RUNE-B1A', ticker: 'RUNE', synth: false, trade: false }
       expect(assetToString(asset)).toEqual('BNB.RUNE-B1A')
     })
     it('ETH', () => {
-      const asset: Asset = { chain: 'ETH', symbol: 'ETH', ticker: 'ETH', synth: false }
+      const asset: Asset = { chain: 'ETH', symbol: 'ETH', ticker: 'ETH', synth: false, trade: false }
       expect(assetToString(asset)).toEqual('ETH.ETH')
     })
     it('ETH/ETH', () => {
-      const asset: Asset = { chain: 'ETH', symbol: 'ETH', ticker: 'ETH', synth: true }
+      const asset: Asset = { chain: 'ETH', symbol: 'ETH', ticker: 'ETH', synth: true, trade: false }
       expect(assetToString(asset)).toEqual('ETH/ETH')
     })
     it('BNB/BNB', () => {
-      const asset: Asset = { chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: true }
+      const asset: Asset = { chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: true, trade: false }
       expect(assetToString(asset)).toEqual('BNB/BNB')
+    })
+    it('BTC-BTC', () => {
+      const asset: Asset = { chain: 'BTC', symbol: 'BTC', ticker: 'BTC', synth: false, trade: true }
+      expect(assetToString(asset)).toEqual('BTC-BTC')
+      expect(isTradeAsset(asset)).toBeTruthy()
     })
   })
 
   describe('isSynthAsset', () => {
     it('false for "standard" asset', () => {
-      expect(isSynthAsset({ chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: false })).toBeFalsy()
+      expect(isSynthAsset({ chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: false, trade: false })).toBeFalsy()
     })
     it('true for synths', () => {
-      expect(isValidAsset({ chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: true })).toBeTruthy()
+      expect(isValidAsset({ chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: true, trade: false })).toBeTruthy()
+    })
+    it('true for trade assets', () => {
+      expect(isTradeAsset({ chain: 'BTC', symbol: 'BTC', ticker: 'BTC', synth: false, trade: true })).toBeTruthy()
     })
     it('composable usage', () => {
       const assets: Asset[] = [
-        { chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: false },
-        { chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: true },
-        { chain: 'ETH', symbol: 'ETH', ticker: 'ETH', synth: false },
+        { chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: false, trade: false },
+        { chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: true, trade: false },
+        { chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: false, trade: true },
+        { chain: 'ETH', symbol: 'ETH', ticker: 'ETH', synth: false, trade: false },
       ]
       const list = assets.filter(isSynthAsset)
       expect(list.length).toEqual(1)
-      expect(list[0]).toEqual({ chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: true })
+      expect(list[0]).toEqual({ chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: true, trade: false })
     })
   })
 
   describe('isValidAsset', () => {
     it('returns false invalid asset data', () => {
-      expect(isValidAsset({ chain: 'BNB', symbol: '', ticker: 'RUNE', synth: false })).toBeFalsy()
-      expect(isValidAsset({ chain: 'BNB', symbol: 'RUNE-B1A', ticker: '', synth: false })).toBeFalsy()
+      expect(isValidAsset({ chain: 'BNB', symbol: '', ticker: 'RUNE', synth: false, trade: false })).toBeFalsy()
+      expect(isValidAsset({ chain: 'BNB', symbol: 'RUNE-B1A', ticker: '', synth: false, trade: false })).toBeFalsy()
     })
     it('returns true for valid `Asset` data', () => {
-      const asset: Asset = { chain: 'BNB', symbol: 'RUNE-B1A', ticker: 'RUNE', synth: false }
+      const asset: Asset = { chain: 'BNB', symbol: 'RUNE-B1A', ticker: 'RUNE', synth: false, trade: false }
       expect(isValidAsset(asset)).toBeTruthy()
     })
   })
@@ -412,7 +423,7 @@ describe('asset', () => {
       expect(currencySymbolByAsset(AssetETH)).toEqual('Ξ')
     })
     it('returns $ for USD', () => {
-      expect(currencySymbolByAsset({ chain: BNBChain, symbol: 'BUSD-BAF', ticker: 'BUSD', synth: false })).toEqual('$')
+      expect(currencySymbolByAsset({ chain: BNBChain, symbol: 'BUSD-BAF', ticker: 'BUSD', synth: false, trade: false })).toEqual('$')
     })
     it('returns ticker as currency symbol for other assets', () => {
       expect(currencySymbolByAsset(AssetBNB)).toEqual('BNB')
@@ -452,6 +463,7 @@ describe('asset', () => {
             symbol: 'XRUNE-0X69FA0FEE221AD11012BAB0FDB45D444D3D2CE71C',
             ticker: 'XRUNE',
             synth: false,
+            trade: false,
           },
           decimal: 2,
         }),

--- a/packages/xchain-util/src/asset.test.ts
+++ b/packages/xchain-util/src/asset.test.ts
@@ -292,23 +292,23 @@ describe('asset', () => {
     })
     it('RUNE', () => {
       const result = assetFromString('BNB.RUNE')
-      expect(result).toEqual({ chain: 'BNB', symbol: 'RUNE', ticker: 'RUNE', synth: false, trade: false})
+      expect(result).toEqual({ chain: 'BNB', symbol: 'RUNE', ticker: 'RUNE', synth: false, trade: false })
     })
     it('BTCB', () => {
       const result = assetFromString('BNB.BTCB-123')
-      expect(result).toEqual({ chain: 'BNB', symbol: 'BTCB-123', ticker: 'BTCB', synth: false, trade: false})
+      expect(result).toEqual({ chain: 'BNB', symbol: 'BTCB-123', ticker: 'BTCB', synth: false, trade: false })
     })
     it('WBTC', () => {
       const result = assetFromString('ETH.WBTC')
-      expect(result).toEqual({ chain: 'ETH', symbol: 'WBTC', ticker: 'WBTC', synth: false, trade: false})
+      expect(result).toEqual({ chain: 'ETH', symbol: 'WBTC', ticker: 'WBTC', synth: false, trade: false })
     })
     it('ETH', () => {
       const result = assetFromString('ETH.ETH')
-      expect(result).toEqual({ chain: 'ETH', symbol: 'ETH', ticker: 'ETH', synth: false, trade: false})
+      expect(result).toEqual({ chain: 'ETH', symbol: 'ETH', ticker: 'ETH', synth: false, trade: false })
     })
     it('BCH', () => {
       const result = assetFromString('BCH.BCH')
-      expect(result).toEqual({ chain: 'BCH', symbol: 'BCH', ticker: 'BCH', synth: false, trade: false})
+      expect(result).toEqual({ chain: 'BCH', symbol: 'BCH', ticker: 'BCH', synth: false, trade: false })
     })
     it('synth BCH/BCH', () => {
       const result = assetFromString('BCH/BCH')
@@ -344,7 +344,7 @@ describe('asset', () => {
     })
     it('null for invalid chain', () => {
       const result = assetFromString('invalid.BNB.BNB')
-      expect(result).toEqual({ chain: 'invalid', symbol: 'BNB', synth: false, ticker: 'BNB', trade: false})
+      expect(result).toEqual({ chain: 'invalid', symbol: 'BNB', synth: false, ticker: 'BNB', trade: false })
     })
   })
 
@@ -423,7 +423,9 @@ describe('asset', () => {
       expect(currencySymbolByAsset(AssetETH)).toEqual('Ξ')
     })
     it('returns $ for USD', () => {
-      expect(currencySymbolByAsset({ chain: BNBChain, symbol: 'BUSD-BAF', ticker: 'BUSD', synth: false, trade: false })).toEqual('$')
+      expect(
+        currencySymbolByAsset({ chain: BNBChain, symbol: 'BUSD-BAF', ticker: 'BUSD', synth: false, trade: false }),
+      ).toEqual('$')
     })
     it('returns ticker as currency symbol for other assets', () => {
       expect(currencySymbolByAsset(AssetBNB)).toEqual('BNB')

--- a/packages/xchain-util/src/asset.test.ts
+++ b/packages/xchain-util/src/asset.test.ts
@@ -365,9 +365,9 @@ describe('asset', () => {
       const asset: Asset = { chain: 'BNB', symbol: 'BNB', ticker: 'BNB', synth: true, trade: false }
       expect(assetToString(asset)).toEqual('BNB/BNB')
     })
-    it('BTC-BTC', () => {
+    it('BTC~BTC', () => {
       const asset: Asset = { chain: 'BTC', symbol: 'BTC', ticker: 'BTC', synth: false, trade: true }
-      expect(assetToString(asset)).toEqual('BTC-BTC')
+      expect(assetToString(asset)).toEqual('BTC~BTC')
       expect(isTradeAsset(asset)).toBeTruthy()
     })
   })

--- a/packages/xchain-util/src/asset.ts
+++ b/packages/xchain-util/src/asset.ts
@@ -204,7 +204,7 @@ export const isSynthAsset = ({ synth }: Asset): boolean => synth
 export const isTradeAsset = ({ trade }: Asset): boolean => trade
 
 const SYNTH_DELIMITER = '/'
-const TRADE_DELIMITER = '-'
+const TRADE_DELIMITER = '~'
 const NON_SYNTH_DELIMITER = '.'
 
 /**
@@ -228,10 +228,10 @@ export const assetFromString = (s: string): Asset | null => {
   const isSynth = s.includes(SYNTH_DELIMITER)
   let isTrade = s.includes(TRADE_DELIMITER)
 
-  isSynth ? true : isTrade = false; // Can't be a Synth and Trade at the same time. 
+  isSynth ? true : isTrade = false; // Can't be a Synth and Trade at the same time.
 
   // const delimiter = isSynth ? SYNTH_DELIMITER : NON_SYNTH_DELIMITER
-   const delimiter = isSynth ? SYNTH_DELIMITER : (!isSynth && !isTrade ? NON_SYNTH_DELIMITER : TRADE_DELIMITER); // Need to look for non-synth or trade, then synth or trade to correctly evaluate 'BNB.RUNE-B1A'  
+   const delimiter = isSynth ? SYNTH_DELIMITER : (!isSynth && !isTrade ? NON_SYNTH_DELIMITER : TRADE_DELIMITER);
 
   const data = s.split(delimiter)
   if (data.length <= 1 || data[1]?.length < 1) {

--- a/packages/xchain-util/src/asset.ts
+++ b/packages/xchain-util/src/asset.ts
@@ -226,17 +226,11 @@ const NON_SYNTH_DELIMITER = '.'
  */
 export const assetFromString = (s: string): Asset | null => {
   const isSynth = s.includes(SYNTH_DELIMITER)
-  let isTrade = s.includes(TRADE_DELIMITER)
+  const isTrade = !isSynth && s.includes(TRADE_DELIMITER) // Ensure isTrade is only considered if not a synth
 
-  isSynth ? true : (isTrade = false) // Can't be a Synth and Trade at the same time.
-  let delimiter
-  if (isSynth) {
-    delimiter = SYNTH_DELIMITER
-  } else if (isTrade) {
-    delimiter = TRADE_DELIMITER
-  } else {
-    delimiter = NON_SYNTH_DELIMITER
-  }
+  // Determine the delimiter based on whether the asset is a synth, trade, or neither
+  const delimiter = isSynth ? SYNTH_DELIMITER : isTrade ? TRADE_DELIMITER : NON_SYNTH_DELIMITER
+
   const data = s.split(delimiter)
   if (data.length <= 1 || data[1]?.length < 1) {
     return null

--- a/packages/xchain-util/src/asset.ts
+++ b/packages/xchain-util/src/asset.ts
@@ -228,11 +228,15 @@ export const assetFromString = (s: string): Asset | null => {
   const isSynth = s.includes(SYNTH_DELIMITER)
   let isTrade = s.includes(TRADE_DELIMITER)
 
-  isSynth ? true : isTrade = false; // Can't be a Synth and Trade at the same time.
-
-  // const delimiter = isSynth ? SYNTH_DELIMITER : NON_SYNTH_DELIMITER
-   const delimiter = isSynth ? SYNTH_DELIMITER : (!isSynth && !isTrade ? NON_SYNTH_DELIMITER : TRADE_DELIMITER);
-
+  isSynth ? true : (isTrade = false) // Can't be a Synth and Trade at the same time.
+  let delimiter
+  if (isSynth) {
+    delimiter = SYNTH_DELIMITER
+  } else if (isTrade) {
+    delimiter = TRADE_DELIMITER
+  } else {
+    delimiter = NON_SYNTH_DELIMITER
+  }
   const data = s.split(delimiter)
   if (data.length <= 1 || data[1]?.length < 1) {
     return null
@@ -246,7 +250,6 @@ export const assetFromString = (s: string): Asset | null => {
   const ticker = symbol.split('-')[0]
 
   if (!symbol) return null
-
 
   return { chain, symbol, ticker, synth: isSynth, trade: isTrade }
 }
@@ -276,7 +279,7 @@ export const assetFromStringEx = (s: string): Asset => {
  * @returns {string} The string from the given asset.
  */
 export const assetToString = ({ chain, symbol, synth, trade }: Asset) => {
-  const delimiter = synth ? SYNTH_DELIMITER : (trade ? TRADE_DELIMITER : NON_SYNTH_DELIMITER);
+  const delimiter = synth ? SYNTH_DELIMITER : trade ? TRADE_DELIMITER : NON_SYNTH_DELIMITER
   return `${chain}${delimiter}${symbol}`
 }
 

--- a/packages/xchain-util/src/asset.ts
+++ b/packages/xchain-util/src/asset.ts
@@ -169,7 +169,7 @@ export const formatBaseAmount = (amount: BaseAmount) => formatBN(amount.amount()
  * Based on definition in Thorchain `common`
  * @see https://gitlab.com/thorchain/thornode/-/blob/master/common/asset.go#L12-24
  */
-const AssetBTC: Asset = { chain: 'BTC', symbol: 'BTC', ticker: 'BTC', synth: false }
+const AssetBTC: Asset = { chain: 'BTC', symbol: 'BTC', ticker: 'BTC', synth: false, trade: false }
 
 /**
  * Base "chain" asset on ethereum main net.
@@ -177,7 +177,7 @@ const AssetBTC: Asset = { chain: 'BTC', symbol: 'BTC', ticker: 'BTC', synth: fal
  * Based on definition in Thorchain `common`
  * @see https://gitlab.com/thorchain/thornode/-/blob/master/common/asset.go#L12-24
  */
-const AssetETH: Asset = { chain: 'ETH', symbol: 'ETH', ticker: 'ETH', synth: false }
+const AssetETH: Asset = { chain: 'ETH', symbol: 'ETH', ticker: 'ETH', synth: false, trade: false }
 
 /**
  * Helper to check whether asset is valid
@@ -195,7 +195,16 @@ export const isValidAsset = (asset: Asset): boolean => !!asset.chain && !!asset.
  */
 export const isSynthAsset = ({ synth }: Asset): boolean => synth
 
+/**
+ * Helper to check whether an asset is trade asset
+ *
+ * @param {Asset} asset
+ * @returns {boolean} `true` or `false`
+ */
+export const isTradeAsset = ({ trade }: Asset): boolean => trade
+
 const SYNTH_DELIMITER = '/'
+const TRADE_DELIMITER = '-'
 const NON_SYNTH_DELIMITER = '.'
 
 /**
@@ -217,7 +226,13 @@ const NON_SYNTH_DELIMITER = '.'
  */
 export const assetFromString = (s: string): Asset | null => {
   const isSynth = s.includes(SYNTH_DELIMITER)
-  const delimiter = isSynth ? SYNTH_DELIMITER : NON_SYNTH_DELIMITER
+  let isTrade = s.includes(TRADE_DELIMITER)
+
+  isSynth ? true : isTrade = false; // Can't be a Synth and Trade at the same time. 
+
+  // const delimiter = isSynth ? SYNTH_DELIMITER : NON_SYNTH_DELIMITER
+   const delimiter = isSynth ? SYNTH_DELIMITER : (!isSynth && !isTrade ? NON_SYNTH_DELIMITER : TRADE_DELIMITER); // Need to look for non-synth or trade, then synth or trade to correctly evaluate 'BNB.RUNE-B1A'  
+
   const data = s.split(delimiter)
   if (data.length <= 1 || data[1]?.length < 1) {
     return null
@@ -232,7 +247,8 @@ export const assetFromString = (s: string): Asset | null => {
 
   if (!symbol) return null
 
-  return { chain, symbol, ticker, synth: isSynth }
+
+  return { chain, symbol, ticker, synth: isSynth, trade: isTrade }
 }
 
 /**
@@ -259,8 +275,8 @@ export const assetFromStringEx = (s: string): Asset => {
  * @param {Asset} asset The given asset.
  * @returns {string} The string from the given asset.
  */
-export const assetToString = ({ chain, symbol, synth }: Asset) => {
-  const delimiter = synth ? SYNTH_DELIMITER : NON_SYNTH_DELIMITER
+export const assetToString = ({ chain, symbol, synth, trade }: Asset) => {
+  const delimiter = synth ? SYNTH_DELIMITER : (trade ? TRADE_DELIMITER : NON_SYNTH_DELIMITER);
   return `${chain}${delimiter}${symbol}`
 }
 
@@ -378,7 +394,7 @@ export const formatBaseAsAssetAmount = ({
  * @return {boolean} Result of equality check
  */
 export const eqAsset = (a: Asset, b: Asset) =>
-  a.chain === b.chain && a.symbol === b.symbol && a.ticker === b.ticker && a.synth === b.synth
+  a.chain === b.chain && a.symbol === b.symbol && a.ticker === b.ticker && a.synth === b.synth && a.trade === b.trade
 
 /**
  * Removes `0x` or `0X` from address

--- a/packages/xchain-util/src/types/asset.ts
+++ b/packages/xchain-util/src/types/asset.ts
@@ -4,4 +4,5 @@ export type Asset = {
   symbol: string
   ticker: string
   synth: boolean
+  trade: boolean
 }


### PR DESCRIPTION
Basic support for Trade Assets - https://gitlab.com/thorchain/thornode/-/merge_requests/3433

- Added `trade` in Asset Type
- Updated Asset declarations 
- Updated test cases
- Updated AssetToString with conversion logic