### PR TITLE
feat: add approveRouter when mayachain-amm do-swap

### DIFF
--- a/examples/mayachain-amm/do-swap.ts
+++ b/examples/mayachain-amm/do-swap.ts
@@ -20,7 +20,7 @@ import {
 } from '@xchainjs/xchain-util'
 import { Wallet } from '@xchainjs/xchain-wallet'
 
-import { printQuoteSwap } from './utils'
+import { isProtocolERC20Asset, printQuoteSwap } from './utils'
 
 const doSwap = async (mayachainAmm: MayachainAMM, quoteSwapParams: QuoteSwapParams) => {
   try {
@@ -34,6 +34,13 @@ const doSwap = async (mayachainAmm: MayachainAMM, quoteSwapParams: QuoteSwapPara
           quoteSwapParams.destinationAsset,
         )}`,
       )
+      if (isProtocolERC20Asset(quoteSwapParams.fromAsset)) {
+        const txApprove = await mayachainAmm.approveRouterToSpend({
+          asset: quoteSwapParams.fromAsset,
+          amount: quoteSwapParams.amount,
+        })
+        console.log('txApprove:', txApprove)
+      }
       const txSubmitted = await mayachainAmm.doSwap(quoteSwapParams)
       console.log(`Tx hash: ${txSubmitted.hash},\n Tx url: ${txSubmitted.url}\n`)
     }

--- a/examples/mayachain-amm/utils.ts
+++ b/examples/mayachain-amm/utils.ts
@@ -1,5 +1,7 @@
-import { QuoteSwap } from '@xchainjs/xchain-mayachain-query'
-import { assetToString } from '@xchainjs/xchain-util'
+import { QuoteSwap, CompatibleAsset } from '@xchainjs/xchain-mayachain-query'
+import { assetToString, Chain, TokenAsset, eqAsset, isSynthAsset } from '@xchainjs/xchain-util'
+import { AssetAETH } from '@xchainjs/xchain-arbitrum'
+import { AssetETH } from '@xchainjs/xchain-ethereum'
 
 export const printQuoteSwap = (quoteSwap: QuoteSwap) => {
   console.log({
@@ -38,4 +40,24 @@ export const printQuoteSwap = (quoteSwap: QuoteSwap) => {
     errors: quoteSwap.errors,
     warning: quoteSwap.warning,
   })
+}
+
+/**
+ * Check if a chain is EVM and supported by the protocol
+ * @param {Chain} chain to check
+ * @returns true if chain is EVM, otherwise, false
+ */
+export const isProtocolEVMChain = (chain: Chain): boolean => {
+  return [AssetETH.chain, AssetAETH.chain].includes(chain)
+}
+
+/**
+ * Check if asset is ERC20
+ * @param {Asset} asset to check
+ * @returns true if asset is ERC20, otherwise, false
+ */
+export const isProtocolERC20Asset = (asset: CompatibleAsset): asset is TokenAsset => {
+  return isProtocolEVMChain(asset.chain)
+    ? [AssetETH, AssetAETH].findIndex((nativeEVMAsset) => eqAsset(nativeEVMAsset, asset)) === -1 && !isSynthAsset(asset)
+    : false
 }


### PR DESCRIPTION
When we tried do-swap with mayachain-amm for real asset in EVM chains, it failes swapping.
So, I added approveRouter in mayachain-amm test file, it works well