### PR TITLE
remove coininfo

### DIFF
--- a/examples/loans/package.json
+++ b/examples/loans/package.json
@@ -32,7 +32,6 @@
     "bech32-buffer": "^0.2.0",
     "bignumber.js": "^9.0.0",
     "bitcoinjs-lib": "5.2.0",
-    "coininfo": "^5.1.0",
     "coinselect": "^3.1.12",
     "ethers": "^5.6.6",
     "rimraf": "~3.0.2",

--- a/packages/xchain-bitcoin/package.json
+++ b/packages/xchain-bitcoin/package.json
@@ -42,7 +42,6 @@
     "@xchainjs/xchain-utxo-providers": "workspace:*",
     "bip32": "4.0.0",
     "bitcoinjs-lib": "6.1.6",
-    "coininfo": "5.1.0",
     "coinselect": "3.1.12",
     "ecpair": "2.1.0"
   },

--- a/packages/xchain-bitcoincash/src/modules.d.ts
+++ b/packages/xchain-bitcoincash/src/modules.d.ts
@@ -5,12 +5,6 @@
 declare module '@psf/bitcoincashjs-lib';
 
 /**
- * Declaration file for the 'coininfo' module.
- * This module likely provides information about various cryptocurrencies or coins.
- */
-declare module 'coininfo';
-
-/**
  * Declaration file for the 'coinselect/accumulative' module.
  * This module likely provides functions or utilities related to coin selection algorithms,
  * specifically the 'accumulative' algorithm.

--- a/packages/xchain-bitcoincash/src/utils.ts
+++ b/packages/xchain-bitcoincash/src/utils.ts
@@ -2,10 +2,9 @@
  * Module importing and providing utilities for Bitcoin Cash (BCH) transactions and addresses.
  */
 import { Network, TxType } from '@xchainjs/xchain-client' // Importing types related to network and transactions
-import { Address, baseAmount } from '@xchainjs/xchain-util' // Importing utilities related to addresses and amounts
+import { Address, baseAmount, toBitcoinJS } from '@xchainjs/xchain-util' // Importing utilities related to addresses and amounts
 import { Tx, TxFrom, TxTo } from '@xchainjs/xchain-utxo' // Importing Bitcoin Cash address utilities
 import * as bchaddr from 'bchaddrjs' // Importing coin information utility
-import coininfo from 'coininfo'
 
 import { AssetBCH, BCH_DECIMAL } from './const' // Importing BCH asset and decimal constants
 import { Transaction, TransactionInput, TransactionOutput } from './types' // Importing custom transaction types
@@ -29,9 +28,9 @@ export const bchNetwork = (network: Network): BCHNetwork => {
   switch (network) {
     case Network.Mainnet:
     case Network.Stagenet:
-      return coininfo.bitcoincash.main.toBitcoinJS()
+      return toBitcoinJS('bitcoincash', 'main');
     case Network.Testnet:
-      return coininfo.bitcoincash.test.toBitcoinJS()
+      return toBitcoinJS('bitcoincash', 'test');
   }
 }
 

--- a/packages/xchain-dash/package.json
+++ b/packages/xchain-dash/package.json
@@ -41,7 +41,6 @@
     "@xchainjs/xchain-utxo": "workspace:*",
     "@xchainjs/xchain-utxo-providers": "workspace:*",
     "bitcoinjs-lib": "5.2.0",
-    "coininfo": "5.1.0",
     "coinselect": "3.1.12"
   },
   "devDependencies": {

--- a/packages/xchain-dash/src/modules.d.ts
+++ b/packages/xchain-dash/src/modules.d.ts
@@ -1,2 +1,1 @@
-declare module 'coininfo'
 declare module '@dashevo/dashcore-lib'

--- a/packages/xchain-dash/src/utils.ts
+++ b/packages/xchain-dash/src/utils.ts
@@ -4,10 +4,9 @@ import { Script } from '@dashevo/dashcore-lib/typings/script/Script'
 import { Transaction } from '@dashevo/dashcore-lib/typings/transaction/Transaction'
 import { Input } from '@dashevo/dashcore-lib/typings/transaction/input/Input'
 import { FeeRate, Network } from '@xchainjs/xchain-client'
-import { Address } from '@xchainjs/xchain-util'
+import { Address, toBitcoinJS } from '@xchainjs/xchain-util'
 import { TxParams, UTXO } from '@xchainjs/xchain-utxo'
 import * as Dash from 'bitcoinjs-lib'
-import * as coininfo from 'coininfo'
 import accumulative from 'coinselect/accumulative'
 
 import * as insight from './insight-api'
@@ -51,9 +50,9 @@ export const dashNetwork = (network: Network): Dash.Network => {
   switch (network) {
     case Network.Mainnet:
     case Network.Stagenet:
-      return coininfo.dash.main.toBitcoinJS() // Convert Dash mainnet to BitcoinJS format
+      return toBitcoinJS('dash', 'main') // Convert Dash mainnet to BitcoinJS format
     case Network.Testnet:
-      return coininfo.dash.test.toBitcoinJS() // Convert Dash testnet to BitcoinJS format
+      return toBitcoinJS('dash', 'test') // Convert Dash testnet to BitcoinJS format
   }
 }
 

--- a/packages/xchain-doge/README.md
+++ b/packages/xchain-doge/README.md
@@ -13,7 +13,7 @@ yarn add @xchainjs/xchain-doge
 Following peer dependencies have to be installed into your project. These are not included in `@xchainjs/xchain-doge`.
 
 ```
-yarn add @xchainjs/xchain-client @xchainjs/xchain-crypto @xchainjs/xchain-util axios bitcoinjs-lib coininfo wif
+yarn add @xchainjs/xchain-client @xchainjs/xchain-crypto @xchainjs/xchain-util axios bitcoinjs-lib wif
 ```
 
 ## Documentation

--- a/packages/xchain-doge/package.json
+++ b/packages/xchain-doge/package.json
@@ -40,7 +40,6 @@
     "@xchainjs/xchain-utxo": "workspace:*",
     "@xchainjs/xchain-utxo-providers": "workspace:*",
     "bitcoinjs-lib": "5.2.0",
-    "coininfo": "5.1.0",
     "coinselect": "3.1.12"
   },
   "devDependencies": {

--- a/packages/xchain-doge/src/modules.d.ts
+++ b/packages/xchain-doge/src/modules.d.ts
@@ -1,12 +1,4 @@
 /**
- * Declaration file for the 'coininfo' module.
- *
- * 'coininfo' is a module used for retrieving information about cryptocurrencies.
- * This declaration file allows TypeScript to recognize and properly handle the module.
- */
-declare module 'coininfo'
-
-/**
  * Declaration file for the 'coinselect/accumulative' module.
  *
  * 'coinselect/accumulative' is a module used for selecting and accumulating unspent transaction outputs (UTXOs).

--- a/packages/xchain-doge/src/utils.ts
+++ b/packages/xchain-doge/src/utils.ts
@@ -2,9 +2,8 @@
  * Import statements for required modules and types.
  */
 import { Network } from '@xchainjs/xchain-client'
-import { Address } from '@xchainjs/xchain-util'
+import { Address, toBitcoinJS } from '@xchainjs/xchain-util'
 import * as Dogecoin from 'bitcoinjs-lib' // Importing bitcoinjs-lib for Dogecoin operations
-import coininfo from 'coininfo' // Importing coininfo for cryptocurrency information retrieval
 
 /**
  * Constant values representing transaction sizes and lengths.
@@ -45,18 +44,11 @@ export function arrayAverage(array: number[]): number {
 export const dogeNetwork = (network: Network): Dogecoin.networks.Network => {
   switch (network) {
     case Network.Mainnet:
-      return coininfo.dogecoin.main.toBitcoinJS()
+      return toBitcoinJS('dogecoin', 'main')
     case Network.Stagenet:
-      return coininfo.dogecoin.main.toBitcoinJS()
+      return toBitcoinJS('dogecoin', 'main')
     case Network.Testnet: {
-      // Latest coininfo on NPM doesn't contain dogetest config information
-      const bip32 = {
-        private: 0x04358394,
-        public: 0x043587cf,
-      }
-      const test = coininfo.dogecoin.test
-      test.versions.bip32 = bip32
-      return test.toBitcoinJS()
+      return toBitcoinJS('dogecoin', 'test')
     }
   }
 }

--- a/packages/xchain-litecoin/README.md
+++ b/packages/xchain-litecoin/README.md
@@ -13,7 +13,7 @@ yarn add @xchainjs/xchain-litecoin
 Following peer dependencies have to be installed into your project. These are not included in `@xchainjs/xchain-litecoin`.
 
 ```
-yarn add @xchainjs/xchain-client @xchainjs/xchain-crypto @xchainjs/xchain-util axios bitcoinjs-lib coininfo wif
+yarn add @xchainjs/xchain-client @xchainjs/xchain-crypto @xchainjs/xchain-util axios bitcoinjs-lib wif
 ```
 
 ## Documentation

--- a/packages/xchain-litecoin/package.json
+++ b/packages/xchain-litecoin/package.json
@@ -41,7 +41,6 @@
     "@xchainjs/xchain-utxo-providers": "workspace:*",
     "axios": "1.8.4",
     "bitcoinjs-lib": "5.2.0",
-    "coininfo": "5.1.0",
     "coinselect": "3.1.12"
   },
   "devDependencies": {

--- a/packages/xchain-litecoin/src/modules.d.ts
+++ b/packages/xchain-litecoin/src/modules.d.ts
@@ -1,10 +1,4 @@
 /**
- * Declaration file for the 'coininfo' module.
- * This module provides information about cryptocurrencies.
- */
-declare module 'coininfo'
-
-/**
  * Declaration file for the 'coinselect/accumulative' module.
  * This module is used for selecting UTXOs for transactions.
  */

--- a/packages/xchain-litecoin/src/utils.ts
+++ b/packages/xchain-litecoin/src/utils.ts
@@ -1,8 +1,7 @@
 import { Balance, Network, TxHash } from '@xchainjs/xchain-client'
-import { Address, assetAmount, assetToBase } from '@xchainjs/xchain-util'
+import { Address, assetAmount, assetToBase, toBitcoinJS } from '@xchainjs/xchain-util'
 import { UTXO } from '@xchainjs/xchain-utxo'
 import * as Litecoin from 'bitcoinjs-lib'
-import coininfo from 'coininfo'
 
 import { AssetLTC, LTC_DECIMAL } from './const'
 import * as nodeApi from './node-api'
@@ -67,9 +66,9 @@ export const ltcNetwork = (network: Network): Litecoin.Network => {
   switch (network) {
     case Network.Mainnet:
     case Network.Stagenet:
-      return coininfo.litecoin.main.toBitcoinJS()
+      return toBitcoinJS('litecoin', 'main')
     case Network.Testnet:
-      return coininfo.litecoin.test.toBitcoinJS()
+      return toBitcoinJS('litecoin', 'test')
   }
 }
 

--- a/packages/xchain-util/__tests__/coininfo.test.ts
+++ b/packages/xchain-util/__tests__/coininfo.test.ts
@@ -1,0 +1,71 @@
+import { toBitcoinJS } from "../src/coininfo";
+
+describe('coininfo', () => {
+    describe('test litecoin', () => {
+        it('test mainnet ok', () => {
+            const result = toBitcoinJS('litecoin', 'main');
+            expect(result).toEqual({
+                messagePrefix: "\u0019Litecoin Signed Message:\n",
+                bech32: "ltc",
+                bip32: {
+                    public: 27108450,
+                    private: 27106558,
+                },
+                pubKeyHash: 48,
+                scriptHash: 50,
+                wif: 176,
+                dustThreshold: null,
+            });
+        });
+
+        it('test testnet ok', () => {
+            const result = toBitcoinJS('litecoin', 'test');
+            expect(result).toEqual({
+                messagePrefix: "\u0019Litecoin Signed Message:\n",
+                bech32: "tltc",
+                bip32: {
+                    public: 70711009,
+                    private: 70709117,
+                },
+                pubKeyHash: 111,
+                scriptHash: 58,
+                wif: 239,
+                dustThreshold: null,
+            });
+        });
+    });
+
+    describe('test doge', () => {
+        it('test mainnet ok', () => {
+            const result = toBitcoinJS('dogecoin', 'main');
+            expect(result).toEqual({
+                messagePrefix: "\u0019Dogecoin Signed Message:\n",
+                bech32: undefined,
+                bip32: {
+                    public: 49990397,
+                    private: 49988504,
+                },
+                pubKeyHash: 30,
+                scriptHash: 22,
+                wif: 158,
+                dustThreshold: null,
+            });
+        });
+
+        it('test testnet ok', () => {
+            const result = toBitcoinJS('dogecoin', 'test');
+            expect(result).toEqual({
+                messagePrefix: "\u0019Dogecoin Signed Message:\n",
+                bech32: undefined,
+                bip32: {
+                    public: 70617039,
+                    private: 70615956,
+                },
+                pubKeyHash: 113,
+                scriptHash: 196,
+                wif: 241,
+                dustThreshold: null,
+            });
+        });
+    });
+});

--- a/packages/xchain-util/package.json
+++ b/packages/xchain-util/package.json
@@ -31,7 +31,9 @@
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0"
   },
   "dependencies": {
-    "bignumber.js": "9.0.0"
+    "bignumber.js": "9.0.0",
+    "jest": "^29.7.0",
+    "test": "^3.3.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/xchain-util/src/coininfo.ts
+++ b/packages/xchain-util/src/coininfo.ts
@@ -1,0 +1,75 @@
+import * as bchData from './coins/bch'
+import * as dogeData from './coins/doge'
+import * as dashData from './coins/dash'
+import * as ltcData from './coins/ltc'
+
+
+interface CoinVersion {
+    bip32: {
+        public: number
+        private: number
+    }
+    bip44?: number
+    private: number
+    public: number
+    scripthash: number
+}
+
+interface CoinConfig {
+    name: string
+    unit: string
+    hashGenesisBlock?: string
+    port?: number
+    protocol?: {
+        magic: number
+    }
+    seedsDns?: string[]
+    versions: CoinVersion
+    messagePrefix?: string
+    bech32?: string
+    testnet?: boolean
+}
+
+interface CoinData {
+    main: CoinConfig
+    test?: CoinConfig
+    regtest?: CoinConfig
+    simnet?: CoinConfig
+}
+
+function toBitcoinJSInner(coinConfig: CoinConfig) {
+    return {
+        messagePrefix: coinConfig.messagePrefix || '\x19' + coinConfig.name + ' Signed Message:\n',
+        bech32: coinConfig.bech32,
+        bip32: {
+            public: (coinConfig.versions.bip32 || {}).public,
+            private: (coinConfig.versions.bip32 || {}).private
+        },
+        pubKeyHash: coinConfig.versions.public,
+        scriptHash: coinConfig.versions.scripthash,
+        wif: coinConfig.versions.private,
+        dustThreshold: null
+    }
+}
+
+const coinConfigs: Record<string, CoinData> = {
+    bitcoincash: bchData,
+    dogecoin: dogeData,
+
+    dash: dashData,
+    litecoin: ltcData,
+}
+
+export function toBitcoinJS(chain: 'bitcoincash' | 'dogecoin' | 'dash' | 'litecoin', network: 'main' | 'test') {
+    const coinData = coinConfigs[chain]
+    if (!coinData) {
+        throw new Error(`Coin data for ${chain} not found`)
+    }
+
+    const config = network === 'main' ? coinData.main : coinData.test
+    if (!config) {
+        throw new Error(`Network ${network} not found for ${chain}`)
+    }
+
+    return toBitcoinJSInner(config)
+}

--- a/packages/xchain-util/src/coins/bch.ts
+++ b/packages/xchain-util/src/coins/bch.ts
@@ -1,0 +1,89 @@
+/*
+  info from:
+    https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/src/chainparams.cpp
+*/
+
+var common = {
+  name: 'BitcoinCash',
+  per1: 1e8,
+  unit: 'BCH'
+}
+
+var main = Object.assign({}, {
+  hashGenesisBlock: '000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f',
+  // nDefaultPort
+  port: 8333,
+  portRpc: 8332,
+  protocol: {
+    // pchMessageStart
+    magic: 0xe8f3e1e3 // careful, sent over wire as little endian
+  },
+  // vSeeds
+  seedsDns: [
+    'seed.bitcoinabc.org',
+    'seed-abc.bitcoinforks.org',
+    'btccash-seeder.bitcoinunlimited.info',
+    'seed.bitprim.org',
+    'seed.deadalnix.me',
+    'seeder.criptolayer.net'
+  ],
+  // base58Prefixes
+  versions: {
+    bip32: {
+      private: 0x0488ade4,
+      public: 0x0488b21e
+    },
+    bip44: 145,
+    private: 0x80,
+    public: 0x00,
+    scripthash: 0x05
+  }
+}, common)
+
+var test = Object.assign({}, {
+  hashGenesisBlock: '000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943',
+  port: 18333,
+  portRpc: 18332,
+  protocol: {
+    magic: 0xf4f3e5f4
+  },
+  seedsDns: [
+    'testnet-seed.bitcoinabc.org',
+    'testnet-seed-abc.bitcoinforks.org',
+    'testnet-seed.bitprim.org',
+    'testnet-seed.deadalnix.me',
+    'testnet-seeder.criptolayer.net'
+  ],
+  versions: {
+    bip32: {
+      private: 0x04358394,
+      public: 0x043587cf
+    },
+    bip44: 1,
+    private: 0xef,
+    public: 0x6f,
+    scripthash: 0xc4
+  }
+}, common)
+
+var regtest = Object.assign({}, {
+  hashGenesisBlock: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
+  port: 18444,
+  portRpc: 18332,
+  protocol: {
+    magic: 0xfabfb5da
+  },
+  seedsDns: [],
+  versions: {
+    bip32: {
+      private: 0x04358394,
+      public: 0x043587cf
+    },
+    bip44: 1,
+    private: 0xef,
+    public: 0x6f,
+    scripthash: 0xc4
+  }
+}, common)
+
+export { main, test, regtest}

--- a/packages/xchain-util/src/coins/dash.ts
+++ b/packages/xchain-util/src/coins/dash.ts
@@ -1,0 +1,65 @@
+/*
+  info from:
+    https://github.com/dashpay/dash/blob/master/src/chainparams.cpp
+*/
+
+var common = {
+  name: 'Dash',
+  unit: 'DASH'
+}
+
+var main = Object.assign({}, {
+  hashGenesisBlock: '00000ffd590b1485b3caadc19b22e6379c733355108f107a430458cdf3407ab6',
+  // nDefaultPort
+  port: 9999,
+  portRpc: 9998,
+  protocol: {
+    magic: 0xbd6b0cbf // careful, sent over wire as little endian
+  },
+  // vSeeds
+  seedsDns: [
+    'dash.org',
+    'dnsseed.dash.org',
+    'dashdot.io',
+    'dnsseed.dashdot.io',
+    'masternode.io',
+    'dnsseed.masternode.io',
+    'dashpay.io',
+    'dnsseed.dashpay.io'
+  ],
+  // base58Prefixes
+  versions: {
+    bip32: {
+      private: 0x0488ade4,
+      public: 0x0488b21e
+    },
+    bip44: 5,
+    private: 0xcc,
+    public: 0x4c,
+    scripthash: 0x10
+  }
+}, common)
+
+var test = Object.assign({}, {
+  hashGenesisBlock: '00000bafbc94add76cb75e2ec92894837288a481e5c005f6563d91623bf8bc2c',
+  port: 19999,
+  portRpc: 19998,
+  seedsDns: [
+    'dashdot.io',
+    'testnet-seed.dashdot.io',
+    'masternode.io',
+    'test.dnsseed.masternode.io'
+  ],
+  versions: {
+    bip32: {
+      private: 0x04358394,
+      public: 0x043587cf
+    },
+    bip44: 1,
+    private: 0xef,
+    public: 0x8c,
+    scripthash: 0x13
+  }
+}, common)
+
+export { main, test }

--- a/packages/xchain-util/src/coins/doge.ts
+++ b/packages/xchain-util/src/coins/doge.ts
@@ -1,0 +1,52 @@
+// https://github.com/dogecoin/dogecoin/blob/master/src/chainparams.cpp
+
+var common = {
+    name: 'Dogecoin',
+    unit: 'DOGE'
+}
+
+var main = Object.assign({}, {
+    hashGenesisBlock: '1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691',
+    port: 22556,
+    protocol: {
+        magic: 0xc0c0c0c0
+    },
+    seedsDns: [
+        'seed.multidoge.org',
+        'seed2.multidoge.org'
+    ],
+    versions: {
+        bip32: {
+            private: 0x02fac398,
+            public: 0x02facafd
+        },
+        bip44: 3,
+        private: 0x9e,
+        public: 0x1e,
+        scripthash: 0x16
+    }
+}, common)
+
+var test = Object.assign({}, {
+    hashGenesisBlock: 'bb0a78264637406b6360aad926284d544d7049f45189db5664f3c4d07350559e',
+    port: 44556,
+    protocol: {
+        magic: 0xfcc1b7dc
+    },
+    seedsDns: [
+        'testseed.jrn.me.uk'
+    ],
+    versions: {
+        bip32: {
+            private: 0x04358394,
+            public: 0x043587cf
+        },
+        bip44: 1,
+        private: 0xf1,
+        public: 0x71,
+        scripthash: 0xc4
+    }
+}, common)
+
+
+export { main, test }

--- a/packages/xchain-util/src/coins/ltc.ts
+++ b/packages/xchain-util/src/coins/ltc.ts
@@ -1,0 +1,51 @@
+// https://github.com/litecoin-project/litecoin/blob/master-0.10/src/chainparams.cpp
+
+var common = {
+  name: 'Litecoin',
+  unit: 'LTC'
+}
+
+var main = Object.assign({}, {
+  hashGenesisBlock: '12a765e31ffd4059bada1e25190f6e98c99d9714d334efa41a195a7e7e04bfe2',
+  port: 9333,
+  protocol: {
+    magic: 0xdbb6c0fb
+  },
+  bech32: 'ltc',
+  seedsDns: [
+    'dnsseed.litecointools.com',
+    'dnsseed.litecoinpool.org',
+    'dnsseed.ltc.xurious.com',
+    'dnsseed.koin-project.com',
+    'dnsseed.weminemnc.com'
+  ],
+  versions: {
+    bip32: {
+      private: 0x019d9cfe,
+      public: 0x019da462
+    },
+    bip44: 2,
+    private: 0xb0,
+    public: 0x30,
+    scripthash: 0x32,
+    scripthash2: 0x05 // old '3' prefix. available for backward compatibility.
+  }
+}, common)
+
+var test = Object.assign({}, {
+  hashGenesisBlock: 'f5ae71e26c74beacc88382716aced69cddf3dffff24f384e1808905e0188f68f',
+  bech32: 'tltc',
+  versions: {
+    bip32: {
+      private: 0x0436ef7d,
+      public: 0x0436f6e1
+    },
+    bip44: 1,
+    private: 0xef,
+    public: 0x6f,
+    scripthash: 0x3a,
+    scripthash2: 0xc4
+  }
+}, common)
+
+export { main, test }

--- a/packages/xchain-util/src/index.ts
+++ b/packages/xchain-util/src/index.ts
@@ -21,3 +21,5 @@ export * from './crypto-amount'
 
 // Export all functions and variables from './cached-value'
 export * from './cached-value'
+
+export * from './coininfo'


### PR DESCRIPTION
coininfo depends on `safe-buffer`, which is not loadable by vite, a lots of new frontend framework use vite to bundle dependencies. This PR make it easier for people to integrate xchainjs into a frontend project. 