### PR TITLE
FIX: Discard ERC20 Synths for EVM aprovals

### DIFF
--- a/packages/xchain-thorchain-amm/src/utils.ts
+++ b/packages/xchain-thorchain-amm/src/utils.ts
@@ -21,7 +21,8 @@ export const isProtocolEVMChain = (chain: Chain): boolean => {
  */
 export const isProtocolERC20Asset = (asset: Asset): boolean => {
   return isProtocolEVMChain(asset.chain)
-    ? [AssetETH, AssetAVAX, AssetBSC].findIndex((nativeEVMAsset) => eqAsset(nativeEVMAsset, asset)) === -1
+    ? [AssetETH, AssetAVAX, AssetBSC].findIndex((nativeEVMAsset) => eqAsset(nativeEVMAsset, asset)) === -1 &&
+        !asset.synth
     : false
 }
 


### PR DESCRIPTION
Add validation that allows synthetics to be discarded from EVM approvals