### PR TITLE
1118 Mayachain backup endpoints

### DIFF
--- a/.changeset/lovely-roses-float.md
+++ b/.changeset/lovely-roses-float.md
@@ -1,0 +1,5 @@
+---
+'@xchainjs/xchain-mayamidgard-query': patch
+---
+
+Migard API backup endpoint

--- a/.changeset/rude-pumpkins-notice.md
+++ b/.changeset/rude-pumpkins-notice.md
@@ -1,0 +1,5 @@
+---
+'@xchainjs/xchain-mayachain-query': patch
+---
+
+Node API backup endpoint

--- a/packages/xchain-mayachain-query/src/utils/mayanode.ts
+++ b/packages/xchain-mayachain-query/src/utils/mayanode.ts
@@ -19,7 +19,7 @@ export type MayanodeConfig = {
 const defaultMayanodeConfig: Record<Network, MayanodeConfig> = {
   mainnet: {
     apiRetries: 3,
-    mayanodeBaseUrls: ['https://mayanode.mayachain.info'],
+    mayanodeBaseUrls: ['https://mayanode.mayachain.info', 'https://api-maya.liquify.com'],
   },
   stagenet: {
     apiRetries: 3,

--- a/packages/xchain-mayamidgard-query/src/midgard-api.ts
+++ b/packages/xchain-mayamidgard-query/src/midgard-api.ts
@@ -17,7 +17,7 @@ import { ActionHistory, GetActionsParams, MAYANameDetails, MidgardConfig, Revers
 const defaultMidgardConfig: Record<Network, MidgardConfig> = {
   mainnet: {
     apiRetries: 3,
-    midgardBaseUrls: ['https://midgard.mayachain.info'],
+    midgardBaseUrls: ['https://midgard.mayachain.info', 'https://midgard-maya.liquify.com'],
   },
   stagenet: {
     apiRetries: 3,


### PR DESCRIPTION
Mayachain Midgard and Mayachain Node backup endpoints added. To be able to add the Mayachain client URL, Cosmos-sdk package needs to be able to work with several clients.