### PR TITLE
use "exports" field in package.json

### DIFF
--- a/.changeset/rude-dancers-buy.md
+++ b/.changeset/rude-dancers-buy.md
@@ -1,0 +1,42 @@
+---
+'@xchainjs/xchain-mayamidgard-query': minor
+'@xchainjs/xchain-mayachain-query': minor
+'@xchainjs/xchain-thorchain-query': minor
+'@xchainjs/xchain-utxo-providers': minor
+'@xchainjs/xchain-evm-providers': minor
+'@xchainjs/xchain-mayachain-amm': minor
+'@xchainjs/xchain-midgard-query': minor
+'@xchainjs/xchain-thorchain-amm': minor
+'@xchainjs/xchain-bitcoincash': minor
+'@xchainjs/xchain-mayamidgard': minor
+'@xchainjs/xchain-aggregator': minor
+'@xchainjs/xchain-cosmos-sdk': minor
+'@xchainjs/xchain-mayachain': minor
+'@xchainjs/xchain-thorchain': minor
+'@xchainjs/xchain-arbitrum': minor
+'@xchainjs/xchain-ethereum': minor
+'@xchainjs/xchain-litecoin': minor
+'@xchainjs/xchain-mayanode': minor
+'@xchainjs/xchain-thornode': minor
+'@xchainjs/xchain-bitcoin': minor
+'@xchainjs/xchain-cardano': minor
+'@xchainjs/xchain-midgard': minor
+'@xchainjs/xchain-client': minor
+'@xchainjs/xchain-cosmos': minor
+'@xchainjs/xchain-crypto': minor
+'@xchainjs/xchain-kujira': minor
+'@xchainjs/xchain-solana': minor
+'@xchainjs/xchain-wallet': minor
+'@xchainjs/xchain-radix': minor
+'@xchainjs/xchain-zcash': minor
+'@xchainjs/xchain-avax': minor
+'@xchainjs/xchain-base': minor
+'@xchainjs/xchain-dash': minor
+'@xchainjs/xchain-doge': minor
+'@xchainjs/xchain-util': minor
+'@xchainjs/xchain-utxo': minor
+'@xchainjs/xchain-bsc': minor
+'@xchainjs/xchain-evm': minor
+---
+
+convert to "type": "module", w/ standard "exports" field

--- a/examples/check-tx/package.json
+++ b/examples/check-tx/package.json
@@ -20,7 +20,7 @@
     "@xchainjs/xchain-util": "workspace:*",
     "axios": "1.8.4",
     "axios-retry": "^3.2.5",
-    "bignumber.js": "^9.0.0",
+    "bignumber.js": "^9.1.2",
     "rimraf": "~3.0.2"
   },
   "devDependencies": {

--- a/examples/estimate-swap/package.json
+++ b/examples/estimate-swap/package.json
@@ -22,7 +22,7 @@
     "@xchainjs/xchain-util": "workspace:*",
     "axios": "1.8.4",
     "axios-retry": "^3.2.5",
-    "bignumber.js": "^9.0.0",
+    "bignumber.js": "^9.1.2",
     "rimraf": "~3.0.2"
   },
   "devDependencies": {

--- a/examples/liquidity/package.json
+++ b/examples/liquidity/package.json
@@ -30,7 +30,7 @@
     "@xchainjs/xchain-util": "workspace:*",
     "axios": "1.8.4",
     "axios-retry": "^3.2.5",
-    "bignumber.js": "^9.0.0",
+    "bignumber.js": "^9.1.2",
     "rimraf": "~3.0.2"
   },
   "devDependencies": {

--- a/examples/loans/package.json
+++ b/examples/loans/package.json
@@ -30,7 +30,7 @@
     "bchaddrjs": "^0.5.2",
     "bech32": "^2.0.0",
     "bech32-buffer": "^0.2.0",
-    "bignumber.js": "^9.0.0",
+    "bignumber.js": "^9.1.2",
     "bitcoinjs-lib": "^6.1.7",
     "coinselect": "^3.1.12",
     "ethers": "^6.14.3",

--- a/packages/xchain-aggregator/jest.config.e2e.mjs
+++ b/packages/xchain-aggregator/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-aggregator/jest.config.mjs
+++ b/packages/xchain-aggregator/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
 }

--- a/packages/xchain-aggregator/package.json
+++ b/packages/xchain-aggregator/package.json
@@ -3,6 +3,7 @@
   "description": "Protocol aggregator to make actions in different protocols",
   "version": "2.0.14",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-aggregator/package.json
+++ b/packages/xchain-aggregator/package.json
@@ -4,8 +4,10 @@
   "version": "2.0.14",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-aggregator/package.json
+++ b/packages/xchain-aggregator/package.json
@@ -4,7 +4,7 @@
   "version": "2.0.14",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-aggregator/package.json
+++ b/packages/xchain-aggregator/package.json
@@ -24,8 +24,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "e2e": "jest --config jest.config.e2e.mjs",
-    "test": "jest"
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/xchain-aggregator/rollup.config.js
+++ b/packages/xchain-aggregator/rollup.config.js
@@ -23,7 +23,7 @@ export default {
       inlineDynamicImports: true,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-aggregator/rollup.config.js
+++ b/packages/xchain-aggregator/rollup.config.js
@@ -15,7 +15,7 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
@@ -23,7 +23,7 @@ export default {
       inlineDynamicImports: true,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-arbitrum/jest.config.mjs
+++ b/packages/xchain-arbitrum/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-arbitrum/package.json
+++ b/packages/xchain-arbitrum/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-arbitrum/package.json
+++ b/packages/xchain-arbitrum/package.json
@@ -40,7 +40,7 @@
     "@xchainjs/xchain-evm": "workspace:*",
     "@xchainjs/xchain-evm-providers": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "bignumber.js": "^9.0.0",
+    "bignumber.js": "^9.1.2",
     "ethers": "^6.14.3"
   }
 }

--- a/packages/xchain-arbitrum/package.json
+++ b/packages/xchain-arbitrum/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-arbitrum/package.json
+++ b/packages/xchain-arbitrum/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest --passWithNoTests",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__, __mocks__}/**/*.ts\" --fix --max-warnings 0"
   },
   "publishConfig": {

--- a/packages/xchain-arbitrum/package.json
+++ b/packages/xchain-arbitrum/package.json
@@ -9,6 +9,7 @@
   "author": "XChainJS",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-arbitrum/rollup.config.js
+++ b/packages/xchain-arbitrum/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-arbitrum/rollup.config.js
+++ b/packages/xchain-arbitrum/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-avax/jest.config.e2e.mjs
+++ b/packages/xchain-avax/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-avax/jest.config.mjs
+++ b/packages/xchain-avax/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-avax/package.json
+++ b/packages/xchain-avax/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-avax/package.json
+++ b/packages/xchain-avax/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-avax/package.json
+++ b/packages/xchain-avax/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest --passWithNoTests",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__, __mocks__}/**/*.ts\" --fix --max-warnings 0"
   },
   "publishConfig": {

--- a/packages/xchain-avax/package.json
+++ b/packages/xchain-avax/package.json
@@ -9,6 +9,7 @@
   "author": "XChainJS",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-avax/package.json
+++ b/packages/xchain-avax/package.json
@@ -41,7 +41,7 @@
     "@xchainjs/xchain-evm": "workspace:*",
     "@xchainjs/xchain-evm-providers": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "bignumber.js": "^9.0.0",
+    "bignumber.js": "^9.1.2",
     "ethers": "^6.14.3"
   },
   "devDependencies": {

--- a/packages/xchain-avax/rollup.config.js
+++ b/packages/xchain-avax/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-avax/rollup.config.js
+++ b/packages/xchain-avax/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-base/jest.config.mjs
+++ b/packages/xchain-base/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-base/package.json
+++ b/packages/xchain-base/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-base/package.json
+++ b/packages/xchain-base/package.json
@@ -40,7 +40,7 @@
     "@xchainjs/xchain-evm": "workspace:*",
     "@xchainjs/xchain-evm-providers": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "bignumber.js": "^9.0.0",
+    "bignumber.js": "^9.1.2",
     "ethers": "^6.14.3"
   },
   "devDependencies": {

--- a/packages/xchain-base/package.json
+++ b/packages/xchain-base/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-base/package.json
+++ b/packages/xchain-base/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest --passWithNoTests",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__, __mocks__}/**/*.ts\" --fix --max-warnings 0"
   },
   "publishConfig": {

--- a/packages/xchain-base/package.json
+++ b/packages/xchain-base/package.json
@@ -9,6 +9,7 @@
   "author": "XChainJS",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-base/rollup.config.js
+++ b/packages/xchain-base/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-base/rollup.config.js
+++ b/packages/xchain-base/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-bitcoin/jest.config.e2e.mjs
+++ b/packages/xchain-bitcoin/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-bitcoin/jest.config.mjs
+++ b/packages/xchain-bitcoin/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
 }

--- a/packages/xchain-bitcoin/package.json
+++ b/packages/xchain-bitcoin/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-bitcoin/package.json
+++ b/packages/xchain-bitcoin/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-bitcoin/package.json
+++ b/packages/xchain-bitcoin/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "postversion": "git push --follow-tags"
   },

--- a/packages/xchain-bitcoin/package.json
+++ b/packages/xchain-bitcoin/package.json
@@ -9,6 +9,7 @@
   "author": "XChainJS",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-bitcoin/rollup.config.js
+++ b/packages/xchain-bitcoin/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-bitcoin/rollup.config.js
+++ b/packages/xchain-bitcoin/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-bitcoin/src/client.ts
+++ b/packages/xchain-bitcoin/src/client.ts
@@ -3,7 +3,7 @@ import { AssetInfo, FeeRate, Network } from '@xchainjs/xchain-client'
 import { Address } from '@xchainjs/xchain-util'
 import { Client as UTXOClient, PreparedTx, TxParams, UTXO, UtxoClientParams } from '@xchainjs/xchain-utxo'
 import * as Bitcoin from 'bitcoinjs-lib'
-import accumulative from 'coinselect/accumulative'
+import accumulative from 'coinselect/accumulative.js'
 
 import {
   AssetBTC,

--- a/packages/xchain-bitcoin/src/modules.d.ts
+++ b/packages/xchain-bitcoin/src/modules.d.ts
@@ -1,2 +1,2 @@
-// This statement declares a module augmentation for the external module 'coinselect/accumulative'.
-declare module 'coinselect/accumulative'
+// This statement declares a module augmentation for the external module 'coinselect/accumulative.js'.
+declare module 'coinselect/accumulative.js'

--- a/packages/xchain-bitcoincash/jest.config.e2e.mjs
+++ b/packages/xchain-bitcoincash/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-bitcoincash/jest.config.mjs
+++ b/packages/xchain-bitcoincash/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
 }

--- a/packages/xchain-bitcoincash/package.json
+++ b/packages/xchain-bitcoincash/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-bitcoincash/package.json
+++ b/packages/xchain-bitcoincash/package.json
@@ -10,6 +10,7 @@
   "author": "XChainJS",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-bitcoincash/package.json
+++ b/packages/xchain-bitcoincash/package.json
@@ -11,8 +11,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-bitcoincash/package.json
+++ b/packages/xchain-bitcoincash/package.json
@@ -31,8 +31,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__,__mocks__}/**/*.ts\" --fix --max-warnings 0",
     "postversion": "git push --follow-tags"
   },

--- a/packages/xchain-bitcoincash/rollup.config.js
+++ b/packages/xchain-bitcoincash/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-bitcoincash/rollup.config.js
+++ b/packages/xchain-bitcoincash/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-bitcoincash/src/client.ts
+++ b/packages/xchain-bitcoincash/src/client.ts
@@ -3,7 +3,7 @@ import * as bitcore from 'bitcore-lib-cash'
 import { AssetInfo, FeeRate, Network } from '@xchainjs/xchain-client' // Importing various types and constants from xchain-client module
 import { Address } from '@xchainjs/xchain-util' // Importing the Address type from xchain-util module
 import { Client as UTXOClient, TxParams, UtxoClientParams, UTXO } from '@xchainjs/xchain-utxo' // Importing necessary types and the UTXOClient class from xchain-utxo module
-import accumulative from 'coinselect/accumulative' // Importing accumulative function from coinselect/accumulative module
+import accumulative from 'coinselect/accumulative.js' // Importing accumulative function from coinselect/accumulative.js module
 
 import {
   AssetBCH,

--- a/packages/xchain-bitcoincash/src/modules.d.ts
+++ b/packages/xchain-bitcoincash/src/modules.d.ts
@@ -1,6 +1,6 @@
 /**
- * Declaration file for the 'coinselect/accumulative' module.
+ * Declaration file for the 'coinselect/accumulative.js' module.
  * This module likely provides functions or utilities related to coin selection algorithms,
  * specifically the 'accumulative' algorithm.
  */
-declare module 'coinselect/accumulative'
+declare module 'coinselect/accumulative.js'

--- a/packages/xchain-bsc/jest.config.e2e.mjs
+++ b/packages/xchain-bsc/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-bsc/jest.config.mjs
+++ b/packages/xchain-bsc/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-bsc/package.json
+++ b/packages/xchain-bsc/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-bsc/package.json
+++ b/packages/xchain-bsc/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-bsc/package.json
+++ b/packages/xchain-bsc/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest --passWithNoTests",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__, __mocks__}/**/*.ts\" --fix --max-warnings 0"
   },
   "publishConfig": {

--- a/packages/xchain-bsc/package.json
+++ b/packages/xchain-bsc/package.json
@@ -41,7 +41,7 @@
     "@xchainjs/xchain-evm": "workspace:*",
     "@xchainjs/xchain-evm-providers": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "bignumber.js": "^9.0.0",
+    "bignumber.js": "^9.1.2",
     "ethers": "^6.14.3"
   }
 }

--- a/packages/xchain-bsc/package.json
+++ b/packages/xchain-bsc/package.json
@@ -9,6 +9,7 @@
   "author": "XChainJS",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-bsc/rollup.config.js
+++ b/packages/xchain-bsc/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-bsc/rollup.config.js
+++ b/packages/xchain-bsc/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-cardano/jest.config.mjs
+++ b/packages/xchain-cardano/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-cardano/package.json
+++ b/packages/xchain-cardano/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0"
   },
   "dependencies": {

--- a/packages/xchain-cardano/package.json
+++ b/packages/xchain-cardano/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-cardano/package.json
+++ b/packages/xchain-cardano/package.json
@@ -9,6 +9,7 @@
   "author": "THORChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-cardano/package.json
+++ b/packages/xchain-cardano/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-cardano/rollup.config.js
+++ b/packages/xchain-cardano/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-cardano/rollup.config.js
+++ b/packages/xchain-cardano/rollup.config.js
@@ -16,13 +16,13 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-client/jest.config.mjs
+++ b/packages/xchain-client/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
 }

--- a/packages/xchain-client/package.json
+++ b/packages/xchain-client/package.json
@@ -3,8 +3,10 @@
   "version": "2.0.3",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib"

--- a/packages/xchain-client/package.json
+++ b/packages/xchain-client/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.3",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib"

--- a/packages/xchain-client/package.json
+++ b/packages/xchain-client/package.json
@@ -2,6 +2,7 @@
   "name": "@xchainjs/xchain-client",
   "version": "2.0.3",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-client/package.json
+++ b/packages/xchain-client/package.json
@@ -19,7 +19,7 @@
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
     "compile": "tsc -p tsconfig.build.json",
-    "test": "jest --passWithNoTests"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests"
   },
   "dependencies": {
     "@xchainjs/xchain-crypto": "workspace:*",

--- a/packages/xchain-client/rollup.config.js
+++ b/packages/xchain-client/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-client/rollup.config.js
+++ b/packages/xchain-client/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-cosmos-sdk/jest.config.e2e.mjs
+++ b/packages/xchain-cosmos-sdk/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-cosmos-sdk/jest.config.mjs
+++ b/packages/xchain-cosmos-sdk/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-cosmos-sdk/package.json
+++ b/packages/xchain-cosmos-sdk/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-cosmos-sdk/package.json
+++ b/packages/xchain-cosmos-sdk/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-cosmos-sdk/package.json
+++ b/packages/xchain-cosmos-sdk/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest --passWithNoTests",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__, __mocks__}/**/*.ts\" --fix --max-warnings 0"
   },
   "publishConfig": {

--- a/packages/xchain-cosmos-sdk/package.json
+++ b/packages/xchain-cosmos-sdk/package.json
@@ -9,6 +9,7 @@
   "author": "XChainJS",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-cosmos-sdk/rollup.config.js
+++ b/packages/xchain-cosmos-sdk/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-cosmos-sdk/rollup.config.js
+++ b/packages/xchain-cosmos-sdk/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-cosmos/jest.config.e2e.mjs
+++ b/packages/xchain-cosmos/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-cosmos/jest.config.mjs
+++ b/packages/xchain-cosmos/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-cosmos/package.json
+++ b/packages/xchain-cosmos/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0"
   },
   "dependencies": {

--- a/packages/xchain-cosmos/package.json
+++ b/packages/xchain-cosmos/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-cosmos/package.json
+++ b/packages/xchain-cosmos/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-cosmos/package.json
+++ b/packages/xchain-cosmos/package.json
@@ -47,7 +47,7 @@
     "@xchainjs/xchain-util": "workspace:*",
     "axios": "1.8.4",
     "bech32": "^1.1.3",
-    "bignumber.js": "^9.0.0",
+    "bignumber.js": "^9.1.2",
     "cosmjs-types": "0.9.0",
     "protobufjs": "6.11.4"
   },

--- a/packages/xchain-cosmos/package.json
+++ b/packages/xchain-cosmos/package.json
@@ -9,6 +9,7 @@
   "author": "XChainJS",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-cosmos/rollup.config.js
+++ b/packages/xchain-cosmos/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-cosmos/rollup.config.js
+++ b/packages/xchain-cosmos/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-cosmos/src/client.ts
+++ b/packages/xchain-cosmos/src/client.ts
@@ -12,7 +12,7 @@ import { AssetInfo, FeeType, Fees, PreparedTx, singleFee } from '@xchainjs/xchai
 import { Client as CosmosSDKClient, CosmosSdkClientParams, MsgTypes, makeClientPath } from '@xchainjs/xchain-cosmos-sdk'
 import { Address, Asset, AssetType, baseAmount, eqAsset } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
-import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
+import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx.js'
 
 import {
   AssetATOM,

--- a/packages/xchain-crypto/package.json
+++ b/packages/xchain-crypto/package.json
@@ -2,6 +2,7 @@
   "name": "@xchainjs/xchain-crypto",
   "version": "1.0.1",
   "description": "XChain Crypto is a crypto module needed by all XChain clients.",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.es.js",
   "jsnext:main": "lib/index.es.js",

--- a/packages/xchain-crypto/package.json
+++ b/packages/xchain-crypto/package.json
@@ -21,7 +21,7 @@
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "test": "jest --coverage"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --coverage"
   },
   "repository": {
     "type": "git",

--- a/packages/xchain-crypto/package.json
+++ b/packages/xchain-crypto/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "description": "XChain Crypto is a crypto module needed by all XChain clients.",
   "main": "lib/index.js",
-  "module": "lib/index.es.js",
+  "exports": "./lib/index.es.js",
   "jsnext:main": "lib/index.es.js",
   "typings": "lib/index.d.ts",
   "directories": {

--- a/packages/xchain-crypto/package.json
+++ b/packages/xchain-crypto/package.json
@@ -3,8 +3,10 @@
   "version": "1.0.1",
   "description": "XChain Crypto is a crypto module needed by all XChain clients.",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.es.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "jsnext:main": "lib/index.es.js",
   "typings": "lib/index.d.ts",
   "directories": {

--- a/packages/xchain-crypto/rollup.config.js
+++ b/packages/xchain-crypto/rollup.config.js
@@ -16,14 +16,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-crypto/rollup.config.js
+++ b/packages/xchain-crypto/rollup.config.js
@@ -23,7 +23,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-dash/jest.config.e2e.mjs
+++ b/packages/xchain-dash/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-dash/jest.config.mjs
+++ b/packages/xchain-dash/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
 }

--- a/packages/xchain-dash/package.json
+++ b/packages/xchain-dash/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-dash/package.json
+++ b/packages/xchain-dash/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-dash/package.json
+++ b/packages/xchain-dash/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "postversion": "git push --follow-tags"
   },

--- a/packages/xchain-dash/package.json
+++ b/packages/xchain-dash/package.json
@@ -9,6 +9,7 @@
   "author": "XChainJS",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-dash/rollup.config.js
+++ b/packages/xchain-dash/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-dash/rollup.config.js
+++ b/packages/xchain-dash/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-dash/src/modules.d copy.ts
+++ b/packages/xchain-dash/src/modules.d copy.ts
@@ -1,1 +1,1 @@
-declare module 'coinselect/accumulative'
+declare module 'coinselect/accumulative.js'

--- a/packages/xchain-dash/src/utils.ts
+++ b/packages/xchain-dash/src/utils.ts
@@ -7,7 +7,7 @@ import { FeeRate, Network } from '@xchainjs/xchain-client'
 import { Address } from '@xchainjs/xchain-util'
 import { TxParams, UTXO, toBitcoinJS } from '@xchainjs/xchain-utxo'
 import * as Dash from 'bitcoinjs-lib'
-import accumulative from 'coinselect/accumulative'
+import accumulative from 'coinselect/accumulative.js'
 
 import * as insight from './insight-api'
 

--- a/packages/xchain-doge/jest.config.e2e.mjs
+++ b/packages/xchain-doge/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-doge/jest.config.mjs
+++ b/packages/xchain-doge/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 30000,

--- a/packages/xchain-doge/package.json
+++ b/packages/xchain-doge/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-doge/package.json
+++ b/packages/xchain-doge/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-doge/package.json
+++ b/packages/xchain-doge/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "postversion": "git push --follow-tags"
   },

--- a/packages/xchain-doge/package.json
+++ b/packages/xchain-doge/package.json
@@ -9,6 +9,7 @@
   "author": "XChainJS",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-doge/rollup.config.js
+++ b/packages/xchain-doge/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-doge/rollup.config.js
+++ b/packages/xchain-doge/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-doge/src/client.ts
+++ b/packages/xchain-doge/src/client.ts
@@ -2,7 +2,7 @@ import { AssetInfo, FeeRate, Network } from '@xchainjs/xchain-client'
 import { Address } from '@xchainjs/xchain-util'
 import { Client as UTXOClient, PreparedTx, TxParams, UTXO, UtxoClientParams } from '@xchainjs/xchain-utxo'
 import * as Dogecoin from 'bitcoinjs-lib'
-import accumulative from 'coinselect/accumulative'
+import accumulative from 'coinselect/accumulative.js'
 
 import {
   AssetDOGE,

--- a/packages/xchain-doge/src/modules.d.ts
+++ b/packages/xchain-doge/src/modules.d.ts
@@ -1,7 +1,7 @@
 /**
- * Declaration file for the 'coinselect/accumulative' module.
+ * Declaration file for the 'coinselect/accumulative.js' module.
  *
- * 'coinselect/accumulative' is a module used for selecting and accumulating unspent transaction outputs (UTXOs).
+ * 'coinselect/accumulative.js' is a module used for selecting and accumulating unspent transaction outputs (UTXOs).
  * This declaration file allows TypeScript to recognize and properly handle the module.
  */
-declare module 'coinselect/accumulative'
+declare module 'coinselect/accumulative.js'

--- a/packages/xchain-ethereum/jest.config.e2e.mjs
+++ b/packages/xchain-ethereum/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-ethereum/jest.config.mjs
+++ b/packages/xchain-ethereum/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-ethereum/package.json
+++ b/packages/xchain-ethereum/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-ethereum/package.json
+++ b/packages/xchain-ethereum/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-ethereum/package.json
+++ b/packages/xchain-ethereum/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest --passWithNoTests",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__, __mocks__}/**/*.ts\" --fix --max-warnings 0"
   },
   "publishConfig": {

--- a/packages/xchain-ethereum/package.json
+++ b/packages/xchain-ethereum/package.json
@@ -41,7 +41,7 @@
     "@xchainjs/xchain-evm": "workspace:*",
     "@xchainjs/xchain-evm-providers": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "bignumber.js": "^9.0.0",
+    "bignumber.js": "^9.1.2",
     "ethers": "^6.14.3"
   }
 }

--- a/packages/xchain-ethereum/package.json
+++ b/packages/xchain-ethereum/package.json
@@ -9,6 +9,7 @@
   "author": "XChainJS",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-ethereum/rollup.config.js
+++ b/packages/xchain-ethereum/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-ethereum/rollup.config.js
+++ b/packages/xchain-ethereum/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-evm-providers/jest.config.e2e.mjs
+++ b/packages/xchain-evm-providers/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-evm-providers/jest.config.mjs
+++ b/packages/xchain-evm-providers/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
 }

--- a/packages/xchain-evm-providers/package.json
+++ b/packages/xchain-evm-providers/package.json
@@ -23,8 +23,8 @@
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
     "clean": "rm -rf .turbo && rm -rf lib",
-    "e2e": "jest --config jest.config.e2e.mjs",
-    "test": "jest --passWithNoTests"
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/xchain-evm-providers/package.json
+++ b/packages/xchain-evm-providers/package.json
@@ -3,8 +3,10 @@
   "version": "2.0.5",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-evm-providers/package.json
+++ b/packages/xchain-evm-providers/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.5",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-evm-providers/package.json
+++ b/packages/xchain-evm-providers/package.json
@@ -2,6 +2,7 @@
   "name": "@xchainjs/xchain-evm-providers",
   "version": "2.0.5",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-evm-providers/rollup.config.js
+++ b/packages/xchain-evm-providers/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-evm-providers/rollup.config.js
+++ b/packages/xchain-evm-providers/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-evm/jest.config.e2e.mjs
+++ b/packages/xchain-evm/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-evm/jest.config.mjs
+++ b/packages/xchain-evm/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-evm/package.json
+++ b/packages/xchain-evm/package.json
@@ -41,7 +41,7 @@
     "@xchainjs/xchain-crypto": "workspace:*",
     "@xchainjs/xchain-evm-providers": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "bignumber.js": "^9.0.0",
+    "bignumber.js": "^9.1.2",
     "ethers": "^6.14.3"
   },
   "devDependencies": {

--- a/packages/xchain-evm/package.json
+++ b/packages/xchain-evm/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-evm/package.json
+++ b/packages/xchain-evm/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-evm/package.json
+++ b/packages/xchain-evm/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__, __mocks__}/**/*.ts\" --fix --max-warnings 0"
   },
   "publishConfig": {

--- a/packages/xchain-evm/package.json
+++ b/packages/xchain-evm/package.json
@@ -9,6 +9,7 @@
   "author": "XChainJS",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-evm/rollup.config.js
+++ b/packages/xchain-evm/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-evm/rollup.config.js
+++ b/packages/xchain-evm/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-kujira/jest.config.e2e.mjs
+++ b/packages/xchain-kujira/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-kujira/jest.config.mjs
+++ b/packages/xchain-kujira/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-kujira/package.json
+++ b/packages/xchain-kujira/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-kujira/package.json
+++ b/packages/xchain-kujira/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest --passWithNoTests",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0"
   },
   "dependencies": {

--- a/packages/xchain-kujira/package.json
+++ b/packages/xchain-kujira/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-kujira/package.json
+++ b/packages/xchain-kujira/package.json
@@ -9,6 +9,7 @@
   "author": "XChainJS",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-kujira/rollup.config.js
+++ b/packages/xchain-kujira/rollup.config.js
@@ -17,14 +17,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-kujira/rollup.config.js
+++ b/packages/xchain-kujira/rollup.config.js
@@ -24,7 +24,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-kujira/src/client.ts
+++ b/packages/xchain-kujira/src/client.ts
@@ -14,7 +14,7 @@ import { getSeed } from '@xchainjs/xchain-crypto'
 import { Address, AssetType, eqAsset } from '@xchainjs/xchain-util'
 import { encode, toWords } from 'bech32'
 import { HDKey } from '@scure/bip32'
-import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
+import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx.js'
 import { createHash } from 'crypto'
 import * as secp from '@bitcoin-js/tiny-secp256k1-asmjs'
 

--- a/packages/xchain-litecoin/jest.config.e2e.mjs
+++ b/packages/xchain-litecoin/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-litecoin/jest.config.mjs
+++ b/packages/xchain-litecoin/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 30000,

--- a/packages/xchain-litecoin/package.json
+++ b/packages/xchain-litecoin/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-litecoin/package.json
+++ b/packages/xchain-litecoin/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-litecoin/package.json
+++ b/packages/xchain-litecoin/package.json
@@ -30,9 +30,9 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "postversion": "git push --follow-tags"
   },
   "dependencies": {

--- a/packages/xchain-litecoin/package.json
+++ b/packages/xchain-litecoin/package.json
@@ -9,6 +9,7 @@
   "author": "XChainJS",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-litecoin/rollup.config.js
+++ b/packages/xchain-litecoin/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-litecoin/rollup.config.js
+++ b/packages/xchain-litecoin/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-litecoin/src/client.ts
+++ b/packages/xchain-litecoin/src/client.ts
@@ -2,7 +2,7 @@ import { AssetInfo, FeeRate, Network } from '@xchainjs/xchain-client'
 import { Address } from '@xchainjs/xchain-util'
 import { Client as UTXOClient, PreparedTx, TxParams, UTXO, UtxoClientParams } from '@xchainjs/xchain-utxo'
 import * as Litecoin from 'bitcoinjs-lib'
-import accumulative from 'coinselect/accumulative'
+import accumulative from 'coinselect/accumulative.js'
 
 import {
   AssetLTC,

--- a/packages/xchain-litecoin/src/modules.d.ts
+++ b/packages/xchain-litecoin/src/modules.d.ts
@@ -1,5 +1,5 @@
 /**
- * Declaration file for the 'coinselect/accumulative' module.
+ * Declaration file for the 'coinselect/accumulative.js' module.
  * This module is used for selecting UTXOs for transactions.
  */
-declare module 'coinselect/accumulative'
+declare module 'coinselect/accumulative.js'

--- a/packages/xchain-mayachain-amm/jest.config.e2e.mjs
+++ b/packages/xchain-mayachain-amm/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-mayachain-amm/jest.config.mjs
+++ b/packages/xchain-mayachain-amm/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-mayachain-amm/package.json
+++ b/packages/xchain-mayachain-amm/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib#readme",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-mayachain-amm/package.json
+++ b/packages/xchain-mayachain-amm/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "postversion": "git push --follow-tags"
   },

--- a/packages/xchain-mayachain-amm/package.json
+++ b/packages/xchain-mayachain-amm/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib#readme",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-mayachain-amm/package.json
+++ b/packages/xchain-mayachain-amm/package.json
@@ -9,6 +9,7 @@
   "author": "MAYAChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib#readme",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-mayachain-amm/rollup.config.js
+++ b/packages/xchain-mayachain-amm/rollup.config.js
@@ -17,14 +17,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-mayachain-amm/rollup.config.js
+++ b/packages/xchain-mayachain-amm/rollup.config.js
@@ -24,7 +24,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-mayachain-query/jest.config.e2e.mjs
+++ b/packages/xchain-mayachain-query/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-mayachain-query/jest.config.mjs
+++ b/packages/xchain-mayachain-query/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-mayachain-query/package.json
+++ b/packages/xchain-mayachain-query/package.json
@@ -40,7 +40,7 @@
     "@xchainjs/xchain-util": "workspace:*",
     "axios": "1.8.4",
     "axios-retry": "3.2.5",
-    "bignumber.js": "^9.0.0"
+    "bignumber.js": "^9.1.2"
   },
   "devDependencies": {
     "axios-mock-adapter": "2.1.0"

--- a/packages/xchain-mayachain-query/package.json
+++ b/packages/xchain-mayachain-query/package.json
@@ -10,7 +10,7 @@
   "author": "MAYAChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib#readme",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-mayachain-query/package.json
+++ b/packages/xchain-mayachain-query/package.json
@@ -9,6 +9,7 @@
   ],
   "author": "MAYAChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib#readme",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-mayachain-query/package.json
+++ b/packages/xchain-mayachain-query/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "postversion": "git push --follow-tags"
   },

--- a/packages/xchain-mayachain-query/package.json
+++ b/packages/xchain-mayachain-query/package.json
@@ -10,8 +10,10 @@
   "author": "MAYAChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib#readme",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-mayachain-query/rollup.config.js
+++ b/packages/xchain-mayachain-query/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-mayachain-query/rollup.config.js
+++ b/packages/xchain-mayachain-query/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-mayachain/genMsgs.sh
+++ b/packages/xchain-mayachain/genMsgs.sh
@@ -17,6 +17,8 @@ tput setaf 2
 echo "Generating $MSG_COMPILED_OUTPUTFILE"
 tput sgr0
 yarn run pbjs -w commonjs -t static-module $TMP_DIR/mayanode/proto/mayachain/v1/common/common.proto $TMP_DIR/mayanode/proto/mayachain/v1/x/mayachain/types/msg_deposit.proto $TMP_DIR/mayanode/proto/mayachain/v1/x/mayachain/types/msg_send.proto $TMP_DIR/mayanode/third_party/proto/cosmos/base/v1beta1/coin.proto -o $MSG_COMPILED_OUTPUTFILE
+# Fix import to be ESM-compatible (no omitted file extension)
+sed -i -E 's|"(protobufjs/minimal)"|"\1.js"|' "$MSG_COMPILED_OUTPUTFILE"
 
 tput setaf 2
 echo "Generating $MSG_COMPILED_TYPES_OUTPUTFILE"

--- a/packages/xchain-mayachain/jest.config.e2e.mjs
+++ b/packages/xchain-mayachain/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-mayachain/jest.config.mjs
+++ b/packages/xchain-mayachain/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-mayachain/package.json
+++ b/packages/xchain-mayachain/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-mayachain/package.json
+++ b/packages/xchain-mayachain/package.json
@@ -29,8 +29,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "start:example": "ts-node example/index.ts",
     "generate:MayachainMsgs": "./genMsgs.sh"

--- a/packages/xchain-mayachain/package.json
+++ b/packages/xchain-mayachain/package.json
@@ -9,6 +9,7 @@
   "author": "MAYAChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-mayachain/package.json
+++ b/packages/xchain-mayachain/package.json
@@ -47,7 +47,7 @@
     "@xchainjs/xchain-util": "workspace:*",
     "axios": "1.8.4",
     "bech32": "^1.1.3",
-    "bignumber.js": "^9.0.0",
+    "bignumber.js": "^9.1.2",
     "cosmjs-types": "0.9.0",
     "protobufjs": "6.11.4"
   },

--- a/packages/xchain-mayachain/package.json
+++ b/packages/xchain-mayachain/package.json
@@ -9,9 +9,10 @@
   "author": "MAYAChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
-  "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.mjs"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-mayachain/rollup.config.js
+++ b/packages/xchain-mayachain/rollup.config.js
@@ -17,14 +17,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-mayachain/rollup.config.js
+++ b/packages/xchain-mayachain/rollup.config.js
@@ -24,7 +24,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-mayachain/src/client.ts
+++ b/packages/xchain-mayachain/src/client.ts
@@ -22,7 +22,7 @@ import { Address, BaseAmount, assetFromString, eqAsset, isSynthAsset } from '@xc
 import { encode, toWords } from 'bech32'
 import BigNumber from 'bignumber.js'
 import { HDKey } from '@scure/bip32'
-import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
+import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx.js'
 import { createHash } from 'crypto'
 import * as secp from '@bitcoin-js/tiny-secp256k1-asmjs'
 

--- a/packages/xchain-mayachain/src/types/proto/MsgCompiled.js
+++ b/packages/xchain-mayachain/src/types/proto/MsgCompiled.js
@@ -1,7 +1,7 @@
 /*eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars*/
 "use strict";
 
-var $protobuf = require("protobufjs/minimal");
+var $protobuf = require("protobufjs/minimal.js");
 
 // Common aliases
 var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;

--- a/packages/xchain-mayamidgard-query/jest.config.e2e.mjs
+++ b/packages/xchain-mayamidgard-query/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-mayamidgard-query/jest.config.mjs
+++ b/packages/xchain-mayamidgard-query/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-mayamidgard-query/package.json
+++ b/packages/xchain-mayamidgard-query/package.json
@@ -9,8 +9,10 @@
   "author": "MayaChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib#readme",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-mayamidgard-query/package.json
+++ b/packages/xchain-mayamidgard-query/package.json
@@ -29,8 +29,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "postversion": "git push --follow-tags"
   },

--- a/packages/xchain-mayamidgard-query/package.json
+++ b/packages/xchain-mayamidgard-query/package.json
@@ -9,7 +9,7 @@
   "author": "MayaChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib#readme",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-mayamidgard-query/package.json
+++ b/packages/xchain-mayamidgard-query/package.json
@@ -8,6 +8,7 @@
   ],
   "author": "MayaChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib#readme",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-mayamidgard-query/rollup.config.js
+++ b/packages/xchain-mayamidgard-query/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-mayamidgard-query/rollup.config.js
+++ b/packages/xchain-mayamidgard-query/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-mayamidgard/package.json
+++ b/packages/xchain-mayamidgard/package.json
@@ -9,6 +9,7 @@
   ],
   "author": "MAYAChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-mayamidgard/package.json
+++ b/packages/xchain-mayamidgard/package.json
@@ -10,8 +10,10 @@
   "author": "MAYAChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-mayamidgard/package.json
+++ b/packages/xchain-mayamidgard/package.json
@@ -31,7 +31,7 @@
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "test": "jest --passWithNoTests",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
     "generate:types": "yarn clean:types:midgard && yarn generate:types:midgard",
     "generate:types:midgard": "TS_POST_PROCESS_FILE=./node_modules/.bin/prettier openapi-generator-cli generate -i https://midgard.mayachain.info/v2/swagger.json -g typescript-axios -o ./src/generated/midgardApi --generate-alias-as-model --reserved-words-mappings in=in",
     "clean:types:midgard": "rimraf ./src/generated/midgardApi"

--- a/packages/xchain-mayamidgard/package.json
+++ b/packages/xchain-mayamidgard/package.json
@@ -10,7 +10,7 @@
   "author": "MAYAChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-mayamidgard/rollup.config.js
+++ b/packages/xchain-mayamidgard/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-mayamidgard/rollup.config.js
+++ b/packages/xchain-mayamidgard/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-mayanode/package.json
+++ b/packages/xchain-mayanode/package.json
@@ -9,6 +9,7 @@
   ],
   "author": "MAYAChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-mayanode/package.json
+++ b/packages/xchain-mayanode/package.json
@@ -10,8 +10,10 @@
   "author": "MAYAChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-mayanode/package.json
+++ b/packages/xchain-mayanode/package.json
@@ -31,7 +31,7 @@
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "test": "jest --passWithNoTests",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
     "generate:types": "yarn clean:types:mayanode && yarn generate:types:mayanode",
     "generate:types:mayanode": "TS_POST_PROCESS_FILE=./node_modules/.bin/prettier openapi-generator-cli generate -i https://mayanode.mayachain.info/mayachain/doc/openapi.yaml -g typescript-axios -o ./src/generated/mayanodeApi --skip-validate-spec --generate-alias-as-model",
     "clean:types:mayanode": "rimraf ./src/generated/mayanodeApi"

--- a/packages/xchain-mayanode/package.json
+++ b/packages/xchain-mayanode/package.json
@@ -10,7 +10,7 @@
   "author": "MAYAChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-mayanode/rollup.config.js
+++ b/packages/xchain-mayanode/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-mayanode/rollup.config.js
+++ b/packages/xchain-mayanode/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-midgard-query/jest.config.e2e.mjs
+++ b/packages/xchain-midgard-query/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-midgard-query/jest.config.mjs
+++ b/packages/xchain-midgard-query/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-midgard-query/package.json
+++ b/packages/xchain-midgard-query/package.json
@@ -9,7 +9,7 @@
   "author": "THORChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib#readme",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-midgard-query/package.json
+++ b/packages/xchain-midgard-query/package.json
@@ -9,8 +9,10 @@
   "author": "THORChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib#readme",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-midgard-query/package.json
+++ b/packages/xchain-midgard-query/package.json
@@ -8,6 +8,7 @@
   ],
   "author": "THORChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib#readme",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-midgard-query/package.json
+++ b/packages/xchain-midgard-query/package.json
@@ -29,8 +29,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "postversion": "git push --follow-tags"
   },

--- a/packages/xchain-midgard-query/rollup.config.js
+++ b/packages/xchain-midgard-query/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-midgard-query/rollup.config.js
+++ b/packages/xchain-midgard-query/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-midgard/package.json
+++ b/packages/xchain-midgard/package.json
@@ -9,6 +9,7 @@
   ],
   "author": "THORChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-midgard/package.json
+++ b/packages/xchain-midgard/package.json
@@ -31,7 +31,7 @@
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "test": "jest --passWithNoTests",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
     "generate:types": "yarn clean:types:midgard && yarn generate:types:midgard",
     "generate:types:midgard": "TS_POST_PROCESS_FILE=./node_modules/.bin/prettier openapi-generator-cli generate -i https://midgard.ninerealms.com/v2/swagger.json -g typescript-axios -o ./src/generated/midgardApi --generate-alias-as-model --reserved-words-mappings in=in",
     "clean:types:midgard": "rimraf ./src/generated/midgardApi"

--- a/packages/xchain-midgard/package.json
+++ b/packages/xchain-midgard/package.json
@@ -10,8 +10,10 @@
   "author": "THORChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-midgard/package.json
+++ b/packages/xchain-midgard/package.json
@@ -10,7 +10,7 @@
   "author": "THORChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-midgard/rollup.config.js
+++ b/packages/xchain-midgard/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-midgard/rollup.config.js
+++ b/packages/xchain-midgard/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-radix/jest.config.mjs
+++ b/packages/xchain-radix/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 30000,

--- a/packages/xchain-radix/package.json
+++ b/packages/xchain-radix/package.json
@@ -10,6 +10,7 @@
   "author": "RadixDLT",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-radix/package.json
+++ b/packages/xchain-radix/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-radix/package.json
+++ b/packages/xchain-radix/package.json
@@ -31,7 +31,7 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "compile": "tsc -p tsconfig.build.json",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "fund": "ts-node src/utils.ts"

--- a/packages/xchain-radix/package.json
+++ b/packages/xchain-radix/package.json
@@ -11,8 +11,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-radix/rollup.config.js
+++ b/packages/xchain-radix/rollup.config.js
@@ -21,7 +21,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-radix/rollup.config.js
+++ b/packages/xchain-radix/rollup.config.js
@@ -14,14 +14,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-ripple/jest.config.e2e.mjs
+++ b/packages/xchain-ripple/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-ripple/jest.config.mjs
+++ b/packages/xchain-ripple/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 30000,

--- a/packages/xchain-ripple/package.json
+++ b/packages/xchain-ripple/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-ripple/package.json
+++ b/packages/xchain-ripple/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest --passWithNoTests",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "postversion": "git push --follow-tags"
   },

--- a/packages/xchain-ripple/package.json
+++ b/packages/xchain-ripple/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-ripple/package.json
+++ b/packages/xchain-ripple/package.json
@@ -9,6 +9,7 @@
   "author": "XChainJS",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-ripple/rollup.config.js
+++ b/packages/xchain-ripple/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: true,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: true,

--- a/packages/xchain-ripple/rollup.config.js
+++ b/packages/xchain-ripple/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: true,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: true,

--- a/packages/xchain-solana/jest.config.e2e.mjs
+++ b/packages/xchain-solana/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-solana/jest.config.mjs
+++ b/packages/xchain-solana/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-solana/package.json
+++ b/packages/xchain-solana/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0"
   },
   "dependencies": {

--- a/packages/xchain-solana/package.json
+++ b/packages/xchain-solana/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-solana/package.json
+++ b/packages/xchain-solana/package.json
@@ -9,6 +9,7 @@
   "author": "THORChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-solana/package.json
+++ b/packages/xchain-solana/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-solana/rollup.config.js
+++ b/packages/xchain-solana/rollup.config.js
@@ -21,7 +21,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-solana/rollup.config.js
+++ b/packages/xchain-solana/rollup.config.js
@@ -14,14 +14,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-thorchain-amm/jest.config.e2e.mjs
+++ b/packages/xchain-thorchain-amm/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-thorchain-amm/jest.config.mjs
+++ b/packages/xchain-thorchain-amm/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-thorchain-amm/package.json
+++ b/packages/xchain-thorchain-amm/package.json
@@ -9,6 +9,7 @@
   "author": "THORChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib#readme",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-thorchain-amm/package.json
+++ b/packages/xchain-thorchain-amm/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib#readme",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-thorchain-amm/package.json
+++ b/packages/xchain-thorchain-amm/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "postversion": "git push --follow-tags"
   },

--- a/packages/xchain-thorchain-amm/package.json
+++ b/packages/xchain-thorchain-amm/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib#readme",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-thorchain-amm/rollup.config.js
+++ b/packages/xchain-thorchain-amm/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-thorchain-amm/rollup.config.js
+++ b/packages/xchain-thorchain-amm/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-thorchain-query/jest.config.e2e.mjs
+++ b/packages/xchain-thorchain-query/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-thorchain-query/jest.config.mjs
+++ b/packages/xchain-thorchain-query/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-thorchain-query/package.json
+++ b/packages/xchain-thorchain-query/package.json
@@ -9,6 +9,7 @@
   ],
   "author": "THORChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib#readme",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-thorchain-query/package.json
+++ b/packages/xchain-thorchain-query/package.json
@@ -10,8 +10,10 @@
   "author": "THORChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib#readme",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-thorchain-query/package.json
+++ b/packages/xchain-thorchain-query/package.json
@@ -10,7 +10,7 @@
   "author": "THORChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib#readme",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-thorchain-query/package.json
+++ b/packages/xchain-thorchain-query/package.json
@@ -39,7 +39,7 @@
     "@xchainjs/xchain-util": "workspace:*",
     "axios": "1.8.4",
     "axios-retry": "3.2.5",
-    "bignumber.js": "^9.0.0"
+    "bignumber.js": "^9.1.2"
   },
   "devDependencies": {
     "axios-mock-adapter": "2.1.0"

--- a/packages/xchain-thorchain-query/package.json
+++ b/packages/xchain-thorchain-query/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "postversion": "git push --follow-tags"
   },

--- a/packages/xchain-thorchain-query/rollup.config.js
+++ b/packages/xchain-thorchain-query/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-thorchain-query/rollup.config.js
+++ b/packages/xchain-thorchain-query/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-thorchain/genMsgs.sh
+++ b/packages/xchain-thorchain/genMsgs.sh
@@ -41,6 +41,10 @@ yarn pbjs -w commonjs -t static-module \
   "$TMP_DIR/thornode/third_party/proto/cosmos/base/v1beta1/coin.proto" \
   -o "$MSG_COMPILED_OUTPUTFILE" 2>pbjs_errors.txt
 
+# Fix import to be ESM-compatible (no omitted file extension)
+sed -i -E 's|"(protobufjs/minimal)"|"\1.js"|' "$MSG_COMPILED_OUTPUTFILE"
+
+
 # Generate TypeScript definitions with explicit namespace
 tput setaf 2
 echo "Generating $MSG_COMPILED_TYPES_OUTPUTFILE"

--- a/packages/xchain-thorchain/jest.config.e2e.mjs
+++ b/packages/xchain-thorchain/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-thorchain/jest.config.mjs
+++ b/packages/xchain-thorchain/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testTimeout: 60000,

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -9,6 +9,7 @@
   "author": "THORChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -29,8 +29,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "start:example": "ts-node example/index.ts",
     "generate:ThorchainMsgs": "./genMsgs.sh"

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -9,9 +9,10 @@
   "author": "THORChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
-  "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.mjs"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -50,7 +50,7 @@
     "@xchainjs/xchain-util": "workspace:*",
     "axios": "1.8.4",
     "bech32": "^1.1.3",
-    "bignumber.js": "^9.0.0",
+    "bignumber.js": "^9.1.2",
     "cosmjs-types": "0.9.0",
     "protobufjs": "6.11.4"
   },

--- a/packages/xchain-thorchain/rollup.config.js
+++ b/packages/xchain-thorchain/rollup.config.js
@@ -17,14 +17,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-thorchain/rollup.config.js
+++ b/packages/xchain-thorchain/rollup.config.js
@@ -24,7 +24,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-thorchain/src/client.ts
+++ b/packages/xchain-thorchain/src/client.ts
@@ -13,7 +13,7 @@ import {
   bech32ToBase64,
 } from '@xchainjs/xchain-cosmos-sdk'
 import { Address, assetFromString, eqAsset } from '@xchainjs/xchain-util'
-import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
+import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx.js'
 
 /**
  * Import constants and types

--- a/packages/xchain-thorchain/src/clientKeystore.ts
+++ b/packages/xchain-thorchain/src/clientKeystore.ts
@@ -13,7 +13,7 @@ import { BaseAmount } from '@xchainjs/xchain-util'
 import { encode, toWords } from 'bech32'
 import BigNumber from 'bignumber.js'
 import { HDKey } from '@scure/bip32'
-import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
+import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx.js'
 import { createHash } from 'crypto'
 import * as secp from '@bitcoin-js/tiny-secp256k1-asmjs'
 

--- a/packages/xchain-thorchain/src/clientLedger.ts
+++ b/packages/xchain-thorchain/src/clientLedger.ts
@@ -7,8 +7,8 @@ import THORChainApp, { extractSignatureFromTLV } from '@xchainjs/ledger-thorchai
 import { CompatibleAsset, base64ToBech32, bech32ToBase64 } from '@xchainjs/xchain-cosmos-sdk'
 import { assetFromStringEx, assetToString } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
-import { SignMode } from 'cosmjs-types/cosmos/tx/signing/v1beta1/signing'
-import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
+import { SignMode } from 'cosmjs-types/cosmos/tx/signing/v1beta1/signing.js'
+import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx.js'
 
 import { Client, ThorchainClientParams } from './client'
 import { AssetRuneNative, DEPOSIT_GAS_LIMIT_VALUE, defaultClientConfig } from './const'

--- a/packages/xchain-thorchain/src/types/proto/MsgCompiled.d.ts
+++ b/packages/xchain-thorchain/src/types/proto/MsgCompiled.d.ts
@@ -636,6 +636,1585 @@ declare namespace types {
              */
             public toJSON(): { [k: string]: any };
         }
+
+        /** Status enum. */
+        enum Status {
+            incomplete = 0,
+            done = 1,
+            reverted = 2
+        }
+
+        /** Properties of an ObservedTx. */
+        interface IObservedTx {
+
+            /** ObservedTx tx */
+            tx?: (common.ITx|null);
+
+            /** ObservedTx status */
+            status?: (common.Status|null);
+
+            /** ObservedTx outHashes */
+            outHashes?: (string[]|null);
+
+            /** ObservedTx blockHeight */
+            blockHeight?: (number|Long|null);
+
+            /** ObservedTx signers */
+            signers?: (string[]|null);
+
+            /** ObservedTx observedPubKey */
+            observedPubKey?: (string|null);
+
+            /** ObservedTx keysignMs */
+            keysignMs?: (number|Long|null);
+
+            /** ObservedTx finaliseHeight */
+            finaliseHeight?: (number|Long|null);
+
+            /** ObservedTx aggregator */
+            aggregator?: (string|null);
+
+            /** ObservedTx aggregatorTarget */
+            aggregatorTarget?: (string|null);
+
+            /** ObservedTx aggregatorTargetLimit */
+            aggregatorTargetLimit?: (string|null);
+        }
+
+        /** Represents an ObservedTx. */
+        class ObservedTx implements IObservedTx {
+
+            /**
+             * Constructs a new ObservedTx.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: common.IObservedTx);
+
+            /** ObservedTx tx. */
+            public tx?: (common.ITx|null);
+
+            /** ObservedTx status. */
+            public status: common.Status;
+
+            /** ObservedTx outHashes. */
+            public outHashes: string[];
+
+            /** ObservedTx blockHeight. */
+            public blockHeight: (number|Long);
+
+            /** ObservedTx signers. */
+            public signers: string[];
+
+            /** ObservedTx observedPubKey. */
+            public observedPubKey: string;
+
+            /** ObservedTx keysignMs. */
+            public keysignMs: (number|Long);
+
+            /** ObservedTx finaliseHeight. */
+            public finaliseHeight: (number|Long);
+
+            /** ObservedTx aggregator. */
+            public aggregator: string;
+
+            /** ObservedTx aggregatorTarget. */
+            public aggregatorTarget: string;
+
+            /** ObservedTx aggregatorTargetLimit. */
+            public aggregatorTargetLimit: string;
+
+            /**
+             * Creates a new ObservedTx instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns ObservedTx instance
+             */
+            public static create(properties?: common.IObservedTx): common.ObservedTx;
+
+            /**
+             * Encodes the specified ObservedTx message. Does not implicitly {@link common.ObservedTx.verify|verify} messages.
+             * @param message ObservedTx message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: common.IObservedTx, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified ObservedTx message, length delimited. Does not implicitly {@link common.ObservedTx.verify|verify} messages.
+             * @param message ObservedTx message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: common.IObservedTx, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes an ObservedTx message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns ObservedTx
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): common.ObservedTx;
+
+            /**
+             * Decodes an ObservedTx message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns ObservedTx
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): common.ObservedTx;
+
+            /**
+             * Verifies an ObservedTx message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates an ObservedTx message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns ObservedTx
+             */
+            public static fromObject(object: { [k: string]: any }): common.ObservedTx;
+
+            /**
+             * Creates a plain object from an ObservedTx message. Also converts values to other types if specified.
+             * @param message ObservedTx
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: common.ObservedTx, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this ObservedTx to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of an Attestation. */
+        interface IAttestation {
+
+            /** Attestation PubKey */
+            PubKey?: (Uint8Array|null);
+
+            /** Attestation Signature */
+            Signature?: (Uint8Array|null);
+        }
+
+        /** Represents an Attestation. */
+        class Attestation implements IAttestation {
+
+            /**
+             * Constructs a new Attestation.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: common.IAttestation);
+
+            /** Attestation PubKey. */
+            public PubKey: Uint8Array;
+
+            /** Attestation Signature. */
+            public Signature: Uint8Array;
+
+            /**
+             * Creates a new Attestation instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns Attestation instance
+             */
+            public static create(properties?: common.IAttestation): common.Attestation;
+
+            /**
+             * Encodes the specified Attestation message. Does not implicitly {@link common.Attestation.verify|verify} messages.
+             * @param message Attestation message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: common.IAttestation, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified Attestation message, length delimited. Does not implicitly {@link common.Attestation.verify|verify} messages.
+             * @param message Attestation message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: common.IAttestation, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes an Attestation message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns Attestation
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): common.Attestation;
+
+            /**
+             * Decodes an Attestation message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns Attestation
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): common.Attestation;
+
+            /**
+             * Verifies an Attestation message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates an Attestation message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns Attestation
+             */
+            public static fromObject(object: { [k: string]: any }): common.Attestation;
+
+            /**
+             * Creates a plain object from an Attestation message. Also converts values to other types if specified.
+             * @param message Attestation
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: common.Attestation, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this Attestation to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of an AttestTx. */
+        interface IAttestTx {
+
+            /** AttestTx obsTx */
+            obsTx?: (common.IObservedTx|null);
+
+            /** AttestTx attestation */
+            attestation?: (common.IAttestation|null);
+
+            /** AttestTx inbound */
+            inbound?: (boolean|null);
+
+            /** AttestTx allowFutureObservation */
+            allowFutureObservation?: (boolean|null);
+        }
+
+        /** Represents an AttestTx. */
+        class AttestTx implements IAttestTx {
+
+            /**
+             * Constructs a new AttestTx.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: common.IAttestTx);
+
+            /** AttestTx obsTx. */
+            public obsTx?: (common.IObservedTx|null);
+
+            /** AttestTx attestation. */
+            public attestation?: (common.IAttestation|null);
+
+            /** AttestTx inbound. */
+            public inbound: boolean;
+
+            /** AttestTx allowFutureObservation. */
+            public allowFutureObservation: boolean;
+
+            /**
+             * Creates a new AttestTx instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns AttestTx instance
+             */
+            public static create(properties?: common.IAttestTx): common.AttestTx;
+
+            /**
+             * Encodes the specified AttestTx message. Does not implicitly {@link common.AttestTx.verify|verify} messages.
+             * @param message AttestTx message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: common.IAttestTx, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified AttestTx message, length delimited. Does not implicitly {@link common.AttestTx.verify|verify} messages.
+             * @param message AttestTx message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: common.IAttestTx, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes an AttestTx message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns AttestTx
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): common.AttestTx;
+
+            /**
+             * Decodes an AttestTx message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns AttestTx
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): common.AttestTx;
+
+            /**
+             * Verifies an AttestTx message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates an AttestTx message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns AttestTx
+             */
+            public static fromObject(object: { [k: string]: any }): common.AttestTx;
+
+            /**
+             * Creates a plain object from an AttestTx message. Also converts values to other types if specified.
+             * @param message AttestTx
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: common.AttestTx, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this AttestTx to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a QuorumTx. */
+        interface IQuorumTx {
+
+            /** QuorumTx obsTx */
+            obsTx?: (common.IObservedTx|null);
+
+            /** QuorumTx attestations */
+            attestations?: (common.IAttestation[]|null);
+
+            /** QuorumTx inbound */
+            inbound?: (boolean|null);
+
+            /** QuorumTx allowFutureObservation */
+            allowFutureObservation?: (boolean|null);
+        }
+
+        /** Represents a QuorumTx. */
+        class QuorumTx implements IQuorumTx {
+
+            /**
+             * Constructs a new QuorumTx.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: common.IQuorumTx);
+
+            /** QuorumTx obsTx. */
+            public obsTx?: (common.IObservedTx|null);
+
+            /** QuorumTx attestations. */
+            public attestations: common.IAttestation[];
+
+            /** QuorumTx inbound. */
+            public inbound: boolean;
+
+            /** QuorumTx allowFutureObservation. */
+            public allowFutureObservation: boolean;
+
+            /**
+             * Creates a new QuorumTx instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns QuorumTx instance
+             */
+            public static create(properties?: common.IQuorumTx): common.QuorumTx;
+
+            /**
+             * Encodes the specified QuorumTx message. Does not implicitly {@link common.QuorumTx.verify|verify} messages.
+             * @param message QuorumTx message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: common.IQuorumTx, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified QuorumTx message, length delimited. Does not implicitly {@link common.QuorumTx.verify|verify} messages.
+             * @param message QuorumTx message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: common.IQuorumTx, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a QuorumTx message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns QuorumTx
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): common.QuorumTx;
+
+            /**
+             * Decodes a QuorumTx message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns QuorumTx
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): common.QuorumTx;
+
+            /**
+             * Verifies a QuorumTx message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a QuorumTx message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns QuorumTx
+             */
+            public static fromObject(object: { [k: string]: any }): common.QuorumTx;
+
+            /**
+             * Creates a plain object from a QuorumTx message. Also converts values to other types if specified.
+             * @param message QuorumTx
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: common.QuorumTx, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this QuorumTx to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a QuorumState. */
+        interface IQuorumState {
+
+            /** QuorumState quoTxs */
+            quoTxs?: (common.IQuorumTx[]|null);
+
+            /** QuorumState quoNetworkFees */
+            quoNetworkFees?: (common.IQuorumNetworkFee[]|null);
+
+            /** QuorumState quoSolvencies */
+            quoSolvencies?: (common.IQuorumSolvency[]|null);
+
+            /** QuorumState quoErrataTxs */
+            quoErrataTxs?: (common.IQuorumErrataTx[]|null);
+        }
+
+        /** Represents a QuorumState. */
+        class QuorumState implements IQuorumState {
+
+            /**
+             * Constructs a new QuorumState.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: common.IQuorumState);
+
+            /** QuorumState quoTxs. */
+            public quoTxs: common.IQuorumTx[];
+
+            /** QuorumState quoNetworkFees. */
+            public quoNetworkFees: common.IQuorumNetworkFee[];
+
+            /** QuorumState quoSolvencies. */
+            public quoSolvencies: common.IQuorumSolvency[];
+
+            /** QuorumState quoErrataTxs. */
+            public quoErrataTxs: common.IQuorumErrataTx[];
+
+            /**
+             * Creates a new QuorumState instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns QuorumState instance
+             */
+            public static create(properties?: common.IQuorumState): common.QuorumState;
+
+            /**
+             * Encodes the specified QuorumState message. Does not implicitly {@link common.QuorumState.verify|verify} messages.
+             * @param message QuorumState message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: common.IQuorumState, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified QuorumState message, length delimited. Does not implicitly {@link common.QuorumState.verify|verify} messages.
+             * @param message QuorumState message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: common.IQuorumState, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a QuorumState message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns QuorumState
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): common.QuorumState;
+
+            /**
+             * Decodes a QuorumState message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns QuorumState
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): common.QuorumState;
+
+            /**
+             * Verifies a QuorumState message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a QuorumState message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns QuorumState
+             */
+            public static fromObject(object: { [k: string]: any }): common.QuorumState;
+
+            /**
+             * Creates a plain object from a QuorumState message. Also converts values to other types if specified.
+             * @param message QuorumState
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: common.QuorumState, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this QuorumState to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a NetworkFee. */
+        interface INetworkFee {
+
+            /** NetworkFee height */
+            height?: (number|Long|null);
+
+            /** NetworkFee chain */
+            chain?: (string|null);
+
+            /** NetworkFee transactionSize */
+            transactionSize?: (number|Long|null);
+
+            /** NetworkFee transactionRate */
+            transactionRate?: (number|Long|null);
+        }
+
+        /** Represents a NetworkFee. */
+        class NetworkFee implements INetworkFee {
+
+            /**
+             * Constructs a new NetworkFee.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: common.INetworkFee);
+
+            /** NetworkFee height. */
+            public height: (number|Long);
+
+            /** NetworkFee chain. */
+            public chain: string;
+
+            /** NetworkFee transactionSize. */
+            public transactionSize: (number|Long);
+
+            /** NetworkFee transactionRate. */
+            public transactionRate: (number|Long);
+
+            /**
+             * Creates a new NetworkFee instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns NetworkFee instance
+             */
+            public static create(properties?: common.INetworkFee): common.NetworkFee;
+
+            /**
+             * Encodes the specified NetworkFee message. Does not implicitly {@link common.NetworkFee.verify|verify} messages.
+             * @param message NetworkFee message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: common.INetworkFee, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified NetworkFee message, length delimited. Does not implicitly {@link common.NetworkFee.verify|verify} messages.
+             * @param message NetworkFee message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: common.INetworkFee, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a NetworkFee message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns NetworkFee
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): common.NetworkFee;
+
+            /**
+             * Decodes a NetworkFee message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns NetworkFee
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): common.NetworkFee;
+
+            /**
+             * Verifies a NetworkFee message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a NetworkFee message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns NetworkFee
+             */
+            public static fromObject(object: { [k: string]: any }): common.NetworkFee;
+
+            /**
+             * Creates a plain object from a NetworkFee message. Also converts values to other types if specified.
+             * @param message NetworkFee
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: common.NetworkFee, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this NetworkFee to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of an AttestNetworkFee. */
+        interface IAttestNetworkFee {
+
+            /** AttestNetworkFee networkFee */
+            networkFee?: (common.INetworkFee|null);
+
+            /** AttestNetworkFee attestation */
+            attestation?: (common.IAttestation|null);
+        }
+
+        /** Represents an AttestNetworkFee. */
+        class AttestNetworkFee implements IAttestNetworkFee {
+
+            /**
+             * Constructs a new AttestNetworkFee.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: common.IAttestNetworkFee);
+
+            /** AttestNetworkFee networkFee. */
+            public networkFee?: (common.INetworkFee|null);
+
+            /** AttestNetworkFee attestation. */
+            public attestation?: (common.IAttestation|null);
+
+            /**
+             * Creates a new AttestNetworkFee instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns AttestNetworkFee instance
+             */
+            public static create(properties?: common.IAttestNetworkFee): common.AttestNetworkFee;
+
+            /**
+             * Encodes the specified AttestNetworkFee message. Does not implicitly {@link common.AttestNetworkFee.verify|verify} messages.
+             * @param message AttestNetworkFee message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: common.IAttestNetworkFee, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified AttestNetworkFee message, length delimited. Does not implicitly {@link common.AttestNetworkFee.verify|verify} messages.
+             * @param message AttestNetworkFee message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: common.IAttestNetworkFee, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes an AttestNetworkFee message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns AttestNetworkFee
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): common.AttestNetworkFee;
+
+            /**
+             * Decodes an AttestNetworkFee message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns AttestNetworkFee
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): common.AttestNetworkFee;
+
+            /**
+             * Verifies an AttestNetworkFee message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates an AttestNetworkFee message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns AttestNetworkFee
+             */
+            public static fromObject(object: { [k: string]: any }): common.AttestNetworkFee;
+
+            /**
+             * Creates a plain object from an AttestNetworkFee message. Also converts values to other types if specified.
+             * @param message AttestNetworkFee
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: common.AttestNetworkFee, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this AttestNetworkFee to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a QuorumNetworkFee. */
+        interface IQuorumNetworkFee {
+
+            /** QuorumNetworkFee networkFee */
+            networkFee?: (common.INetworkFee|null);
+
+            /** QuorumNetworkFee attestations */
+            attestations?: (common.IAttestation[]|null);
+        }
+
+        /** Represents a QuorumNetworkFee. */
+        class QuorumNetworkFee implements IQuorumNetworkFee {
+
+            /**
+             * Constructs a new QuorumNetworkFee.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: common.IQuorumNetworkFee);
+
+            /** QuorumNetworkFee networkFee. */
+            public networkFee?: (common.INetworkFee|null);
+
+            /** QuorumNetworkFee attestations. */
+            public attestations: common.IAttestation[];
+
+            /**
+             * Creates a new QuorumNetworkFee instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns QuorumNetworkFee instance
+             */
+            public static create(properties?: common.IQuorumNetworkFee): common.QuorumNetworkFee;
+
+            /**
+             * Encodes the specified QuorumNetworkFee message. Does not implicitly {@link common.QuorumNetworkFee.verify|verify} messages.
+             * @param message QuorumNetworkFee message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: common.IQuorumNetworkFee, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified QuorumNetworkFee message, length delimited. Does not implicitly {@link common.QuorumNetworkFee.verify|verify} messages.
+             * @param message QuorumNetworkFee message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: common.IQuorumNetworkFee, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a QuorumNetworkFee message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns QuorumNetworkFee
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): common.QuorumNetworkFee;
+
+            /**
+             * Decodes a QuorumNetworkFee message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns QuorumNetworkFee
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): common.QuorumNetworkFee;
+
+            /**
+             * Verifies a QuorumNetworkFee message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a QuorumNetworkFee message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns QuorumNetworkFee
+             */
+            public static fromObject(object: { [k: string]: any }): common.QuorumNetworkFee;
+
+            /**
+             * Creates a plain object from a QuorumNetworkFee message. Also converts values to other types if specified.
+             * @param message QuorumNetworkFee
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: common.QuorumNetworkFee, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this QuorumNetworkFee to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a Solvency. */
+        interface ISolvency {
+
+            /** Solvency id */
+            id?: (string|null);
+
+            /** Solvency chain */
+            chain?: (string|null);
+
+            /** Solvency pubKey */
+            pubKey?: (string|null);
+
+            /** Solvency coins */
+            coins?: (common.ICoin[]|null);
+
+            /** Solvency height */
+            height?: (number|Long|null);
+        }
+
+        /** Represents a Solvency. */
+        class Solvency implements ISolvency {
+
+            /**
+             * Constructs a new Solvency.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: common.ISolvency);
+
+            /** Solvency id. */
+            public id: string;
+
+            /** Solvency chain. */
+            public chain: string;
+
+            /** Solvency pubKey. */
+            public pubKey: string;
+
+            /** Solvency coins. */
+            public coins: common.ICoin[];
+
+            /** Solvency height. */
+            public height: (number|Long);
+
+            /**
+             * Creates a new Solvency instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns Solvency instance
+             */
+            public static create(properties?: common.ISolvency): common.Solvency;
+
+            /**
+             * Encodes the specified Solvency message. Does not implicitly {@link common.Solvency.verify|verify} messages.
+             * @param message Solvency message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: common.ISolvency, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified Solvency message, length delimited. Does not implicitly {@link common.Solvency.verify|verify} messages.
+             * @param message Solvency message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: common.ISolvency, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a Solvency message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns Solvency
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): common.Solvency;
+
+            /**
+             * Decodes a Solvency message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns Solvency
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): common.Solvency;
+
+            /**
+             * Verifies a Solvency message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a Solvency message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns Solvency
+             */
+            public static fromObject(object: { [k: string]: any }): common.Solvency;
+
+            /**
+             * Creates a plain object from a Solvency message. Also converts values to other types if specified.
+             * @param message Solvency
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: common.Solvency, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this Solvency to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of an AttestSolvency. */
+        interface IAttestSolvency {
+
+            /** AttestSolvency solvency */
+            solvency?: (common.ISolvency|null);
+
+            /** AttestSolvency attestation */
+            attestation?: (common.IAttestation|null);
+        }
+
+        /** Represents an AttestSolvency. */
+        class AttestSolvency implements IAttestSolvency {
+
+            /**
+             * Constructs a new AttestSolvency.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: common.IAttestSolvency);
+
+            /** AttestSolvency solvency. */
+            public solvency?: (common.ISolvency|null);
+
+            /** AttestSolvency attestation. */
+            public attestation?: (common.IAttestation|null);
+
+            /**
+             * Creates a new AttestSolvency instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns AttestSolvency instance
+             */
+            public static create(properties?: common.IAttestSolvency): common.AttestSolvency;
+
+            /**
+             * Encodes the specified AttestSolvency message. Does not implicitly {@link common.AttestSolvency.verify|verify} messages.
+             * @param message AttestSolvency message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: common.IAttestSolvency, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified AttestSolvency message, length delimited. Does not implicitly {@link common.AttestSolvency.verify|verify} messages.
+             * @param message AttestSolvency message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: common.IAttestSolvency, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes an AttestSolvency message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns AttestSolvency
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): common.AttestSolvency;
+
+            /**
+             * Decodes an AttestSolvency message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns AttestSolvency
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): common.AttestSolvency;
+
+            /**
+             * Verifies an AttestSolvency message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates an AttestSolvency message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns AttestSolvency
+             */
+            public static fromObject(object: { [k: string]: any }): common.AttestSolvency;
+
+            /**
+             * Creates a plain object from an AttestSolvency message. Also converts values to other types if specified.
+             * @param message AttestSolvency
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: common.AttestSolvency, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this AttestSolvency to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a QuorumSolvency. */
+        interface IQuorumSolvency {
+
+            /** QuorumSolvency solvency */
+            solvency?: (common.ISolvency|null);
+
+            /** QuorumSolvency attestations */
+            attestations?: (common.IAttestation[]|null);
+        }
+
+        /** Represents a QuorumSolvency. */
+        class QuorumSolvency implements IQuorumSolvency {
+
+            /**
+             * Constructs a new QuorumSolvency.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: common.IQuorumSolvency);
+
+            /** QuorumSolvency solvency. */
+            public solvency?: (common.ISolvency|null);
+
+            /** QuorumSolvency attestations. */
+            public attestations: common.IAttestation[];
+
+            /**
+             * Creates a new QuorumSolvency instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns QuorumSolvency instance
+             */
+            public static create(properties?: common.IQuorumSolvency): common.QuorumSolvency;
+
+            /**
+             * Encodes the specified QuorumSolvency message. Does not implicitly {@link common.QuorumSolvency.verify|verify} messages.
+             * @param message QuorumSolvency message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: common.IQuorumSolvency, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified QuorumSolvency message, length delimited. Does not implicitly {@link common.QuorumSolvency.verify|verify} messages.
+             * @param message QuorumSolvency message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: common.IQuorumSolvency, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a QuorumSolvency message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns QuorumSolvency
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): common.QuorumSolvency;
+
+            /**
+             * Decodes a QuorumSolvency message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns QuorumSolvency
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): common.QuorumSolvency;
+
+            /**
+             * Verifies a QuorumSolvency message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a QuorumSolvency message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns QuorumSolvency
+             */
+            public static fromObject(object: { [k: string]: any }): common.QuorumSolvency;
+
+            /**
+             * Creates a plain object from a QuorumSolvency message. Also converts values to other types if specified.
+             * @param message QuorumSolvency
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: common.QuorumSolvency, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this QuorumSolvency to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of an ErrataTx. */
+        interface IErrataTx {
+
+            /** ErrataTx id */
+            id?: (string|null);
+
+            /** ErrataTx chain */
+            chain?: (string|null);
+        }
+
+        /** Represents an ErrataTx. */
+        class ErrataTx implements IErrataTx {
+
+            /**
+             * Constructs a new ErrataTx.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: common.IErrataTx);
+
+            /** ErrataTx id. */
+            public id: string;
+
+            /** ErrataTx chain. */
+            public chain: string;
+
+            /**
+             * Creates a new ErrataTx instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns ErrataTx instance
+             */
+            public static create(properties?: common.IErrataTx): common.ErrataTx;
+
+            /**
+             * Encodes the specified ErrataTx message. Does not implicitly {@link common.ErrataTx.verify|verify} messages.
+             * @param message ErrataTx message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: common.IErrataTx, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified ErrataTx message, length delimited. Does not implicitly {@link common.ErrataTx.verify|verify} messages.
+             * @param message ErrataTx message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: common.IErrataTx, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes an ErrataTx message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns ErrataTx
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): common.ErrataTx;
+
+            /**
+             * Decodes an ErrataTx message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns ErrataTx
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): common.ErrataTx;
+
+            /**
+             * Verifies an ErrataTx message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates an ErrataTx message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns ErrataTx
+             */
+            public static fromObject(object: { [k: string]: any }): common.ErrataTx;
+
+            /**
+             * Creates a plain object from an ErrataTx message. Also converts values to other types if specified.
+             * @param message ErrataTx
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: common.ErrataTx, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this ErrataTx to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of an AttestErrataTx. */
+        interface IAttestErrataTx {
+
+            /** AttestErrataTx errataTx */
+            errataTx?: (common.IErrataTx|null);
+
+            /** AttestErrataTx attestation */
+            attestation?: (common.IAttestation|null);
+        }
+
+        /** Represents an AttestErrataTx. */
+        class AttestErrataTx implements IAttestErrataTx {
+
+            /**
+             * Constructs a new AttestErrataTx.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: common.IAttestErrataTx);
+
+            /** AttestErrataTx errataTx. */
+            public errataTx?: (common.IErrataTx|null);
+
+            /** AttestErrataTx attestation. */
+            public attestation?: (common.IAttestation|null);
+
+            /**
+             * Creates a new AttestErrataTx instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns AttestErrataTx instance
+             */
+            public static create(properties?: common.IAttestErrataTx): common.AttestErrataTx;
+
+            /**
+             * Encodes the specified AttestErrataTx message. Does not implicitly {@link common.AttestErrataTx.verify|verify} messages.
+             * @param message AttestErrataTx message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: common.IAttestErrataTx, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified AttestErrataTx message, length delimited. Does not implicitly {@link common.AttestErrataTx.verify|verify} messages.
+             * @param message AttestErrataTx message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: common.IAttestErrataTx, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes an AttestErrataTx message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns AttestErrataTx
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): common.AttestErrataTx;
+
+            /**
+             * Decodes an AttestErrataTx message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns AttestErrataTx
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): common.AttestErrataTx;
+
+            /**
+             * Verifies an AttestErrataTx message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates an AttestErrataTx message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns AttestErrataTx
+             */
+            public static fromObject(object: { [k: string]: any }): common.AttestErrataTx;
+
+            /**
+             * Creates a plain object from an AttestErrataTx message. Also converts values to other types if specified.
+             * @param message AttestErrataTx
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: common.AttestErrataTx, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this AttestErrataTx to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a QuorumErrataTx. */
+        interface IQuorumErrataTx {
+
+            /** QuorumErrataTx errataTx */
+            errataTx?: (common.IErrataTx|null);
+
+            /** QuorumErrataTx attestations */
+            attestations?: (common.IAttestation[]|null);
+        }
+
+        /** Represents a QuorumErrataTx. */
+        class QuorumErrataTx implements IQuorumErrataTx {
+
+            /**
+             * Constructs a new QuorumErrataTx.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: common.IQuorumErrataTx);
+
+            /** QuorumErrataTx errataTx. */
+            public errataTx?: (common.IErrataTx|null);
+
+            /** QuorumErrataTx attestations. */
+            public attestations: common.IAttestation[];
+
+            /**
+             * Creates a new QuorumErrataTx instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns QuorumErrataTx instance
+             */
+            public static create(properties?: common.IQuorumErrataTx): common.QuorumErrataTx;
+
+            /**
+             * Encodes the specified QuorumErrataTx message. Does not implicitly {@link common.QuorumErrataTx.verify|verify} messages.
+             * @param message QuorumErrataTx message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: common.IQuorumErrataTx, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified QuorumErrataTx message, length delimited. Does not implicitly {@link common.QuorumErrataTx.verify|verify} messages.
+             * @param message QuorumErrataTx message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: common.IQuorumErrataTx, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a QuorumErrataTx message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns QuorumErrataTx
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): common.QuorumErrataTx;
+
+            /**
+             * Decodes a QuorumErrataTx message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns QuorumErrataTx
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): common.QuorumErrataTx;
+
+            /**
+             * Verifies a QuorumErrataTx message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a QuorumErrataTx message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns QuorumErrataTx
+             */
+            public static fromObject(object: { [k: string]: any }): common.QuorumErrataTx;
+
+            /**
+             * Creates a plain object from a QuorumErrataTx message. Also converts values to other types if specified.
+             * @param message QuorumErrataTx
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: common.QuorumErrataTx, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this QuorumErrataTx to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of an AttestationBatch. */
+        interface IAttestationBatch {
+
+            /** AttestationBatch attestTxs */
+            attestTxs?: (common.IAttestTx[]|null);
+
+            /** AttestationBatch attestNetworkFees */
+            attestNetworkFees?: (common.IAttestNetworkFee[]|null);
+
+            /** AttestationBatch attestSolvencies */
+            attestSolvencies?: (common.IAttestSolvency[]|null);
+
+            /** AttestationBatch attestErrataTxs */
+            attestErrataTxs?: (common.IAttestErrataTx[]|null);
+        }
+
+        /** Represents an AttestationBatch. */
+        class AttestationBatch implements IAttestationBatch {
+
+            /**
+             * Constructs a new AttestationBatch.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: common.IAttestationBatch);
+
+            /** AttestationBatch attestTxs. */
+            public attestTxs: common.IAttestTx[];
+
+            /** AttestationBatch attestNetworkFees. */
+            public attestNetworkFees: common.IAttestNetworkFee[];
+
+            /** AttestationBatch attestSolvencies. */
+            public attestSolvencies: common.IAttestSolvency[];
+
+            /** AttestationBatch attestErrataTxs. */
+            public attestErrataTxs: common.IAttestErrataTx[];
+
+            /**
+             * Creates a new AttestationBatch instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns AttestationBatch instance
+             */
+            public static create(properties?: common.IAttestationBatch): common.AttestationBatch;
+
+            /**
+             * Encodes the specified AttestationBatch message. Does not implicitly {@link common.AttestationBatch.verify|verify} messages.
+             * @param message AttestationBatch message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: common.IAttestationBatch, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified AttestationBatch message, length delimited. Does not implicitly {@link common.AttestationBatch.verify|verify} messages.
+             * @param message AttestationBatch message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: common.IAttestationBatch, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes an AttestationBatch message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns AttestationBatch
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): common.AttestationBatch;
+
+            /**
+             * Decodes an AttestationBatch message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns AttestationBatch
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): common.AttestationBatch;
+
+            /**
+             * Verifies an AttestationBatch message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates an AttestationBatch message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns AttestationBatch
+             */
+            public static fromObject(object: { [k: string]: any }): common.AttestationBatch;
+
+            /**
+             * Creates a plain object from an AttestationBatch message. Also converts values to other types if specified.
+             * @param message AttestationBatch
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: common.AttestationBatch, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this AttestationBatch to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
     }
 
     /** Namespace types. */

--- a/packages/xchain-thorchain/src/types/proto/MsgCompiled.js
+++ b/packages/xchain-thorchain/src/types/proto/MsgCompiled.js
@@ -1,7 +1,7 @@
 /*eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars*/
 "use strict";
 
-var $protobuf = require("protobufjs/minimal");
+var $protobuf = require("protobufjs/minimal.js");
 
 // Common aliases
 var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
@@ -1557,6 +1557,4164 @@ $root.common = (function() {
         };
 
         return ProtoUint;
+    })();
+
+    /**
+     * Status enum.
+     * @name common.Status
+     * @enum {number}
+     * @property {number} incomplete=0 incomplete value
+     * @property {number} done=1 done value
+     * @property {number} reverted=2 reverted value
+     */
+    common.Status = (function() {
+        var valuesById = {}, values = Object.create(valuesById);
+        values[valuesById[0] = "incomplete"] = 0;
+        values[valuesById[1] = "done"] = 1;
+        values[valuesById[2] = "reverted"] = 2;
+        return values;
+    })();
+
+    common.ObservedTx = (function() {
+
+        /**
+         * Properties of an ObservedTx.
+         * @memberof common
+         * @interface IObservedTx
+         * @property {common.ITx|null} [tx] ObservedTx tx
+         * @property {common.Status|null} [status] ObservedTx status
+         * @property {Array.<string>|null} [outHashes] ObservedTx outHashes
+         * @property {number|Long|null} [blockHeight] ObservedTx blockHeight
+         * @property {Array.<string>|null} [signers] ObservedTx signers
+         * @property {string|null} [observedPubKey] ObservedTx observedPubKey
+         * @property {number|Long|null} [keysignMs] ObservedTx keysignMs
+         * @property {number|Long|null} [finaliseHeight] ObservedTx finaliseHeight
+         * @property {string|null} [aggregator] ObservedTx aggregator
+         * @property {string|null} [aggregatorTarget] ObservedTx aggregatorTarget
+         * @property {string|null} [aggregatorTargetLimit] ObservedTx aggregatorTargetLimit
+         */
+
+        /**
+         * Constructs a new ObservedTx.
+         * @memberof common
+         * @classdesc Represents an ObservedTx.
+         * @implements IObservedTx
+         * @constructor
+         * @param {common.IObservedTx=} [properties] Properties to set
+         */
+        function ObservedTx(properties) {
+            this.outHashes = [];
+            this.signers = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * ObservedTx tx.
+         * @member {common.ITx|null|undefined} tx
+         * @memberof common.ObservedTx
+         * @instance
+         */
+        ObservedTx.prototype.tx = null;
+
+        /**
+         * ObservedTx status.
+         * @member {common.Status} status
+         * @memberof common.ObservedTx
+         * @instance
+         */
+        ObservedTx.prototype.status = 0;
+
+        /**
+         * ObservedTx outHashes.
+         * @member {Array.<string>} outHashes
+         * @memberof common.ObservedTx
+         * @instance
+         */
+        ObservedTx.prototype.outHashes = $util.emptyArray;
+
+        /**
+         * ObservedTx blockHeight.
+         * @member {number|Long} blockHeight
+         * @memberof common.ObservedTx
+         * @instance
+         */
+        ObservedTx.prototype.blockHeight = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+
+        /**
+         * ObservedTx signers.
+         * @member {Array.<string>} signers
+         * @memberof common.ObservedTx
+         * @instance
+         */
+        ObservedTx.prototype.signers = $util.emptyArray;
+
+        /**
+         * ObservedTx observedPubKey.
+         * @member {string} observedPubKey
+         * @memberof common.ObservedTx
+         * @instance
+         */
+        ObservedTx.prototype.observedPubKey = "";
+
+        /**
+         * ObservedTx keysignMs.
+         * @member {number|Long} keysignMs
+         * @memberof common.ObservedTx
+         * @instance
+         */
+        ObservedTx.prototype.keysignMs = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+
+        /**
+         * ObservedTx finaliseHeight.
+         * @member {number|Long} finaliseHeight
+         * @memberof common.ObservedTx
+         * @instance
+         */
+        ObservedTx.prototype.finaliseHeight = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+
+        /**
+         * ObservedTx aggregator.
+         * @member {string} aggregator
+         * @memberof common.ObservedTx
+         * @instance
+         */
+        ObservedTx.prototype.aggregator = "";
+
+        /**
+         * ObservedTx aggregatorTarget.
+         * @member {string} aggregatorTarget
+         * @memberof common.ObservedTx
+         * @instance
+         */
+        ObservedTx.prototype.aggregatorTarget = "";
+
+        /**
+         * ObservedTx aggregatorTargetLimit.
+         * @member {string} aggregatorTargetLimit
+         * @memberof common.ObservedTx
+         * @instance
+         */
+        ObservedTx.prototype.aggregatorTargetLimit = "";
+
+        /**
+         * Creates a new ObservedTx instance using the specified properties.
+         * @function create
+         * @memberof common.ObservedTx
+         * @static
+         * @param {common.IObservedTx=} [properties] Properties to set
+         * @returns {common.ObservedTx} ObservedTx instance
+         */
+        ObservedTx.create = function create(properties) {
+            return new ObservedTx(properties);
+        };
+
+        /**
+         * Encodes the specified ObservedTx message. Does not implicitly {@link common.ObservedTx.verify|verify} messages.
+         * @function encode
+         * @memberof common.ObservedTx
+         * @static
+         * @param {common.IObservedTx} message ObservedTx message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        ObservedTx.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.tx != null && Object.hasOwnProperty.call(message, "tx"))
+                $root.common.Tx.encode(message.tx, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.status != null && Object.hasOwnProperty.call(message, "status"))
+                writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
+            if (message.outHashes != null && message.outHashes.length)
+                for (var i = 0; i < message.outHashes.length; ++i)
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.outHashes[i]);
+            if (message.blockHeight != null && Object.hasOwnProperty.call(message, "blockHeight"))
+                writer.uint32(/* id 4, wireType 0 =*/32).int64(message.blockHeight);
+            if (message.signers != null && message.signers.length)
+                for (var i = 0; i < message.signers.length; ++i)
+                    writer.uint32(/* id 5, wireType 2 =*/42).string(message.signers[i]);
+            if (message.observedPubKey != null && Object.hasOwnProperty.call(message, "observedPubKey"))
+                writer.uint32(/* id 6, wireType 2 =*/50).string(message.observedPubKey);
+            if (message.keysignMs != null && Object.hasOwnProperty.call(message, "keysignMs"))
+                writer.uint32(/* id 7, wireType 0 =*/56).int64(message.keysignMs);
+            if (message.finaliseHeight != null && Object.hasOwnProperty.call(message, "finaliseHeight"))
+                writer.uint32(/* id 8, wireType 0 =*/64).int64(message.finaliseHeight);
+            if (message.aggregator != null && Object.hasOwnProperty.call(message, "aggregator"))
+                writer.uint32(/* id 9, wireType 2 =*/74).string(message.aggregator);
+            if (message.aggregatorTarget != null && Object.hasOwnProperty.call(message, "aggregatorTarget"))
+                writer.uint32(/* id 10, wireType 2 =*/82).string(message.aggregatorTarget);
+            if (message.aggregatorTargetLimit != null && Object.hasOwnProperty.call(message, "aggregatorTargetLimit"))
+                writer.uint32(/* id 11, wireType 2 =*/90).string(message.aggregatorTargetLimit);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified ObservedTx message, length delimited. Does not implicitly {@link common.ObservedTx.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common.ObservedTx
+         * @static
+         * @param {common.IObservedTx} message ObservedTx message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        ObservedTx.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes an ObservedTx message from the specified reader or buffer.
+         * @function decode
+         * @memberof common.ObservedTx
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common.ObservedTx} ObservedTx
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        ObservedTx.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common.ObservedTx();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.tx = $root.common.Tx.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    message.status = reader.int32();
+                    break;
+                case 3:
+                    if (!(message.outHashes && message.outHashes.length))
+                        message.outHashes = [];
+                    message.outHashes.push(reader.string());
+                    break;
+                case 4:
+                    message.blockHeight = reader.int64();
+                    break;
+                case 5:
+                    if (!(message.signers && message.signers.length))
+                        message.signers = [];
+                    message.signers.push(reader.string());
+                    break;
+                case 6:
+                    message.observedPubKey = reader.string();
+                    break;
+                case 7:
+                    message.keysignMs = reader.int64();
+                    break;
+                case 8:
+                    message.finaliseHeight = reader.int64();
+                    break;
+                case 9:
+                    message.aggregator = reader.string();
+                    break;
+                case 10:
+                    message.aggregatorTarget = reader.string();
+                    break;
+                case 11:
+                    message.aggregatorTargetLimit = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes an ObservedTx message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common.ObservedTx
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common.ObservedTx} ObservedTx
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        ObservedTx.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies an ObservedTx message.
+         * @function verify
+         * @memberof common.ObservedTx
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        ObservedTx.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.tx != null && message.hasOwnProperty("tx")) {
+                var error = $root.common.Tx.verify(message.tx);
+                if (error)
+                    return "tx." + error;
+            }
+            if (message.status != null && message.hasOwnProperty("status"))
+                switch (message.status) {
+                default:
+                    return "status: enum value expected";
+                case 0:
+                case 1:
+                case 2:
+                    break;
+                }
+            if (message.outHashes != null && message.hasOwnProperty("outHashes")) {
+                if (!Array.isArray(message.outHashes))
+                    return "outHashes: array expected";
+                for (var i = 0; i < message.outHashes.length; ++i)
+                    if (!$util.isString(message.outHashes[i]))
+                        return "outHashes: string[] expected";
+            }
+            if (message.blockHeight != null && message.hasOwnProperty("blockHeight"))
+                if (!$util.isInteger(message.blockHeight) && !(message.blockHeight && $util.isInteger(message.blockHeight.low) && $util.isInteger(message.blockHeight.high)))
+                    return "blockHeight: integer|Long expected";
+            if (message.signers != null && message.hasOwnProperty("signers")) {
+                if (!Array.isArray(message.signers))
+                    return "signers: array expected";
+                for (var i = 0; i < message.signers.length; ++i)
+                    if (!$util.isString(message.signers[i]))
+                        return "signers: string[] expected";
+            }
+            if (message.observedPubKey != null && message.hasOwnProperty("observedPubKey"))
+                if (!$util.isString(message.observedPubKey))
+                    return "observedPubKey: string expected";
+            if (message.keysignMs != null && message.hasOwnProperty("keysignMs"))
+                if (!$util.isInteger(message.keysignMs) && !(message.keysignMs && $util.isInteger(message.keysignMs.low) && $util.isInteger(message.keysignMs.high)))
+                    return "keysignMs: integer|Long expected";
+            if (message.finaliseHeight != null && message.hasOwnProperty("finaliseHeight"))
+                if (!$util.isInteger(message.finaliseHeight) && !(message.finaliseHeight && $util.isInteger(message.finaliseHeight.low) && $util.isInteger(message.finaliseHeight.high)))
+                    return "finaliseHeight: integer|Long expected";
+            if (message.aggregator != null && message.hasOwnProperty("aggregator"))
+                if (!$util.isString(message.aggregator))
+                    return "aggregator: string expected";
+            if (message.aggregatorTarget != null && message.hasOwnProperty("aggregatorTarget"))
+                if (!$util.isString(message.aggregatorTarget))
+                    return "aggregatorTarget: string expected";
+            if (message.aggregatorTargetLimit != null && message.hasOwnProperty("aggregatorTargetLimit"))
+                if (!$util.isString(message.aggregatorTargetLimit))
+                    return "aggregatorTargetLimit: string expected";
+            return null;
+        };
+
+        /**
+         * Creates an ObservedTx message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common.ObservedTx
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common.ObservedTx} ObservedTx
+         */
+        ObservedTx.fromObject = function fromObject(object) {
+            if (object instanceof $root.common.ObservedTx)
+                return object;
+            var message = new $root.common.ObservedTx();
+            if (object.tx != null) {
+                if (typeof object.tx !== "object")
+                    throw TypeError(".common.ObservedTx.tx: object expected");
+                message.tx = $root.common.Tx.fromObject(object.tx);
+            }
+            switch (object.status) {
+            case "incomplete":
+            case 0:
+                message.status = 0;
+                break;
+            case "done":
+            case 1:
+                message.status = 1;
+                break;
+            case "reverted":
+            case 2:
+                message.status = 2;
+                break;
+            }
+            if (object.outHashes) {
+                if (!Array.isArray(object.outHashes))
+                    throw TypeError(".common.ObservedTx.outHashes: array expected");
+                message.outHashes = [];
+                for (var i = 0; i < object.outHashes.length; ++i)
+                    message.outHashes[i] = String(object.outHashes[i]);
+            }
+            if (object.blockHeight != null)
+                if ($util.Long)
+                    (message.blockHeight = $util.Long.fromValue(object.blockHeight)).unsigned = false;
+                else if (typeof object.blockHeight === "string")
+                    message.blockHeight = parseInt(object.blockHeight, 10);
+                else if (typeof object.blockHeight === "number")
+                    message.blockHeight = object.blockHeight;
+                else if (typeof object.blockHeight === "object")
+                    message.blockHeight = new $util.LongBits(object.blockHeight.low >>> 0, object.blockHeight.high >>> 0).toNumber();
+            if (object.signers) {
+                if (!Array.isArray(object.signers))
+                    throw TypeError(".common.ObservedTx.signers: array expected");
+                message.signers = [];
+                for (var i = 0; i < object.signers.length; ++i)
+                    message.signers[i] = String(object.signers[i]);
+            }
+            if (object.observedPubKey != null)
+                message.observedPubKey = String(object.observedPubKey);
+            if (object.keysignMs != null)
+                if ($util.Long)
+                    (message.keysignMs = $util.Long.fromValue(object.keysignMs)).unsigned = false;
+                else if (typeof object.keysignMs === "string")
+                    message.keysignMs = parseInt(object.keysignMs, 10);
+                else if (typeof object.keysignMs === "number")
+                    message.keysignMs = object.keysignMs;
+                else if (typeof object.keysignMs === "object")
+                    message.keysignMs = new $util.LongBits(object.keysignMs.low >>> 0, object.keysignMs.high >>> 0).toNumber();
+            if (object.finaliseHeight != null)
+                if ($util.Long)
+                    (message.finaliseHeight = $util.Long.fromValue(object.finaliseHeight)).unsigned = false;
+                else if (typeof object.finaliseHeight === "string")
+                    message.finaliseHeight = parseInt(object.finaliseHeight, 10);
+                else if (typeof object.finaliseHeight === "number")
+                    message.finaliseHeight = object.finaliseHeight;
+                else if (typeof object.finaliseHeight === "object")
+                    message.finaliseHeight = new $util.LongBits(object.finaliseHeight.low >>> 0, object.finaliseHeight.high >>> 0).toNumber();
+            if (object.aggregator != null)
+                message.aggregator = String(object.aggregator);
+            if (object.aggregatorTarget != null)
+                message.aggregatorTarget = String(object.aggregatorTarget);
+            if (object.aggregatorTargetLimit != null)
+                message.aggregatorTargetLimit = String(object.aggregatorTargetLimit);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from an ObservedTx message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common.ObservedTx
+         * @static
+         * @param {common.ObservedTx} message ObservedTx
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        ObservedTx.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults) {
+                object.outHashes = [];
+                object.signers = [];
+            }
+            if (options.defaults) {
+                object.tx = null;
+                object.status = options.enums === String ? "incomplete" : 0;
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, false);
+                    object.blockHeight = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.blockHeight = options.longs === String ? "0" : 0;
+                object.observedPubKey = "";
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, false);
+                    object.keysignMs = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.keysignMs = options.longs === String ? "0" : 0;
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, false);
+                    object.finaliseHeight = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.finaliseHeight = options.longs === String ? "0" : 0;
+                object.aggregator = "";
+                object.aggregatorTarget = "";
+                object.aggregatorTargetLimit = "";
+            }
+            if (message.tx != null && message.hasOwnProperty("tx"))
+                object.tx = $root.common.Tx.toObject(message.tx, options);
+            if (message.status != null && message.hasOwnProperty("status"))
+                object.status = options.enums === String ? $root.common.Status[message.status] : message.status;
+            if (message.outHashes && message.outHashes.length) {
+                object.outHashes = [];
+                for (var j = 0; j < message.outHashes.length; ++j)
+                    object.outHashes[j] = message.outHashes[j];
+            }
+            if (message.blockHeight != null && message.hasOwnProperty("blockHeight"))
+                if (typeof message.blockHeight === "number")
+                    object.blockHeight = options.longs === String ? String(message.blockHeight) : message.blockHeight;
+                else
+                    object.blockHeight = options.longs === String ? $util.Long.prototype.toString.call(message.blockHeight) : options.longs === Number ? new $util.LongBits(message.blockHeight.low >>> 0, message.blockHeight.high >>> 0).toNumber() : message.blockHeight;
+            if (message.signers && message.signers.length) {
+                object.signers = [];
+                for (var j = 0; j < message.signers.length; ++j)
+                    object.signers[j] = message.signers[j];
+            }
+            if (message.observedPubKey != null && message.hasOwnProperty("observedPubKey"))
+                object.observedPubKey = message.observedPubKey;
+            if (message.keysignMs != null && message.hasOwnProperty("keysignMs"))
+                if (typeof message.keysignMs === "number")
+                    object.keysignMs = options.longs === String ? String(message.keysignMs) : message.keysignMs;
+                else
+                    object.keysignMs = options.longs === String ? $util.Long.prototype.toString.call(message.keysignMs) : options.longs === Number ? new $util.LongBits(message.keysignMs.low >>> 0, message.keysignMs.high >>> 0).toNumber() : message.keysignMs;
+            if (message.finaliseHeight != null && message.hasOwnProperty("finaliseHeight"))
+                if (typeof message.finaliseHeight === "number")
+                    object.finaliseHeight = options.longs === String ? String(message.finaliseHeight) : message.finaliseHeight;
+                else
+                    object.finaliseHeight = options.longs === String ? $util.Long.prototype.toString.call(message.finaliseHeight) : options.longs === Number ? new $util.LongBits(message.finaliseHeight.low >>> 0, message.finaliseHeight.high >>> 0).toNumber() : message.finaliseHeight;
+            if (message.aggregator != null && message.hasOwnProperty("aggregator"))
+                object.aggregator = message.aggregator;
+            if (message.aggregatorTarget != null && message.hasOwnProperty("aggregatorTarget"))
+                object.aggregatorTarget = message.aggregatorTarget;
+            if (message.aggregatorTargetLimit != null && message.hasOwnProperty("aggregatorTargetLimit"))
+                object.aggregatorTargetLimit = message.aggregatorTargetLimit;
+            return object;
+        };
+
+        /**
+         * Converts this ObservedTx to JSON.
+         * @function toJSON
+         * @memberof common.ObservedTx
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        ObservedTx.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return ObservedTx;
+    })();
+
+    common.Attestation = (function() {
+
+        /**
+         * Properties of an Attestation.
+         * @memberof common
+         * @interface IAttestation
+         * @property {Uint8Array|null} [PubKey] Attestation PubKey
+         * @property {Uint8Array|null} [Signature] Attestation Signature
+         */
+
+        /**
+         * Constructs a new Attestation.
+         * @memberof common
+         * @classdesc Represents an Attestation.
+         * @implements IAttestation
+         * @constructor
+         * @param {common.IAttestation=} [properties] Properties to set
+         */
+        function Attestation(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * Attestation PubKey.
+         * @member {Uint8Array} PubKey
+         * @memberof common.Attestation
+         * @instance
+         */
+        Attestation.prototype.PubKey = $util.newBuffer([]);
+
+        /**
+         * Attestation Signature.
+         * @member {Uint8Array} Signature
+         * @memberof common.Attestation
+         * @instance
+         */
+        Attestation.prototype.Signature = $util.newBuffer([]);
+
+        /**
+         * Creates a new Attestation instance using the specified properties.
+         * @function create
+         * @memberof common.Attestation
+         * @static
+         * @param {common.IAttestation=} [properties] Properties to set
+         * @returns {common.Attestation} Attestation instance
+         */
+        Attestation.create = function create(properties) {
+            return new Attestation(properties);
+        };
+
+        /**
+         * Encodes the specified Attestation message. Does not implicitly {@link common.Attestation.verify|verify} messages.
+         * @function encode
+         * @memberof common.Attestation
+         * @static
+         * @param {common.IAttestation} message Attestation message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Attestation.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.PubKey != null && Object.hasOwnProperty.call(message, "PubKey"))
+                writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.PubKey);
+            if (message.Signature != null && Object.hasOwnProperty.call(message, "Signature"))
+                writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.Signature);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified Attestation message, length delimited. Does not implicitly {@link common.Attestation.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common.Attestation
+         * @static
+         * @param {common.IAttestation} message Attestation message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Attestation.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes an Attestation message from the specified reader or buffer.
+         * @function decode
+         * @memberof common.Attestation
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common.Attestation} Attestation
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Attestation.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common.Attestation();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.PubKey = reader.bytes();
+                    break;
+                case 2:
+                    message.Signature = reader.bytes();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes an Attestation message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common.Attestation
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common.Attestation} Attestation
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Attestation.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies an Attestation message.
+         * @function verify
+         * @memberof common.Attestation
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        Attestation.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.PubKey != null && message.hasOwnProperty("PubKey"))
+                if (!(message.PubKey && typeof message.PubKey.length === "number" || $util.isString(message.PubKey)))
+                    return "PubKey: buffer expected";
+            if (message.Signature != null && message.hasOwnProperty("Signature"))
+                if (!(message.Signature && typeof message.Signature.length === "number" || $util.isString(message.Signature)))
+                    return "Signature: buffer expected";
+            return null;
+        };
+
+        /**
+         * Creates an Attestation message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common.Attestation
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common.Attestation} Attestation
+         */
+        Attestation.fromObject = function fromObject(object) {
+            if (object instanceof $root.common.Attestation)
+                return object;
+            var message = new $root.common.Attestation();
+            if (object.PubKey != null)
+                if (typeof object.PubKey === "string")
+                    $util.base64.decode(object.PubKey, message.PubKey = $util.newBuffer($util.base64.length(object.PubKey)), 0);
+                else if (object.PubKey.length)
+                    message.PubKey = object.PubKey;
+            if (object.Signature != null)
+                if (typeof object.Signature === "string")
+                    $util.base64.decode(object.Signature, message.Signature = $util.newBuffer($util.base64.length(object.Signature)), 0);
+                else if (object.Signature.length)
+                    message.Signature = object.Signature;
+            return message;
+        };
+
+        /**
+         * Creates a plain object from an Attestation message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common.Attestation
+         * @static
+         * @param {common.Attestation} message Attestation
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        Attestation.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                if (options.bytes === String)
+                    object.PubKey = "";
+                else {
+                    object.PubKey = [];
+                    if (options.bytes !== Array)
+                        object.PubKey = $util.newBuffer(object.PubKey);
+                }
+                if (options.bytes === String)
+                    object.Signature = "";
+                else {
+                    object.Signature = [];
+                    if (options.bytes !== Array)
+                        object.Signature = $util.newBuffer(object.Signature);
+                }
+            }
+            if (message.PubKey != null && message.hasOwnProperty("PubKey"))
+                object.PubKey = options.bytes === String ? $util.base64.encode(message.PubKey, 0, message.PubKey.length) : options.bytes === Array ? Array.prototype.slice.call(message.PubKey) : message.PubKey;
+            if (message.Signature != null && message.hasOwnProperty("Signature"))
+                object.Signature = options.bytes === String ? $util.base64.encode(message.Signature, 0, message.Signature.length) : options.bytes === Array ? Array.prototype.slice.call(message.Signature) : message.Signature;
+            return object;
+        };
+
+        /**
+         * Converts this Attestation to JSON.
+         * @function toJSON
+         * @memberof common.Attestation
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        Attestation.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return Attestation;
+    })();
+
+    common.AttestTx = (function() {
+
+        /**
+         * Properties of an AttestTx.
+         * @memberof common
+         * @interface IAttestTx
+         * @property {common.IObservedTx|null} [obsTx] AttestTx obsTx
+         * @property {common.IAttestation|null} [attestation] AttestTx attestation
+         * @property {boolean|null} [inbound] AttestTx inbound
+         * @property {boolean|null} [allowFutureObservation] AttestTx allowFutureObservation
+         */
+
+        /**
+         * Constructs a new AttestTx.
+         * @memberof common
+         * @classdesc Represents an AttestTx.
+         * @implements IAttestTx
+         * @constructor
+         * @param {common.IAttestTx=} [properties] Properties to set
+         */
+        function AttestTx(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * AttestTx obsTx.
+         * @member {common.IObservedTx|null|undefined} obsTx
+         * @memberof common.AttestTx
+         * @instance
+         */
+        AttestTx.prototype.obsTx = null;
+
+        /**
+         * AttestTx attestation.
+         * @member {common.IAttestation|null|undefined} attestation
+         * @memberof common.AttestTx
+         * @instance
+         */
+        AttestTx.prototype.attestation = null;
+
+        /**
+         * AttestTx inbound.
+         * @member {boolean} inbound
+         * @memberof common.AttestTx
+         * @instance
+         */
+        AttestTx.prototype.inbound = false;
+
+        /**
+         * AttestTx allowFutureObservation.
+         * @member {boolean} allowFutureObservation
+         * @memberof common.AttestTx
+         * @instance
+         */
+        AttestTx.prototype.allowFutureObservation = false;
+
+        /**
+         * Creates a new AttestTx instance using the specified properties.
+         * @function create
+         * @memberof common.AttestTx
+         * @static
+         * @param {common.IAttestTx=} [properties] Properties to set
+         * @returns {common.AttestTx} AttestTx instance
+         */
+        AttestTx.create = function create(properties) {
+            return new AttestTx(properties);
+        };
+
+        /**
+         * Encodes the specified AttestTx message. Does not implicitly {@link common.AttestTx.verify|verify} messages.
+         * @function encode
+         * @memberof common.AttestTx
+         * @static
+         * @param {common.IAttestTx} message AttestTx message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        AttestTx.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.obsTx != null && Object.hasOwnProperty.call(message, "obsTx"))
+                $root.common.ObservedTx.encode(message.obsTx, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.attestation != null && Object.hasOwnProperty.call(message, "attestation"))
+                $root.common.Attestation.encode(message.attestation, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            if (message.inbound != null && Object.hasOwnProperty.call(message, "inbound"))
+                writer.uint32(/* id 3, wireType 0 =*/24).bool(message.inbound);
+            if (message.allowFutureObservation != null && Object.hasOwnProperty.call(message, "allowFutureObservation"))
+                writer.uint32(/* id 4, wireType 0 =*/32).bool(message.allowFutureObservation);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified AttestTx message, length delimited. Does not implicitly {@link common.AttestTx.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common.AttestTx
+         * @static
+         * @param {common.IAttestTx} message AttestTx message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        AttestTx.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes an AttestTx message from the specified reader or buffer.
+         * @function decode
+         * @memberof common.AttestTx
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common.AttestTx} AttestTx
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        AttestTx.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common.AttestTx();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.obsTx = $root.common.ObservedTx.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    message.attestation = $root.common.Attestation.decode(reader, reader.uint32());
+                    break;
+                case 3:
+                    message.inbound = reader.bool();
+                    break;
+                case 4:
+                    message.allowFutureObservation = reader.bool();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes an AttestTx message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common.AttestTx
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common.AttestTx} AttestTx
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        AttestTx.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies an AttestTx message.
+         * @function verify
+         * @memberof common.AttestTx
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        AttestTx.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.obsTx != null && message.hasOwnProperty("obsTx")) {
+                var error = $root.common.ObservedTx.verify(message.obsTx);
+                if (error)
+                    return "obsTx." + error;
+            }
+            if (message.attestation != null && message.hasOwnProperty("attestation")) {
+                var error = $root.common.Attestation.verify(message.attestation);
+                if (error)
+                    return "attestation." + error;
+            }
+            if (message.inbound != null && message.hasOwnProperty("inbound"))
+                if (typeof message.inbound !== "boolean")
+                    return "inbound: boolean expected";
+            if (message.allowFutureObservation != null && message.hasOwnProperty("allowFutureObservation"))
+                if (typeof message.allowFutureObservation !== "boolean")
+                    return "allowFutureObservation: boolean expected";
+            return null;
+        };
+
+        /**
+         * Creates an AttestTx message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common.AttestTx
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common.AttestTx} AttestTx
+         */
+        AttestTx.fromObject = function fromObject(object) {
+            if (object instanceof $root.common.AttestTx)
+                return object;
+            var message = new $root.common.AttestTx();
+            if (object.obsTx != null) {
+                if (typeof object.obsTx !== "object")
+                    throw TypeError(".common.AttestTx.obsTx: object expected");
+                message.obsTx = $root.common.ObservedTx.fromObject(object.obsTx);
+            }
+            if (object.attestation != null) {
+                if (typeof object.attestation !== "object")
+                    throw TypeError(".common.AttestTx.attestation: object expected");
+                message.attestation = $root.common.Attestation.fromObject(object.attestation);
+            }
+            if (object.inbound != null)
+                message.inbound = Boolean(object.inbound);
+            if (object.allowFutureObservation != null)
+                message.allowFutureObservation = Boolean(object.allowFutureObservation);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from an AttestTx message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common.AttestTx
+         * @static
+         * @param {common.AttestTx} message AttestTx
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        AttestTx.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.obsTx = null;
+                object.attestation = null;
+                object.inbound = false;
+                object.allowFutureObservation = false;
+            }
+            if (message.obsTx != null && message.hasOwnProperty("obsTx"))
+                object.obsTx = $root.common.ObservedTx.toObject(message.obsTx, options);
+            if (message.attestation != null && message.hasOwnProperty("attestation"))
+                object.attestation = $root.common.Attestation.toObject(message.attestation, options);
+            if (message.inbound != null && message.hasOwnProperty("inbound"))
+                object.inbound = message.inbound;
+            if (message.allowFutureObservation != null && message.hasOwnProperty("allowFutureObservation"))
+                object.allowFutureObservation = message.allowFutureObservation;
+            return object;
+        };
+
+        /**
+         * Converts this AttestTx to JSON.
+         * @function toJSON
+         * @memberof common.AttestTx
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        AttestTx.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return AttestTx;
+    })();
+
+    common.QuorumTx = (function() {
+
+        /**
+         * Properties of a QuorumTx.
+         * @memberof common
+         * @interface IQuorumTx
+         * @property {common.IObservedTx|null} [obsTx] QuorumTx obsTx
+         * @property {Array.<common.IAttestation>|null} [attestations] QuorumTx attestations
+         * @property {boolean|null} [inbound] QuorumTx inbound
+         * @property {boolean|null} [allowFutureObservation] QuorumTx allowFutureObservation
+         */
+
+        /**
+         * Constructs a new QuorumTx.
+         * @memberof common
+         * @classdesc Represents a QuorumTx.
+         * @implements IQuorumTx
+         * @constructor
+         * @param {common.IQuorumTx=} [properties] Properties to set
+         */
+        function QuorumTx(properties) {
+            this.attestations = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * QuorumTx obsTx.
+         * @member {common.IObservedTx|null|undefined} obsTx
+         * @memberof common.QuorumTx
+         * @instance
+         */
+        QuorumTx.prototype.obsTx = null;
+
+        /**
+         * QuorumTx attestations.
+         * @member {Array.<common.IAttestation>} attestations
+         * @memberof common.QuorumTx
+         * @instance
+         */
+        QuorumTx.prototype.attestations = $util.emptyArray;
+
+        /**
+         * QuorumTx inbound.
+         * @member {boolean} inbound
+         * @memberof common.QuorumTx
+         * @instance
+         */
+        QuorumTx.prototype.inbound = false;
+
+        /**
+         * QuorumTx allowFutureObservation.
+         * @member {boolean} allowFutureObservation
+         * @memberof common.QuorumTx
+         * @instance
+         */
+        QuorumTx.prototype.allowFutureObservation = false;
+
+        /**
+         * Creates a new QuorumTx instance using the specified properties.
+         * @function create
+         * @memberof common.QuorumTx
+         * @static
+         * @param {common.IQuorumTx=} [properties] Properties to set
+         * @returns {common.QuorumTx} QuorumTx instance
+         */
+        QuorumTx.create = function create(properties) {
+            return new QuorumTx(properties);
+        };
+
+        /**
+         * Encodes the specified QuorumTx message. Does not implicitly {@link common.QuorumTx.verify|verify} messages.
+         * @function encode
+         * @memberof common.QuorumTx
+         * @static
+         * @param {common.IQuorumTx} message QuorumTx message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        QuorumTx.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.obsTx != null && Object.hasOwnProperty.call(message, "obsTx"))
+                $root.common.ObservedTx.encode(message.obsTx, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.attestations != null && message.attestations.length)
+                for (var i = 0; i < message.attestations.length; ++i)
+                    $root.common.Attestation.encode(message.attestations[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            if (message.inbound != null && Object.hasOwnProperty.call(message, "inbound"))
+                writer.uint32(/* id 3, wireType 0 =*/24).bool(message.inbound);
+            if (message.allowFutureObservation != null && Object.hasOwnProperty.call(message, "allowFutureObservation"))
+                writer.uint32(/* id 4, wireType 0 =*/32).bool(message.allowFutureObservation);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified QuorumTx message, length delimited. Does not implicitly {@link common.QuorumTx.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common.QuorumTx
+         * @static
+         * @param {common.IQuorumTx} message QuorumTx message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        QuorumTx.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a QuorumTx message from the specified reader or buffer.
+         * @function decode
+         * @memberof common.QuorumTx
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common.QuorumTx} QuorumTx
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        QuorumTx.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common.QuorumTx();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.obsTx = $root.common.ObservedTx.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    if (!(message.attestations && message.attestations.length))
+                        message.attestations = [];
+                    message.attestations.push($root.common.Attestation.decode(reader, reader.uint32()));
+                    break;
+                case 3:
+                    message.inbound = reader.bool();
+                    break;
+                case 4:
+                    message.allowFutureObservation = reader.bool();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a QuorumTx message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common.QuorumTx
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common.QuorumTx} QuorumTx
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        QuorumTx.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a QuorumTx message.
+         * @function verify
+         * @memberof common.QuorumTx
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        QuorumTx.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.obsTx != null && message.hasOwnProperty("obsTx")) {
+                var error = $root.common.ObservedTx.verify(message.obsTx);
+                if (error)
+                    return "obsTx." + error;
+            }
+            if (message.attestations != null && message.hasOwnProperty("attestations")) {
+                if (!Array.isArray(message.attestations))
+                    return "attestations: array expected";
+                for (var i = 0; i < message.attestations.length; ++i) {
+                    var error = $root.common.Attestation.verify(message.attestations[i]);
+                    if (error)
+                        return "attestations." + error;
+                }
+            }
+            if (message.inbound != null && message.hasOwnProperty("inbound"))
+                if (typeof message.inbound !== "boolean")
+                    return "inbound: boolean expected";
+            if (message.allowFutureObservation != null && message.hasOwnProperty("allowFutureObservation"))
+                if (typeof message.allowFutureObservation !== "boolean")
+                    return "allowFutureObservation: boolean expected";
+            return null;
+        };
+
+        /**
+         * Creates a QuorumTx message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common.QuorumTx
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common.QuorumTx} QuorumTx
+         */
+        QuorumTx.fromObject = function fromObject(object) {
+            if (object instanceof $root.common.QuorumTx)
+                return object;
+            var message = new $root.common.QuorumTx();
+            if (object.obsTx != null) {
+                if (typeof object.obsTx !== "object")
+                    throw TypeError(".common.QuorumTx.obsTx: object expected");
+                message.obsTx = $root.common.ObservedTx.fromObject(object.obsTx);
+            }
+            if (object.attestations) {
+                if (!Array.isArray(object.attestations))
+                    throw TypeError(".common.QuorumTx.attestations: array expected");
+                message.attestations = [];
+                for (var i = 0; i < object.attestations.length; ++i) {
+                    if (typeof object.attestations[i] !== "object")
+                        throw TypeError(".common.QuorumTx.attestations: object expected");
+                    message.attestations[i] = $root.common.Attestation.fromObject(object.attestations[i]);
+                }
+            }
+            if (object.inbound != null)
+                message.inbound = Boolean(object.inbound);
+            if (object.allowFutureObservation != null)
+                message.allowFutureObservation = Boolean(object.allowFutureObservation);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a QuorumTx message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common.QuorumTx
+         * @static
+         * @param {common.QuorumTx} message QuorumTx
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        QuorumTx.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.attestations = [];
+            if (options.defaults) {
+                object.obsTx = null;
+                object.inbound = false;
+                object.allowFutureObservation = false;
+            }
+            if (message.obsTx != null && message.hasOwnProperty("obsTx"))
+                object.obsTx = $root.common.ObservedTx.toObject(message.obsTx, options);
+            if (message.attestations && message.attestations.length) {
+                object.attestations = [];
+                for (var j = 0; j < message.attestations.length; ++j)
+                    object.attestations[j] = $root.common.Attestation.toObject(message.attestations[j], options);
+            }
+            if (message.inbound != null && message.hasOwnProperty("inbound"))
+                object.inbound = message.inbound;
+            if (message.allowFutureObservation != null && message.hasOwnProperty("allowFutureObservation"))
+                object.allowFutureObservation = message.allowFutureObservation;
+            return object;
+        };
+
+        /**
+         * Converts this QuorumTx to JSON.
+         * @function toJSON
+         * @memberof common.QuorumTx
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        QuorumTx.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return QuorumTx;
+    })();
+
+    common.QuorumState = (function() {
+
+        /**
+         * Properties of a QuorumState.
+         * @memberof common
+         * @interface IQuorumState
+         * @property {Array.<common.IQuorumTx>|null} [quoTxs] QuorumState quoTxs
+         * @property {Array.<common.IQuorumNetworkFee>|null} [quoNetworkFees] QuorumState quoNetworkFees
+         * @property {Array.<common.IQuorumSolvency>|null} [quoSolvencies] QuorumState quoSolvencies
+         * @property {Array.<common.IQuorumErrataTx>|null} [quoErrataTxs] QuorumState quoErrataTxs
+         */
+
+        /**
+         * Constructs a new QuorumState.
+         * @memberof common
+         * @classdesc Represents a QuorumState.
+         * @implements IQuorumState
+         * @constructor
+         * @param {common.IQuorumState=} [properties] Properties to set
+         */
+        function QuorumState(properties) {
+            this.quoTxs = [];
+            this.quoNetworkFees = [];
+            this.quoSolvencies = [];
+            this.quoErrataTxs = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * QuorumState quoTxs.
+         * @member {Array.<common.IQuorumTx>} quoTxs
+         * @memberof common.QuorumState
+         * @instance
+         */
+        QuorumState.prototype.quoTxs = $util.emptyArray;
+
+        /**
+         * QuorumState quoNetworkFees.
+         * @member {Array.<common.IQuorumNetworkFee>} quoNetworkFees
+         * @memberof common.QuorumState
+         * @instance
+         */
+        QuorumState.prototype.quoNetworkFees = $util.emptyArray;
+
+        /**
+         * QuorumState quoSolvencies.
+         * @member {Array.<common.IQuorumSolvency>} quoSolvencies
+         * @memberof common.QuorumState
+         * @instance
+         */
+        QuorumState.prototype.quoSolvencies = $util.emptyArray;
+
+        /**
+         * QuorumState quoErrataTxs.
+         * @member {Array.<common.IQuorumErrataTx>} quoErrataTxs
+         * @memberof common.QuorumState
+         * @instance
+         */
+        QuorumState.prototype.quoErrataTxs = $util.emptyArray;
+
+        /**
+         * Creates a new QuorumState instance using the specified properties.
+         * @function create
+         * @memberof common.QuorumState
+         * @static
+         * @param {common.IQuorumState=} [properties] Properties to set
+         * @returns {common.QuorumState} QuorumState instance
+         */
+        QuorumState.create = function create(properties) {
+            return new QuorumState(properties);
+        };
+
+        /**
+         * Encodes the specified QuorumState message. Does not implicitly {@link common.QuorumState.verify|verify} messages.
+         * @function encode
+         * @memberof common.QuorumState
+         * @static
+         * @param {common.IQuorumState} message QuorumState message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        QuorumState.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.quoTxs != null && message.quoTxs.length)
+                for (var i = 0; i < message.quoTxs.length; ++i)
+                    $root.common.QuorumTx.encode(message.quoTxs[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.quoNetworkFees != null && message.quoNetworkFees.length)
+                for (var i = 0; i < message.quoNetworkFees.length; ++i)
+                    $root.common.QuorumNetworkFee.encode(message.quoNetworkFees[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            if (message.quoSolvencies != null && message.quoSolvencies.length)
+                for (var i = 0; i < message.quoSolvencies.length; ++i)
+                    $root.common.QuorumSolvency.encode(message.quoSolvencies[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+            if (message.quoErrataTxs != null && message.quoErrataTxs.length)
+                for (var i = 0; i < message.quoErrataTxs.length; ++i)
+                    $root.common.QuorumErrataTx.encode(message.quoErrataTxs[i], writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified QuorumState message, length delimited. Does not implicitly {@link common.QuorumState.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common.QuorumState
+         * @static
+         * @param {common.IQuorumState} message QuorumState message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        QuorumState.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a QuorumState message from the specified reader or buffer.
+         * @function decode
+         * @memberof common.QuorumState
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common.QuorumState} QuorumState
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        QuorumState.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common.QuorumState();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    if (!(message.quoTxs && message.quoTxs.length))
+                        message.quoTxs = [];
+                    message.quoTxs.push($root.common.QuorumTx.decode(reader, reader.uint32()));
+                    break;
+                case 2:
+                    if (!(message.quoNetworkFees && message.quoNetworkFees.length))
+                        message.quoNetworkFees = [];
+                    message.quoNetworkFees.push($root.common.QuorumNetworkFee.decode(reader, reader.uint32()));
+                    break;
+                case 3:
+                    if (!(message.quoSolvencies && message.quoSolvencies.length))
+                        message.quoSolvencies = [];
+                    message.quoSolvencies.push($root.common.QuorumSolvency.decode(reader, reader.uint32()));
+                    break;
+                case 4:
+                    if (!(message.quoErrataTxs && message.quoErrataTxs.length))
+                        message.quoErrataTxs = [];
+                    message.quoErrataTxs.push($root.common.QuorumErrataTx.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a QuorumState message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common.QuorumState
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common.QuorumState} QuorumState
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        QuorumState.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a QuorumState message.
+         * @function verify
+         * @memberof common.QuorumState
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        QuorumState.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.quoTxs != null && message.hasOwnProperty("quoTxs")) {
+                if (!Array.isArray(message.quoTxs))
+                    return "quoTxs: array expected";
+                for (var i = 0; i < message.quoTxs.length; ++i) {
+                    var error = $root.common.QuorumTx.verify(message.quoTxs[i]);
+                    if (error)
+                        return "quoTxs." + error;
+                }
+            }
+            if (message.quoNetworkFees != null && message.hasOwnProperty("quoNetworkFees")) {
+                if (!Array.isArray(message.quoNetworkFees))
+                    return "quoNetworkFees: array expected";
+                for (var i = 0; i < message.quoNetworkFees.length; ++i) {
+                    var error = $root.common.QuorumNetworkFee.verify(message.quoNetworkFees[i]);
+                    if (error)
+                        return "quoNetworkFees." + error;
+                }
+            }
+            if (message.quoSolvencies != null && message.hasOwnProperty("quoSolvencies")) {
+                if (!Array.isArray(message.quoSolvencies))
+                    return "quoSolvencies: array expected";
+                for (var i = 0; i < message.quoSolvencies.length; ++i) {
+                    var error = $root.common.QuorumSolvency.verify(message.quoSolvencies[i]);
+                    if (error)
+                        return "quoSolvencies." + error;
+                }
+            }
+            if (message.quoErrataTxs != null && message.hasOwnProperty("quoErrataTxs")) {
+                if (!Array.isArray(message.quoErrataTxs))
+                    return "quoErrataTxs: array expected";
+                for (var i = 0; i < message.quoErrataTxs.length; ++i) {
+                    var error = $root.common.QuorumErrataTx.verify(message.quoErrataTxs[i]);
+                    if (error)
+                        return "quoErrataTxs." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a QuorumState message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common.QuorumState
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common.QuorumState} QuorumState
+         */
+        QuorumState.fromObject = function fromObject(object) {
+            if (object instanceof $root.common.QuorumState)
+                return object;
+            var message = new $root.common.QuorumState();
+            if (object.quoTxs) {
+                if (!Array.isArray(object.quoTxs))
+                    throw TypeError(".common.QuorumState.quoTxs: array expected");
+                message.quoTxs = [];
+                for (var i = 0; i < object.quoTxs.length; ++i) {
+                    if (typeof object.quoTxs[i] !== "object")
+                        throw TypeError(".common.QuorumState.quoTxs: object expected");
+                    message.quoTxs[i] = $root.common.QuorumTx.fromObject(object.quoTxs[i]);
+                }
+            }
+            if (object.quoNetworkFees) {
+                if (!Array.isArray(object.quoNetworkFees))
+                    throw TypeError(".common.QuorumState.quoNetworkFees: array expected");
+                message.quoNetworkFees = [];
+                for (var i = 0; i < object.quoNetworkFees.length; ++i) {
+                    if (typeof object.quoNetworkFees[i] !== "object")
+                        throw TypeError(".common.QuorumState.quoNetworkFees: object expected");
+                    message.quoNetworkFees[i] = $root.common.QuorumNetworkFee.fromObject(object.quoNetworkFees[i]);
+                }
+            }
+            if (object.quoSolvencies) {
+                if (!Array.isArray(object.quoSolvencies))
+                    throw TypeError(".common.QuorumState.quoSolvencies: array expected");
+                message.quoSolvencies = [];
+                for (var i = 0; i < object.quoSolvencies.length; ++i) {
+                    if (typeof object.quoSolvencies[i] !== "object")
+                        throw TypeError(".common.QuorumState.quoSolvencies: object expected");
+                    message.quoSolvencies[i] = $root.common.QuorumSolvency.fromObject(object.quoSolvencies[i]);
+                }
+            }
+            if (object.quoErrataTxs) {
+                if (!Array.isArray(object.quoErrataTxs))
+                    throw TypeError(".common.QuorumState.quoErrataTxs: array expected");
+                message.quoErrataTxs = [];
+                for (var i = 0; i < object.quoErrataTxs.length; ++i) {
+                    if (typeof object.quoErrataTxs[i] !== "object")
+                        throw TypeError(".common.QuorumState.quoErrataTxs: object expected");
+                    message.quoErrataTxs[i] = $root.common.QuorumErrataTx.fromObject(object.quoErrataTxs[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a QuorumState message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common.QuorumState
+         * @static
+         * @param {common.QuorumState} message QuorumState
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        QuorumState.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults) {
+                object.quoTxs = [];
+                object.quoNetworkFees = [];
+                object.quoSolvencies = [];
+                object.quoErrataTxs = [];
+            }
+            if (message.quoTxs && message.quoTxs.length) {
+                object.quoTxs = [];
+                for (var j = 0; j < message.quoTxs.length; ++j)
+                    object.quoTxs[j] = $root.common.QuorumTx.toObject(message.quoTxs[j], options);
+            }
+            if (message.quoNetworkFees && message.quoNetworkFees.length) {
+                object.quoNetworkFees = [];
+                for (var j = 0; j < message.quoNetworkFees.length; ++j)
+                    object.quoNetworkFees[j] = $root.common.QuorumNetworkFee.toObject(message.quoNetworkFees[j], options);
+            }
+            if (message.quoSolvencies && message.quoSolvencies.length) {
+                object.quoSolvencies = [];
+                for (var j = 0; j < message.quoSolvencies.length; ++j)
+                    object.quoSolvencies[j] = $root.common.QuorumSolvency.toObject(message.quoSolvencies[j], options);
+            }
+            if (message.quoErrataTxs && message.quoErrataTxs.length) {
+                object.quoErrataTxs = [];
+                for (var j = 0; j < message.quoErrataTxs.length; ++j)
+                    object.quoErrataTxs[j] = $root.common.QuorumErrataTx.toObject(message.quoErrataTxs[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this QuorumState to JSON.
+         * @function toJSON
+         * @memberof common.QuorumState
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        QuorumState.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return QuorumState;
+    })();
+
+    common.NetworkFee = (function() {
+
+        /**
+         * Properties of a NetworkFee.
+         * @memberof common
+         * @interface INetworkFee
+         * @property {number|Long|null} [height] NetworkFee height
+         * @property {string|null} [chain] NetworkFee chain
+         * @property {number|Long|null} [transactionSize] NetworkFee transactionSize
+         * @property {number|Long|null} [transactionRate] NetworkFee transactionRate
+         */
+
+        /**
+         * Constructs a new NetworkFee.
+         * @memberof common
+         * @classdesc Represents a NetworkFee.
+         * @implements INetworkFee
+         * @constructor
+         * @param {common.INetworkFee=} [properties] Properties to set
+         */
+        function NetworkFee(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * NetworkFee height.
+         * @member {number|Long} height
+         * @memberof common.NetworkFee
+         * @instance
+         */
+        NetworkFee.prototype.height = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+
+        /**
+         * NetworkFee chain.
+         * @member {string} chain
+         * @memberof common.NetworkFee
+         * @instance
+         */
+        NetworkFee.prototype.chain = "";
+
+        /**
+         * NetworkFee transactionSize.
+         * @member {number|Long} transactionSize
+         * @memberof common.NetworkFee
+         * @instance
+         */
+        NetworkFee.prototype.transactionSize = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+
+        /**
+         * NetworkFee transactionRate.
+         * @member {number|Long} transactionRate
+         * @memberof common.NetworkFee
+         * @instance
+         */
+        NetworkFee.prototype.transactionRate = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+
+        /**
+         * Creates a new NetworkFee instance using the specified properties.
+         * @function create
+         * @memberof common.NetworkFee
+         * @static
+         * @param {common.INetworkFee=} [properties] Properties to set
+         * @returns {common.NetworkFee} NetworkFee instance
+         */
+        NetworkFee.create = function create(properties) {
+            return new NetworkFee(properties);
+        };
+
+        /**
+         * Encodes the specified NetworkFee message. Does not implicitly {@link common.NetworkFee.verify|verify} messages.
+         * @function encode
+         * @memberof common.NetworkFee
+         * @static
+         * @param {common.INetworkFee} message NetworkFee message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        NetworkFee.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.height != null && Object.hasOwnProperty.call(message, "height"))
+                writer.uint32(/* id 1, wireType 0 =*/8).int64(message.height);
+            if (message.chain != null && Object.hasOwnProperty.call(message, "chain"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.chain);
+            if (message.transactionSize != null && Object.hasOwnProperty.call(message, "transactionSize"))
+                writer.uint32(/* id 3, wireType 0 =*/24).uint64(message.transactionSize);
+            if (message.transactionRate != null && Object.hasOwnProperty.call(message, "transactionRate"))
+                writer.uint32(/* id 4, wireType 0 =*/32).uint64(message.transactionRate);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified NetworkFee message, length delimited. Does not implicitly {@link common.NetworkFee.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common.NetworkFee
+         * @static
+         * @param {common.INetworkFee} message NetworkFee message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        NetworkFee.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a NetworkFee message from the specified reader or buffer.
+         * @function decode
+         * @memberof common.NetworkFee
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common.NetworkFee} NetworkFee
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        NetworkFee.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common.NetworkFee();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.height = reader.int64();
+                    break;
+                case 2:
+                    message.chain = reader.string();
+                    break;
+                case 3:
+                    message.transactionSize = reader.uint64();
+                    break;
+                case 4:
+                    message.transactionRate = reader.uint64();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a NetworkFee message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common.NetworkFee
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common.NetworkFee} NetworkFee
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        NetworkFee.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a NetworkFee message.
+         * @function verify
+         * @memberof common.NetworkFee
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        NetworkFee.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.height != null && message.hasOwnProperty("height"))
+                if (!$util.isInteger(message.height) && !(message.height && $util.isInteger(message.height.low) && $util.isInteger(message.height.high)))
+                    return "height: integer|Long expected";
+            if (message.chain != null && message.hasOwnProperty("chain"))
+                if (!$util.isString(message.chain))
+                    return "chain: string expected";
+            if (message.transactionSize != null && message.hasOwnProperty("transactionSize"))
+                if (!$util.isInteger(message.transactionSize) && !(message.transactionSize && $util.isInteger(message.transactionSize.low) && $util.isInteger(message.transactionSize.high)))
+                    return "transactionSize: integer|Long expected";
+            if (message.transactionRate != null && message.hasOwnProperty("transactionRate"))
+                if (!$util.isInteger(message.transactionRate) && !(message.transactionRate && $util.isInteger(message.transactionRate.low) && $util.isInteger(message.transactionRate.high)))
+                    return "transactionRate: integer|Long expected";
+            return null;
+        };
+
+        /**
+         * Creates a NetworkFee message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common.NetworkFee
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common.NetworkFee} NetworkFee
+         */
+        NetworkFee.fromObject = function fromObject(object) {
+            if (object instanceof $root.common.NetworkFee)
+                return object;
+            var message = new $root.common.NetworkFee();
+            if (object.height != null)
+                if ($util.Long)
+                    (message.height = $util.Long.fromValue(object.height)).unsigned = false;
+                else if (typeof object.height === "string")
+                    message.height = parseInt(object.height, 10);
+                else if (typeof object.height === "number")
+                    message.height = object.height;
+                else if (typeof object.height === "object")
+                    message.height = new $util.LongBits(object.height.low >>> 0, object.height.high >>> 0).toNumber();
+            if (object.chain != null)
+                message.chain = String(object.chain);
+            if (object.transactionSize != null)
+                if ($util.Long)
+                    (message.transactionSize = $util.Long.fromValue(object.transactionSize)).unsigned = true;
+                else if (typeof object.transactionSize === "string")
+                    message.transactionSize = parseInt(object.transactionSize, 10);
+                else if (typeof object.transactionSize === "number")
+                    message.transactionSize = object.transactionSize;
+                else if (typeof object.transactionSize === "object")
+                    message.transactionSize = new $util.LongBits(object.transactionSize.low >>> 0, object.transactionSize.high >>> 0).toNumber(true);
+            if (object.transactionRate != null)
+                if ($util.Long)
+                    (message.transactionRate = $util.Long.fromValue(object.transactionRate)).unsigned = true;
+                else if (typeof object.transactionRate === "string")
+                    message.transactionRate = parseInt(object.transactionRate, 10);
+                else if (typeof object.transactionRate === "number")
+                    message.transactionRate = object.transactionRate;
+                else if (typeof object.transactionRate === "object")
+                    message.transactionRate = new $util.LongBits(object.transactionRate.low >>> 0, object.transactionRate.high >>> 0).toNumber(true);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a NetworkFee message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common.NetworkFee
+         * @static
+         * @param {common.NetworkFee} message NetworkFee
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        NetworkFee.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, false);
+                    object.height = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.height = options.longs === String ? "0" : 0;
+                object.chain = "";
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, true);
+                    object.transactionSize = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.transactionSize = options.longs === String ? "0" : 0;
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, true);
+                    object.transactionRate = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.transactionRate = options.longs === String ? "0" : 0;
+            }
+            if (message.height != null && message.hasOwnProperty("height"))
+                if (typeof message.height === "number")
+                    object.height = options.longs === String ? String(message.height) : message.height;
+                else
+                    object.height = options.longs === String ? $util.Long.prototype.toString.call(message.height) : options.longs === Number ? new $util.LongBits(message.height.low >>> 0, message.height.high >>> 0).toNumber() : message.height;
+            if (message.chain != null && message.hasOwnProperty("chain"))
+                object.chain = message.chain;
+            if (message.transactionSize != null && message.hasOwnProperty("transactionSize"))
+                if (typeof message.transactionSize === "number")
+                    object.transactionSize = options.longs === String ? String(message.transactionSize) : message.transactionSize;
+                else
+                    object.transactionSize = options.longs === String ? $util.Long.prototype.toString.call(message.transactionSize) : options.longs === Number ? new $util.LongBits(message.transactionSize.low >>> 0, message.transactionSize.high >>> 0).toNumber(true) : message.transactionSize;
+            if (message.transactionRate != null && message.hasOwnProperty("transactionRate"))
+                if (typeof message.transactionRate === "number")
+                    object.transactionRate = options.longs === String ? String(message.transactionRate) : message.transactionRate;
+                else
+                    object.transactionRate = options.longs === String ? $util.Long.prototype.toString.call(message.transactionRate) : options.longs === Number ? new $util.LongBits(message.transactionRate.low >>> 0, message.transactionRate.high >>> 0).toNumber(true) : message.transactionRate;
+            return object;
+        };
+
+        /**
+         * Converts this NetworkFee to JSON.
+         * @function toJSON
+         * @memberof common.NetworkFee
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        NetworkFee.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return NetworkFee;
+    })();
+
+    common.AttestNetworkFee = (function() {
+
+        /**
+         * Properties of an AttestNetworkFee.
+         * @memberof common
+         * @interface IAttestNetworkFee
+         * @property {common.INetworkFee|null} [networkFee] AttestNetworkFee networkFee
+         * @property {common.IAttestation|null} [attestation] AttestNetworkFee attestation
+         */
+
+        /**
+         * Constructs a new AttestNetworkFee.
+         * @memberof common
+         * @classdesc Represents an AttestNetworkFee.
+         * @implements IAttestNetworkFee
+         * @constructor
+         * @param {common.IAttestNetworkFee=} [properties] Properties to set
+         */
+        function AttestNetworkFee(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * AttestNetworkFee networkFee.
+         * @member {common.INetworkFee|null|undefined} networkFee
+         * @memberof common.AttestNetworkFee
+         * @instance
+         */
+        AttestNetworkFee.prototype.networkFee = null;
+
+        /**
+         * AttestNetworkFee attestation.
+         * @member {common.IAttestation|null|undefined} attestation
+         * @memberof common.AttestNetworkFee
+         * @instance
+         */
+        AttestNetworkFee.prototype.attestation = null;
+
+        /**
+         * Creates a new AttestNetworkFee instance using the specified properties.
+         * @function create
+         * @memberof common.AttestNetworkFee
+         * @static
+         * @param {common.IAttestNetworkFee=} [properties] Properties to set
+         * @returns {common.AttestNetworkFee} AttestNetworkFee instance
+         */
+        AttestNetworkFee.create = function create(properties) {
+            return new AttestNetworkFee(properties);
+        };
+
+        /**
+         * Encodes the specified AttestNetworkFee message. Does not implicitly {@link common.AttestNetworkFee.verify|verify} messages.
+         * @function encode
+         * @memberof common.AttestNetworkFee
+         * @static
+         * @param {common.IAttestNetworkFee} message AttestNetworkFee message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        AttestNetworkFee.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.networkFee != null && Object.hasOwnProperty.call(message, "networkFee"))
+                $root.common.NetworkFee.encode(message.networkFee, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.attestation != null && Object.hasOwnProperty.call(message, "attestation"))
+                $root.common.Attestation.encode(message.attestation, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified AttestNetworkFee message, length delimited. Does not implicitly {@link common.AttestNetworkFee.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common.AttestNetworkFee
+         * @static
+         * @param {common.IAttestNetworkFee} message AttestNetworkFee message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        AttestNetworkFee.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes an AttestNetworkFee message from the specified reader or buffer.
+         * @function decode
+         * @memberof common.AttestNetworkFee
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common.AttestNetworkFee} AttestNetworkFee
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        AttestNetworkFee.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common.AttestNetworkFee();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.networkFee = $root.common.NetworkFee.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    message.attestation = $root.common.Attestation.decode(reader, reader.uint32());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes an AttestNetworkFee message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common.AttestNetworkFee
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common.AttestNetworkFee} AttestNetworkFee
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        AttestNetworkFee.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies an AttestNetworkFee message.
+         * @function verify
+         * @memberof common.AttestNetworkFee
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        AttestNetworkFee.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.networkFee != null && message.hasOwnProperty("networkFee")) {
+                var error = $root.common.NetworkFee.verify(message.networkFee);
+                if (error)
+                    return "networkFee." + error;
+            }
+            if (message.attestation != null && message.hasOwnProperty("attestation")) {
+                var error = $root.common.Attestation.verify(message.attestation);
+                if (error)
+                    return "attestation." + error;
+            }
+            return null;
+        };
+
+        /**
+         * Creates an AttestNetworkFee message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common.AttestNetworkFee
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common.AttestNetworkFee} AttestNetworkFee
+         */
+        AttestNetworkFee.fromObject = function fromObject(object) {
+            if (object instanceof $root.common.AttestNetworkFee)
+                return object;
+            var message = new $root.common.AttestNetworkFee();
+            if (object.networkFee != null) {
+                if (typeof object.networkFee !== "object")
+                    throw TypeError(".common.AttestNetworkFee.networkFee: object expected");
+                message.networkFee = $root.common.NetworkFee.fromObject(object.networkFee);
+            }
+            if (object.attestation != null) {
+                if (typeof object.attestation !== "object")
+                    throw TypeError(".common.AttestNetworkFee.attestation: object expected");
+                message.attestation = $root.common.Attestation.fromObject(object.attestation);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from an AttestNetworkFee message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common.AttestNetworkFee
+         * @static
+         * @param {common.AttestNetworkFee} message AttestNetworkFee
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        AttestNetworkFee.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.networkFee = null;
+                object.attestation = null;
+            }
+            if (message.networkFee != null && message.hasOwnProperty("networkFee"))
+                object.networkFee = $root.common.NetworkFee.toObject(message.networkFee, options);
+            if (message.attestation != null && message.hasOwnProperty("attestation"))
+                object.attestation = $root.common.Attestation.toObject(message.attestation, options);
+            return object;
+        };
+
+        /**
+         * Converts this AttestNetworkFee to JSON.
+         * @function toJSON
+         * @memberof common.AttestNetworkFee
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        AttestNetworkFee.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return AttestNetworkFee;
+    })();
+
+    common.QuorumNetworkFee = (function() {
+
+        /**
+         * Properties of a QuorumNetworkFee.
+         * @memberof common
+         * @interface IQuorumNetworkFee
+         * @property {common.INetworkFee|null} [networkFee] QuorumNetworkFee networkFee
+         * @property {Array.<common.IAttestation>|null} [attestations] QuorumNetworkFee attestations
+         */
+
+        /**
+         * Constructs a new QuorumNetworkFee.
+         * @memberof common
+         * @classdesc Represents a QuorumNetworkFee.
+         * @implements IQuorumNetworkFee
+         * @constructor
+         * @param {common.IQuorumNetworkFee=} [properties] Properties to set
+         */
+        function QuorumNetworkFee(properties) {
+            this.attestations = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * QuorumNetworkFee networkFee.
+         * @member {common.INetworkFee|null|undefined} networkFee
+         * @memberof common.QuorumNetworkFee
+         * @instance
+         */
+        QuorumNetworkFee.prototype.networkFee = null;
+
+        /**
+         * QuorumNetworkFee attestations.
+         * @member {Array.<common.IAttestation>} attestations
+         * @memberof common.QuorumNetworkFee
+         * @instance
+         */
+        QuorumNetworkFee.prototype.attestations = $util.emptyArray;
+
+        /**
+         * Creates a new QuorumNetworkFee instance using the specified properties.
+         * @function create
+         * @memberof common.QuorumNetworkFee
+         * @static
+         * @param {common.IQuorumNetworkFee=} [properties] Properties to set
+         * @returns {common.QuorumNetworkFee} QuorumNetworkFee instance
+         */
+        QuorumNetworkFee.create = function create(properties) {
+            return new QuorumNetworkFee(properties);
+        };
+
+        /**
+         * Encodes the specified QuorumNetworkFee message. Does not implicitly {@link common.QuorumNetworkFee.verify|verify} messages.
+         * @function encode
+         * @memberof common.QuorumNetworkFee
+         * @static
+         * @param {common.IQuorumNetworkFee} message QuorumNetworkFee message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        QuorumNetworkFee.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.networkFee != null && Object.hasOwnProperty.call(message, "networkFee"))
+                $root.common.NetworkFee.encode(message.networkFee, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.attestations != null && message.attestations.length)
+                for (var i = 0; i < message.attestations.length; ++i)
+                    $root.common.Attestation.encode(message.attestations[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified QuorumNetworkFee message, length delimited. Does not implicitly {@link common.QuorumNetworkFee.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common.QuorumNetworkFee
+         * @static
+         * @param {common.IQuorumNetworkFee} message QuorumNetworkFee message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        QuorumNetworkFee.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a QuorumNetworkFee message from the specified reader or buffer.
+         * @function decode
+         * @memberof common.QuorumNetworkFee
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common.QuorumNetworkFee} QuorumNetworkFee
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        QuorumNetworkFee.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common.QuorumNetworkFee();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.networkFee = $root.common.NetworkFee.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    if (!(message.attestations && message.attestations.length))
+                        message.attestations = [];
+                    message.attestations.push($root.common.Attestation.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a QuorumNetworkFee message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common.QuorumNetworkFee
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common.QuorumNetworkFee} QuorumNetworkFee
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        QuorumNetworkFee.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a QuorumNetworkFee message.
+         * @function verify
+         * @memberof common.QuorumNetworkFee
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        QuorumNetworkFee.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.networkFee != null && message.hasOwnProperty("networkFee")) {
+                var error = $root.common.NetworkFee.verify(message.networkFee);
+                if (error)
+                    return "networkFee." + error;
+            }
+            if (message.attestations != null && message.hasOwnProperty("attestations")) {
+                if (!Array.isArray(message.attestations))
+                    return "attestations: array expected";
+                for (var i = 0; i < message.attestations.length; ++i) {
+                    var error = $root.common.Attestation.verify(message.attestations[i]);
+                    if (error)
+                        return "attestations." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a QuorumNetworkFee message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common.QuorumNetworkFee
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common.QuorumNetworkFee} QuorumNetworkFee
+         */
+        QuorumNetworkFee.fromObject = function fromObject(object) {
+            if (object instanceof $root.common.QuorumNetworkFee)
+                return object;
+            var message = new $root.common.QuorumNetworkFee();
+            if (object.networkFee != null) {
+                if (typeof object.networkFee !== "object")
+                    throw TypeError(".common.QuorumNetworkFee.networkFee: object expected");
+                message.networkFee = $root.common.NetworkFee.fromObject(object.networkFee);
+            }
+            if (object.attestations) {
+                if (!Array.isArray(object.attestations))
+                    throw TypeError(".common.QuorumNetworkFee.attestations: array expected");
+                message.attestations = [];
+                for (var i = 0; i < object.attestations.length; ++i) {
+                    if (typeof object.attestations[i] !== "object")
+                        throw TypeError(".common.QuorumNetworkFee.attestations: object expected");
+                    message.attestations[i] = $root.common.Attestation.fromObject(object.attestations[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a QuorumNetworkFee message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common.QuorumNetworkFee
+         * @static
+         * @param {common.QuorumNetworkFee} message QuorumNetworkFee
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        QuorumNetworkFee.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.attestations = [];
+            if (options.defaults)
+                object.networkFee = null;
+            if (message.networkFee != null && message.hasOwnProperty("networkFee"))
+                object.networkFee = $root.common.NetworkFee.toObject(message.networkFee, options);
+            if (message.attestations && message.attestations.length) {
+                object.attestations = [];
+                for (var j = 0; j < message.attestations.length; ++j)
+                    object.attestations[j] = $root.common.Attestation.toObject(message.attestations[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this QuorumNetworkFee to JSON.
+         * @function toJSON
+         * @memberof common.QuorumNetworkFee
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        QuorumNetworkFee.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return QuorumNetworkFee;
+    })();
+
+    common.Solvency = (function() {
+
+        /**
+         * Properties of a Solvency.
+         * @memberof common
+         * @interface ISolvency
+         * @property {string|null} [id] Solvency id
+         * @property {string|null} [chain] Solvency chain
+         * @property {string|null} [pubKey] Solvency pubKey
+         * @property {Array.<common.ICoin>|null} [coins] Solvency coins
+         * @property {number|Long|null} [height] Solvency height
+         */
+
+        /**
+         * Constructs a new Solvency.
+         * @memberof common
+         * @classdesc Represents a Solvency.
+         * @implements ISolvency
+         * @constructor
+         * @param {common.ISolvency=} [properties] Properties to set
+         */
+        function Solvency(properties) {
+            this.coins = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * Solvency id.
+         * @member {string} id
+         * @memberof common.Solvency
+         * @instance
+         */
+        Solvency.prototype.id = "";
+
+        /**
+         * Solvency chain.
+         * @member {string} chain
+         * @memberof common.Solvency
+         * @instance
+         */
+        Solvency.prototype.chain = "";
+
+        /**
+         * Solvency pubKey.
+         * @member {string} pubKey
+         * @memberof common.Solvency
+         * @instance
+         */
+        Solvency.prototype.pubKey = "";
+
+        /**
+         * Solvency coins.
+         * @member {Array.<common.ICoin>} coins
+         * @memberof common.Solvency
+         * @instance
+         */
+        Solvency.prototype.coins = $util.emptyArray;
+
+        /**
+         * Solvency height.
+         * @member {number|Long} height
+         * @memberof common.Solvency
+         * @instance
+         */
+        Solvency.prototype.height = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+
+        /**
+         * Creates a new Solvency instance using the specified properties.
+         * @function create
+         * @memberof common.Solvency
+         * @static
+         * @param {common.ISolvency=} [properties] Properties to set
+         * @returns {common.Solvency} Solvency instance
+         */
+        Solvency.create = function create(properties) {
+            return new Solvency(properties);
+        };
+
+        /**
+         * Encodes the specified Solvency message. Does not implicitly {@link common.Solvency.verify|verify} messages.
+         * @function encode
+         * @memberof common.Solvency
+         * @static
+         * @param {common.ISolvency} message Solvency message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Solvency.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+            if (message.chain != null && Object.hasOwnProperty.call(message, "chain"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.chain);
+            if (message.pubKey != null && Object.hasOwnProperty.call(message, "pubKey"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.pubKey);
+            if (message.coins != null && message.coins.length)
+                for (var i = 0; i < message.coins.length; ++i)
+                    $root.common.Coin.encode(message.coins[i], writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+            if (message.height != null && Object.hasOwnProperty.call(message, "height"))
+                writer.uint32(/* id 5, wireType 0 =*/40).int64(message.height);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified Solvency message, length delimited. Does not implicitly {@link common.Solvency.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common.Solvency
+         * @static
+         * @param {common.ISolvency} message Solvency message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Solvency.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a Solvency message from the specified reader or buffer.
+         * @function decode
+         * @memberof common.Solvency
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common.Solvency} Solvency
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Solvency.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common.Solvency();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.id = reader.string();
+                    break;
+                case 2:
+                    message.chain = reader.string();
+                    break;
+                case 3:
+                    message.pubKey = reader.string();
+                    break;
+                case 4:
+                    if (!(message.coins && message.coins.length))
+                        message.coins = [];
+                    message.coins.push($root.common.Coin.decode(reader, reader.uint32()));
+                    break;
+                case 5:
+                    message.height = reader.int64();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a Solvency message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common.Solvency
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common.Solvency} Solvency
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Solvency.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a Solvency message.
+         * @function verify
+         * @memberof common.Solvency
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        Solvency.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.id != null && message.hasOwnProperty("id"))
+                if (!$util.isString(message.id))
+                    return "id: string expected";
+            if (message.chain != null && message.hasOwnProperty("chain"))
+                if (!$util.isString(message.chain))
+                    return "chain: string expected";
+            if (message.pubKey != null && message.hasOwnProperty("pubKey"))
+                if (!$util.isString(message.pubKey))
+                    return "pubKey: string expected";
+            if (message.coins != null && message.hasOwnProperty("coins")) {
+                if (!Array.isArray(message.coins))
+                    return "coins: array expected";
+                for (var i = 0; i < message.coins.length; ++i) {
+                    var error = $root.common.Coin.verify(message.coins[i]);
+                    if (error)
+                        return "coins." + error;
+                }
+            }
+            if (message.height != null && message.hasOwnProperty("height"))
+                if (!$util.isInteger(message.height) && !(message.height && $util.isInteger(message.height.low) && $util.isInteger(message.height.high)))
+                    return "height: integer|Long expected";
+            return null;
+        };
+
+        /**
+         * Creates a Solvency message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common.Solvency
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common.Solvency} Solvency
+         */
+        Solvency.fromObject = function fromObject(object) {
+            if (object instanceof $root.common.Solvency)
+                return object;
+            var message = new $root.common.Solvency();
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.chain != null)
+                message.chain = String(object.chain);
+            if (object.pubKey != null)
+                message.pubKey = String(object.pubKey);
+            if (object.coins) {
+                if (!Array.isArray(object.coins))
+                    throw TypeError(".common.Solvency.coins: array expected");
+                message.coins = [];
+                for (var i = 0; i < object.coins.length; ++i) {
+                    if (typeof object.coins[i] !== "object")
+                        throw TypeError(".common.Solvency.coins: object expected");
+                    message.coins[i] = $root.common.Coin.fromObject(object.coins[i]);
+                }
+            }
+            if (object.height != null)
+                if ($util.Long)
+                    (message.height = $util.Long.fromValue(object.height)).unsigned = false;
+                else if (typeof object.height === "string")
+                    message.height = parseInt(object.height, 10);
+                else if (typeof object.height === "number")
+                    message.height = object.height;
+                else if (typeof object.height === "object")
+                    message.height = new $util.LongBits(object.height.low >>> 0, object.height.high >>> 0).toNumber();
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a Solvency message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common.Solvency
+         * @static
+         * @param {common.Solvency} message Solvency
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        Solvency.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.coins = [];
+            if (options.defaults) {
+                object.id = "";
+                object.chain = "";
+                object.pubKey = "";
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, false);
+                    object.height = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.height = options.longs === String ? "0" : 0;
+            }
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.chain != null && message.hasOwnProperty("chain"))
+                object.chain = message.chain;
+            if (message.pubKey != null && message.hasOwnProperty("pubKey"))
+                object.pubKey = message.pubKey;
+            if (message.coins && message.coins.length) {
+                object.coins = [];
+                for (var j = 0; j < message.coins.length; ++j)
+                    object.coins[j] = $root.common.Coin.toObject(message.coins[j], options);
+            }
+            if (message.height != null && message.hasOwnProperty("height"))
+                if (typeof message.height === "number")
+                    object.height = options.longs === String ? String(message.height) : message.height;
+                else
+                    object.height = options.longs === String ? $util.Long.prototype.toString.call(message.height) : options.longs === Number ? new $util.LongBits(message.height.low >>> 0, message.height.high >>> 0).toNumber() : message.height;
+            return object;
+        };
+
+        /**
+         * Converts this Solvency to JSON.
+         * @function toJSON
+         * @memberof common.Solvency
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        Solvency.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return Solvency;
+    })();
+
+    common.AttestSolvency = (function() {
+
+        /**
+         * Properties of an AttestSolvency.
+         * @memberof common
+         * @interface IAttestSolvency
+         * @property {common.ISolvency|null} [solvency] AttestSolvency solvency
+         * @property {common.IAttestation|null} [attestation] AttestSolvency attestation
+         */
+
+        /**
+         * Constructs a new AttestSolvency.
+         * @memberof common
+         * @classdesc Represents an AttestSolvency.
+         * @implements IAttestSolvency
+         * @constructor
+         * @param {common.IAttestSolvency=} [properties] Properties to set
+         */
+        function AttestSolvency(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * AttestSolvency solvency.
+         * @member {common.ISolvency|null|undefined} solvency
+         * @memberof common.AttestSolvency
+         * @instance
+         */
+        AttestSolvency.prototype.solvency = null;
+
+        /**
+         * AttestSolvency attestation.
+         * @member {common.IAttestation|null|undefined} attestation
+         * @memberof common.AttestSolvency
+         * @instance
+         */
+        AttestSolvency.prototype.attestation = null;
+
+        /**
+         * Creates a new AttestSolvency instance using the specified properties.
+         * @function create
+         * @memberof common.AttestSolvency
+         * @static
+         * @param {common.IAttestSolvency=} [properties] Properties to set
+         * @returns {common.AttestSolvency} AttestSolvency instance
+         */
+        AttestSolvency.create = function create(properties) {
+            return new AttestSolvency(properties);
+        };
+
+        /**
+         * Encodes the specified AttestSolvency message. Does not implicitly {@link common.AttestSolvency.verify|verify} messages.
+         * @function encode
+         * @memberof common.AttestSolvency
+         * @static
+         * @param {common.IAttestSolvency} message AttestSolvency message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        AttestSolvency.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.solvency != null && Object.hasOwnProperty.call(message, "solvency"))
+                $root.common.Solvency.encode(message.solvency, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.attestation != null && Object.hasOwnProperty.call(message, "attestation"))
+                $root.common.Attestation.encode(message.attestation, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified AttestSolvency message, length delimited. Does not implicitly {@link common.AttestSolvency.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common.AttestSolvency
+         * @static
+         * @param {common.IAttestSolvency} message AttestSolvency message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        AttestSolvency.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes an AttestSolvency message from the specified reader or buffer.
+         * @function decode
+         * @memberof common.AttestSolvency
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common.AttestSolvency} AttestSolvency
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        AttestSolvency.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common.AttestSolvency();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.solvency = $root.common.Solvency.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    message.attestation = $root.common.Attestation.decode(reader, reader.uint32());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes an AttestSolvency message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common.AttestSolvency
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common.AttestSolvency} AttestSolvency
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        AttestSolvency.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies an AttestSolvency message.
+         * @function verify
+         * @memberof common.AttestSolvency
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        AttestSolvency.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.solvency != null && message.hasOwnProperty("solvency")) {
+                var error = $root.common.Solvency.verify(message.solvency);
+                if (error)
+                    return "solvency." + error;
+            }
+            if (message.attestation != null && message.hasOwnProperty("attestation")) {
+                var error = $root.common.Attestation.verify(message.attestation);
+                if (error)
+                    return "attestation." + error;
+            }
+            return null;
+        };
+
+        /**
+         * Creates an AttestSolvency message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common.AttestSolvency
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common.AttestSolvency} AttestSolvency
+         */
+        AttestSolvency.fromObject = function fromObject(object) {
+            if (object instanceof $root.common.AttestSolvency)
+                return object;
+            var message = new $root.common.AttestSolvency();
+            if (object.solvency != null) {
+                if (typeof object.solvency !== "object")
+                    throw TypeError(".common.AttestSolvency.solvency: object expected");
+                message.solvency = $root.common.Solvency.fromObject(object.solvency);
+            }
+            if (object.attestation != null) {
+                if (typeof object.attestation !== "object")
+                    throw TypeError(".common.AttestSolvency.attestation: object expected");
+                message.attestation = $root.common.Attestation.fromObject(object.attestation);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from an AttestSolvency message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common.AttestSolvency
+         * @static
+         * @param {common.AttestSolvency} message AttestSolvency
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        AttestSolvency.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.solvency = null;
+                object.attestation = null;
+            }
+            if (message.solvency != null && message.hasOwnProperty("solvency"))
+                object.solvency = $root.common.Solvency.toObject(message.solvency, options);
+            if (message.attestation != null && message.hasOwnProperty("attestation"))
+                object.attestation = $root.common.Attestation.toObject(message.attestation, options);
+            return object;
+        };
+
+        /**
+         * Converts this AttestSolvency to JSON.
+         * @function toJSON
+         * @memberof common.AttestSolvency
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        AttestSolvency.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return AttestSolvency;
+    })();
+
+    common.QuorumSolvency = (function() {
+
+        /**
+         * Properties of a QuorumSolvency.
+         * @memberof common
+         * @interface IQuorumSolvency
+         * @property {common.ISolvency|null} [solvency] QuorumSolvency solvency
+         * @property {Array.<common.IAttestation>|null} [attestations] QuorumSolvency attestations
+         */
+
+        /**
+         * Constructs a new QuorumSolvency.
+         * @memberof common
+         * @classdesc Represents a QuorumSolvency.
+         * @implements IQuorumSolvency
+         * @constructor
+         * @param {common.IQuorumSolvency=} [properties] Properties to set
+         */
+        function QuorumSolvency(properties) {
+            this.attestations = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * QuorumSolvency solvency.
+         * @member {common.ISolvency|null|undefined} solvency
+         * @memberof common.QuorumSolvency
+         * @instance
+         */
+        QuorumSolvency.prototype.solvency = null;
+
+        /**
+         * QuorumSolvency attestations.
+         * @member {Array.<common.IAttestation>} attestations
+         * @memberof common.QuorumSolvency
+         * @instance
+         */
+        QuorumSolvency.prototype.attestations = $util.emptyArray;
+
+        /**
+         * Creates a new QuorumSolvency instance using the specified properties.
+         * @function create
+         * @memberof common.QuorumSolvency
+         * @static
+         * @param {common.IQuorumSolvency=} [properties] Properties to set
+         * @returns {common.QuorumSolvency} QuorumSolvency instance
+         */
+        QuorumSolvency.create = function create(properties) {
+            return new QuorumSolvency(properties);
+        };
+
+        /**
+         * Encodes the specified QuorumSolvency message. Does not implicitly {@link common.QuorumSolvency.verify|verify} messages.
+         * @function encode
+         * @memberof common.QuorumSolvency
+         * @static
+         * @param {common.IQuorumSolvency} message QuorumSolvency message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        QuorumSolvency.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.solvency != null && Object.hasOwnProperty.call(message, "solvency"))
+                $root.common.Solvency.encode(message.solvency, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.attestations != null && message.attestations.length)
+                for (var i = 0; i < message.attestations.length; ++i)
+                    $root.common.Attestation.encode(message.attestations[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified QuorumSolvency message, length delimited. Does not implicitly {@link common.QuorumSolvency.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common.QuorumSolvency
+         * @static
+         * @param {common.IQuorumSolvency} message QuorumSolvency message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        QuorumSolvency.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a QuorumSolvency message from the specified reader or buffer.
+         * @function decode
+         * @memberof common.QuorumSolvency
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common.QuorumSolvency} QuorumSolvency
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        QuorumSolvency.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common.QuorumSolvency();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.solvency = $root.common.Solvency.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    if (!(message.attestations && message.attestations.length))
+                        message.attestations = [];
+                    message.attestations.push($root.common.Attestation.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a QuorumSolvency message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common.QuorumSolvency
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common.QuorumSolvency} QuorumSolvency
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        QuorumSolvency.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a QuorumSolvency message.
+         * @function verify
+         * @memberof common.QuorumSolvency
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        QuorumSolvency.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.solvency != null && message.hasOwnProperty("solvency")) {
+                var error = $root.common.Solvency.verify(message.solvency);
+                if (error)
+                    return "solvency." + error;
+            }
+            if (message.attestations != null && message.hasOwnProperty("attestations")) {
+                if (!Array.isArray(message.attestations))
+                    return "attestations: array expected";
+                for (var i = 0; i < message.attestations.length; ++i) {
+                    var error = $root.common.Attestation.verify(message.attestations[i]);
+                    if (error)
+                        return "attestations." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a QuorumSolvency message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common.QuorumSolvency
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common.QuorumSolvency} QuorumSolvency
+         */
+        QuorumSolvency.fromObject = function fromObject(object) {
+            if (object instanceof $root.common.QuorumSolvency)
+                return object;
+            var message = new $root.common.QuorumSolvency();
+            if (object.solvency != null) {
+                if (typeof object.solvency !== "object")
+                    throw TypeError(".common.QuorumSolvency.solvency: object expected");
+                message.solvency = $root.common.Solvency.fromObject(object.solvency);
+            }
+            if (object.attestations) {
+                if (!Array.isArray(object.attestations))
+                    throw TypeError(".common.QuorumSolvency.attestations: array expected");
+                message.attestations = [];
+                for (var i = 0; i < object.attestations.length; ++i) {
+                    if (typeof object.attestations[i] !== "object")
+                        throw TypeError(".common.QuorumSolvency.attestations: object expected");
+                    message.attestations[i] = $root.common.Attestation.fromObject(object.attestations[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a QuorumSolvency message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common.QuorumSolvency
+         * @static
+         * @param {common.QuorumSolvency} message QuorumSolvency
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        QuorumSolvency.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.attestations = [];
+            if (options.defaults)
+                object.solvency = null;
+            if (message.solvency != null && message.hasOwnProperty("solvency"))
+                object.solvency = $root.common.Solvency.toObject(message.solvency, options);
+            if (message.attestations && message.attestations.length) {
+                object.attestations = [];
+                for (var j = 0; j < message.attestations.length; ++j)
+                    object.attestations[j] = $root.common.Attestation.toObject(message.attestations[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this QuorumSolvency to JSON.
+         * @function toJSON
+         * @memberof common.QuorumSolvency
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        QuorumSolvency.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return QuorumSolvency;
+    })();
+
+    common.ErrataTx = (function() {
+
+        /**
+         * Properties of an ErrataTx.
+         * @memberof common
+         * @interface IErrataTx
+         * @property {string|null} [id] ErrataTx id
+         * @property {string|null} [chain] ErrataTx chain
+         */
+
+        /**
+         * Constructs a new ErrataTx.
+         * @memberof common
+         * @classdesc Represents an ErrataTx.
+         * @implements IErrataTx
+         * @constructor
+         * @param {common.IErrataTx=} [properties] Properties to set
+         */
+        function ErrataTx(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * ErrataTx id.
+         * @member {string} id
+         * @memberof common.ErrataTx
+         * @instance
+         */
+        ErrataTx.prototype.id = "";
+
+        /**
+         * ErrataTx chain.
+         * @member {string} chain
+         * @memberof common.ErrataTx
+         * @instance
+         */
+        ErrataTx.prototype.chain = "";
+
+        /**
+         * Creates a new ErrataTx instance using the specified properties.
+         * @function create
+         * @memberof common.ErrataTx
+         * @static
+         * @param {common.IErrataTx=} [properties] Properties to set
+         * @returns {common.ErrataTx} ErrataTx instance
+         */
+        ErrataTx.create = function create(properties) {
+            return new ErrataTx(properties);
+        };
+
+        /**
+         * Encodes the specified ErrataTx message. Does not implicitly {@link common.ErrataTx.verify|verify} messages.
+         * @function encode
+         * @memberof common.ErrataTx
+         * @static
+         * @param {common.IErrataTx} message ErrataTx message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        ErrataTx.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+            if (message.chain != null && Object.hasOwnProperty.call(message, "chain"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.chain);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified ErrataTx message, length delimited. Does not implicitly {@link common.ErrataTx.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common.ErrataTx
+         * @static
+         * @param {common.IErrataTx} message ErrataTx message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        ErrataTx.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes an ErrataTx message from the specified reader or buffer.
+         * @function decode
+         * @memberof common.ErrataTx
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common.ErrataTx} ErrataTx
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        ErrataTx.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common.ErrataTx();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.id = reader.string();
+                    break;
+                case 2:
+                    message.chain = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes an ErrataTx message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common.ErrataTx
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common.ErrataTx} ErrataTx
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        ErrataTx.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies an ErrataTx message.
+         * @function verify
+         * @memberof common.ErrataTx
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        ErrataTx.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.id != null && message.hasOwnProperty("id"))
+                if (!$util.isString(message.id))
+                    return "id: string expected";
+            if (message.chain != null && message.hasOwnProperty("chain"))
+                if (!$util.isString(message.chain))
+                    return "chain: string expected";
+            return null;
+        };
+
+        /**
+         * Creates an ErrataTx message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common.ErrataTx
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common.ErrataTx} ErrataTx
+         */
+        ErrataTx.fromObject = function fromObject(object) {
+            if (object instanceof $root.common.ErrataTx)
+                return object;
+            var message = new $root.common.ErrataTx();
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.chain != null)
+                message.chain = String(object.chain);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from an ErrataTx message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common.ErrataTx
+         * @static
+         * @param {common.ErrataTx} message ErrataTx
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        ErrataTx.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.id = "";
+                object.chain = "";
+            }
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.chain != null && message.hasOwnProperty("chain"))
+                object.chain = message.chain;
+            return object;
+        };
+
+        /**
+         * Converts this ErrataTx to JSON.
+         * @function toJSON
+         * @memberof common.ErrataTx
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        ErrataTx.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return ErrataTx;
+    })();
+
+    common.AttestErrataTx = (function() {
+
+        /**
+         * Properties of an AttestErrataTx.
+         * @memberof common
+         * @interface IAttestErrataTx
+         * @property {common.IErrataTx|null} [errataTx] AttestErrataTx errataTx
+         * @property {common.IAttestation|null} [attestation] AttestErrataTx attestation
+         */
+
+        /**
+         * Constructs a new AttestErrataTx.
+         * @memberof common
+         * @classdesc Represents an AttestErrataTx.
+         * @implements IAttestErrataTx
+         * @constructor
+         * @param {common.IAttestErrataTx=} [properties] Properties to set
+         */
+        function AttestErrataTx(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * AttestErrataTx errataTx.
+         * @member {common.IErrataTx|null|undefined} errataTx
+         * @memberof common.AttestErrataTx
+         * @instance
+         */
+        AttestErrataTx.prototype.errataTx = null;
+
+        /**
+         * AttestErrataTx attestation.
+         * @member {common.IAttestation|null|undefined} attestation
+         * @memberof common.AttestErrataTx
+         * @instance
+         */
+        AttestErrataTx.prototype.attestation = null;
+
+        /**
+         * Creates a new AttestErrataTx instance using the specified properties.
+         * @function create
+         * @memberof common.AttestErrataTx
+         * @static
+         * @param {common.IAttestErrataTx=} [properties] Properties to set
+         * @returns {common.AttestErrataTx} AttestErrataTx instance
+         */
+        AttestErrataTx.create = function create(properties) {
+            return new AttestErrataTx(properties);
+        };
+
+        /**
+         * Encodes the specified AttestErrataTx message. Does not implicitly {@link common.AttestErrataTx.verify|verify} messages.
+         * @function encode
+         * @memberof common.AttestErrataTx
+         * @static
+         * @param {common.IAttestErrataTx} message AttestErrataTx message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        AttestErrataTx.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.errataTx != null && Object.hasOwnProperty.call(message, "errataTx"))
+                $root.common.ErrataTx.encode(message.errataTx, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.attestation != null && Object.hasOwnProperty.call(message, "attestation"))
+                $root.common.Attestation.encode(message.attestation, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified AttestErrataTx message, length delimited. Does not implicitly {@link common.AttestErrataTx.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common.AttestErrataTx
+         * @static
+         * @param {common.IAttestErrataTx} message AttestErrataTx message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        AttestErrataTx.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes an AttestErrataTx message from the specified reader or buffer.
+         * @function decode
+         * @memberof common.AttestErrataTx
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common.AttestErrataTx} AttestErrataTx
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        AttestErrataTx.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common.AttestErrataTx();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.errataTx = $root.common.ErrataTx.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    message.attestation = $root.common.Attestation.decode(reader, reader.uint32());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes an AttestErrataTx message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common.AttestErrataTx
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common.AttestErrataTx} AttestErrataTx
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        AttestErrataTx.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies an AttestErrataTx message.
+         * @function verify
+         * @memberof common.AttestErrataTx
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        AttestErrataTx.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.errataTx != null && message.hasOwnProperty("errataTx")) {
+                var error = $root.common.ErrataTx.verify(message.errataTx);
+                if (error)
+                    return "errataTx." + error;
+            }
+            if (message.attestation != null && message.hasOwnProperty("attestation")) {
+                var error = $root.common.Attestation.verify(message.attestation);
+                if (error)
+                    return "attestation." + error;
+            }
+            return null;
+        };
+
+        /**
+         * Creates an AttestErrataTx message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common.AttestErrataTx
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common.AttestErrataTx} AttestErrataTx
+         */
+        AttestErrataTx.fromObject = function fromObject(object) {
+            if (object instanceof $root.common.AttestErrataTx)
+                return object;
+            var message = new $root.common.AttestErrataTx();
+            if (object.errataTx != null) {
+                if (typeof object.errataTx !== "object")
+                    throw TypeError(".common.AttestErrataTx.errataTx: object expected");
+                message.errataTx = $root.common.ErrataTx.fromObject(object.errataTx);
+            }
+            if (object.attestation != null) {
+                if (typeof object.attestation !== "object")
+                    throw TypeError(".common.AttestErrataTx.attestation: object expected");
+                message.attestation = $root.common.Attestation.fromObject(object.attestation);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from an AttestErrataTx message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common.AttestErrataTx
+         * @static
+         * @param {common.AttestErrataTx} message AttestErrataTx
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        AttestErrataTx.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.errataTx = null;
+                object.attestation = null;
+            }
+            if (message.errataTx != null && message.hasOwnProperty("errataTx"))
+                object.errataTx = $root.common.ErrataTx.toObject(message.errataTx, options);
+            if (message.attestation != null && message.hasOwnProperty("attestation"))
+                object.attestation = $root.common.Attestation.toObject(message.attestation, options);
+            return object;
+        };
+
+        /**
+         * Converts this AttestErrataTx to JSON.
+         * @function toJSON
+         * @memberof common.AttestErrataTx
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        AttestErrataTx.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return AttestErrataTx;
+    })();
+
+    common.QuorumErrataTx = (function() {
+
+        /**
+         * Properties of a QuorumErrataTx.
+         * @memberof common
+         * @interface IQuorumErrataTx
+         * @property {common.IErrataTx|null} [errataTx] QuorumErrataTx errataTx
+         * @property {Array.<common.IAttestation>|null} [attestations] QuorumErrataTx attestations
+         */
+
+        /**
+         * Constructs a new QuorumErrataTx.
+         * @memberof common
+         * @classdesc Represents a QuorumErrataTx.
+         * @implements IQuorumErrataTx
+         * @constructor
+         * @param {common.IQuorumErrataTx=} [properties] Properties to set
+         */
+        function QuorumErrataTx(properties) {
+            this.attestations = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * QuorumErrataTx errataTx.
+         * @member {common.IErrataTx|null|undefined} errataTx
+         * @memberof common.QuorumErrataTx
+         * @instance
+         */
+        QuorumErrataTx.prototype.errataTx = null;
+
+        /**
+         * QuorumErrataTx attestations.
+         * @member {Array.<common.IAttestation>} attestations
+         * @memberof common.QuorumErrataTx
+         * @instance
+         */
+        QuorumErrataTx.prototype.attestations = $util.emptyArray;
+
+        /**
+         * Creates a new QuorumErrataTx instance using the specified properties.
+         * @function create
+         * @memberof common.QuorumErrataTx
+         * @static
+         * @param {common.IQuorumErrataTx=} [properties] Properties to set
+         * @returns {common.QuorumErrataTx} QuorumErrataTx instance
+         */
+        QuorumErrataTx.create = function create(properties) {
+            return new QuorumErrataTx(properties);
+        };
+
+        /**
+         * Encodes the specified QuorumErrataTx message. Does not implicitly {@link common.QuorumErrataTx.verify|verify} messages.
+         * @function encode
+         * @memberof common.QuorumErrataTx
+         * @static
+         * @param {common.IQuorumErrataTx} message QuorumErrataTx message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        QuorumErrataTx.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.errataTx != null && Object.hasOwnProperty.call(message, "errataTx"))
+                $root.common.ErrataTx.encode(message.errataTx, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.attestations != null && message.attestations.length)
+                for (var i = 0; i < message.attestations.length; ++i)
+                    $root.common.Attestation.encode(message.attestations[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified QuorumErrataTx message, length delimited. Does not implicitly {@link common.QuorumErrataTx.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common.QuorumErrataTx
+         * @static
+         * @param {common.IQuorumErrataTx} message QuorumErrataTx message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        QuorumErrataTx.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a QuorumErrataTx message from the specified reader or buffer.
+         * @function decode
+         * @memberof common.QuorumErrataTx
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common.QuorumErrataTx} QuorumErrataTx
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        QuorumErrataTx.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common.QuorumErrataTx();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.errataTx = $root.common.ErrataTx.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    if (!(message.attestations && message.attestations.length))
+                        message.attestations = [];
+                    message.attestations.push($root.common.Attestation.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a QuorumErrataTx message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common.QuorumErrataTx
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common.QuorumErrataTx} QuorumErrataTx
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        QuorumErrataTx.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a QuorumErrataTx message.
+         * @function verify
+         * @memberof common.QuorumErrataTx
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        QuorumErrataTx.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.errataTx != null && message.hasOwnProperty("errataTx")) {
+                var error = $root.common.ErrataTx.verify(message.errataTx);
+                if (error)
+                    return "errataTx." + error;
+            }
+            if (message.attestations != null && message.hasOwnProperty("attestations")) {
+                if (!Array.isArray(message.attestations))
+                    return "attestations: array expected";
+                for (var i = 0; i < message.attestations.length; ++i) {
+                    var error = $root.common.Attestation.verify(message.attestations[i]);
+                    if (error)
+                        return "attestations." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a QuorumErrataTx message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common.QuorumErrataTx
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common.QuorumErrataTx} QuorumErrataTx
+         */
+        QuorumErrataTx.fromObject = function fromObject(object) {
+            if (object instanceof $root.common.QuorumErrataTx)
+                return object;
+            var message = new $root.common.QuorumErrataTx();
+            if (object.errataTx != null) {
+                if (typeof object.errataTx !== "object")
+                    throw TypeError(".common.QuorumErrataTx.errataTx: object expected");
+                message.errataTx = $root.common.ErrataTx.fromObject(object.errataTx);
+            }
+            if (object.attestations) {
+                if (!Array.isArray(object.attestations))
+                    throw TypeError(".common.QuorumErrataTx.attestations: array expected");
+                message.attestations = [];
+                for (var i = 0; i < object.attestations.length; ++i) {
+                    if (typeof object.attestations[i] !== "object")
+                        throw TypeError(".common.QuorumErrataTx.attestations: object expected");
+                    message.attestations[i] = $root.common.Attestation.fromObject(object.attestations[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a QuorumErrataTx message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common.QuorumErrataTx
+         * @static
+         * @param {common.QuorumErrataTx} message QuorumErrataTx
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        QuorumErrataTx.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.attestations = [];
+            if (options.defaults)
+                object.errataTx = null;
+            if (message.errataTx != null && message.hasOwnProperty("errataTx"))
+                object.errataTx = $root.common.ErrataTx.toObject(message.errataTx, options);
+            if (message.attestations && message.attestations.length) {
+                object.attestations = [];
+                for (var j = 0; j < message.attestations.length; ++j)
+                    object.attestations[j] = $root.common.Attestation.toObject(message.attestations[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this QuorumErrataTx to JSON.
+         * @function toJSON
+         * @memberof common.QuorumErrataTx
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        QuorumErrataTx.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return QuorumErrataTx;
+    })();
+
+    common.AttestationBatch = (function() {
+
+        /**
+         * Properties of an AttestationBatch.
+         * @memberof common
+         * @interface IAttestationBatch
+         * @property {Array.<common.IAttestTx>|null} [attestTxs] AttestationBatch attestTxs
+         * @property {Array.<common.IAttestNetworkFee>|null} [attestNetworkFees] AttestationBatch attestNetworkFees
+         * @property {Array.<common.IAttestSolvency>|null} [attestSolvencies] AttestationBatch attestSolvencies
+         * @property {Array.<common.IAttestErrataTx>|null} [attestErrataTxs] AttestationBatch attestErrataTxs
+         */
+
+        /**
+         * Constructs a new AttestationBatch.
+         * @memberof common
+         * @classdesc Represents an AttestationBatch.
+         * @implements IAttestationBatch
+         * @constructor
+         * @param {common.IAttestationBatch=} [properties] Properties to set
+         */
+        function AttestationBatch(properties) {
+            this.attestTxs = [];
+            this.attestNetworkFees = [];
+            this.attestSolvencies = [];
+            this.attestErrataTxs = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * AttestationBatch attestTxs.
+         * @member {Array.<common.IAttestTx>} attestTxs
+         * @memberof common.AttestationBatch
+         * @instance
+         */
+        AttestationBatch.prototype.attestTxs = $util.emptyArray;
+
+        /**
+         * AttestationBatch attestNetworkFees.
+         * @member {Array.<common.IAttestNetworkFee>} attestNetworkFees
+         * @memberof common.AttestationBatch
+         * @instance
+         */
+        AttestationBatch.prototype.attestNetworkFees = $util.emptyArray;
+
+        /**
+         * AttestationBatch attestSolvencies.
+         * @member {Array.<common.IAttestSolvency>} attestSolvencies
+         * @memberof common.AttestationBatch
+         * @instance
+         */
+        AttestationBatch.prototype.attestSolvencies = $util.emptyArray;
+
+        /**
+         * AttestationBatch attestErrataTxs.
+         * @member {Array.<common.IAttestErrataTx>} attestErrataTxs
+         * @memberof common.AttestationBatch
+         * @instance
+         */
+        AttestationBatch.prototype.attestErrataTxs = $util.emptyArray;
+
+        /**
+         * Creates a new AttestationBatch instance using the specified properties.
+         * @function create
+         * @memberof common.AttestationBatch
+         * @static
+         * @param {common.IAttestationBatch=} [properties] Properties to set
+         * @returns {common.AttestationBatch} AttestationBatch instance
+         */
+        AttestationBatch.create = function create(properties) {
+            return new AttestationBatch(properties);
+        };
+
+        /**
+         * Encodes the specified AttestationBatch message. Does not implicitly {@link common.AttestationBatch.verify|verify} messages.
+         * @function encode
+         * @memberof common.AttestationBatch
+         * @static
+         * @param {common.IAttestationBatch} message AttestationBatch message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        AttestationBatch.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.attestTxs != null && message.attestTxs.length)
+                for (var i = 0; i < message.attestTxs.length; ++i)
+                    $root.common.AttestTx.encode(message.attestTxs[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.attestNetworkFees != null && message.attestNetworkFees.length)
+                for (var i = 0; i < message.attestNetworkFees.length; ++i)
+                    $root.common.AttestNetworkFee.encode(message.attestNetworkFees[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            if (message.attestSolvencies != null && message.attestSolvencies.length)
+                for (var i = 0; i < message.attestSolvencies.length; ++i)
+                    $root.common.AttestSolvency.encode(message.attestSolvencies[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+            if (message.attestErrataTxs != null && message.attestErrataTxs.length)
+                for (var i = 0; i < message.attestErrataTxs.length; ++i)
+                    $root.common.AttestErrataTx.encode(message.attestErrataTxs[i], writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified AttestationBatch message, length delimited. Does not implicitly {@link common.AttestationBatch.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common.AttestationBatch
+         * @static
+         * @param {common.IAttestationBatch} message AttestationBatch message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        AttestationBatch.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes an AttestationBatch message from the specified reader or buffer.
+         * @function decode
+         * @memberof common.AttestationBatch
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common.AttestationBatch} AttestationBatch
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        AttestationBatch.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common.AttestationBatch();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    if (!(message.attestTxs && message.attestTxs.length))
+                        message.attestTxs = [];
+                    message.attestTxs.push($root.common.AttestTx.decode(reader, reader.uint32()));
+                    break;
+                case 2:
+                    if (!(message.attestNetworkFees && message.attestNetworkFees.length))
+                        message.attestNetworkFees = [];
+                    message.attestNetworkFees.push($root.common.AttestNetworkFee.decode(reader, reader.uint32()));
+                    break;
+                case 3:
+                    if (!(message.attestSolvencies && message.attestSolvencies.length))
+                        message.attestSolvencies = [];
+                    message.attestSolvencies.push($root.common.AttestSolvency.decode(reader, reader.uint32()));
+                    break;
+                case 4:
+                    if (!(message.attestErrataTxs && message.attestErrataTxs.length))
+                        message.attestErrataTxs = [];
+                    message.attestErrataTxs.push($root.common.AttestErrataTx.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes an AttestationBatch message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common.AttestationBatch
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common.AttestationBatch} AttestationBatch
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        AttestationBatch.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies an AttestationBatch message.
+         * @function verify
+         * @memberof common.AttestationBatch
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        AttestationBatch.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.attestTxs != null && message.hasOwnProperty("attestTxs")) {
+                if (!Array.isArray(message.attestTxs))
+                    return "attestTxs: array expected";
+                for (var i = 0; i < message.attestTxs.length; ++i) {
+                    var error = $root.common.AttestTx.verify(message.attestTxs[i]);
+                    if (error)
+                        return "attestTxs." + error;
+                }
+            }
+            if (message.attestNetworkFees != null && message.hasOwnProperty("attestNetworkFees")) {
+                if (!Array.isArray(message.attestNetworkFees))
+                    return "attestNetworkFees: array expected";
+                for (var i = 0; i < message.attestNetworkFees.length; ++i) {
+                    var error = $root.common.AttestNetworkFee.verify(message.attestNetworkFees[i]);
+                    if (error)
+                        return "attestNetworkFees." + error;
+                }
+            }
+            if (message.attestSolvencies != null && message.hasOwnProperty("attestSolvencies")) {
+                if (!Array.isArray(message.attestSolvencies))
+                    return "attestSolvencies: array expected";
+                for (var i = 0; i < message.attestSolvencies.length; ++i) {
+                    var error = $root.common.AttestSolvency.verify(message.attestSolvencies[i]);
+                    if (error)
+                        return "attestSolvencies." + error;
+                }
+            }
+            if (message.attestErrataTxs != null && message.hasOwnProperty("attestErrataTxs")) {
+                if (!Array.isArray(message.attestErrataTxs))
+                    return "attestErrataTxs: array expected";
+                for (var i = 0; i < message.attestErrataTxs.length; ++i) {
+                    var error = $root.common.AttestErrataTx.verify(message.attestErrataTxs[i]);
+                    if (error)
+                        return "attestErrataTxs." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates an AttestationBatch message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common.AttestationBatch
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common.AttestationBatch} AttestationBatch
+         */
+        AttestationBatch.fromObject = function fromObject(object) {
+            if (object instanceof $root.common.AttestationBatch)
+                return object;
+            var message = new $root.common.AttestationBatch();
+            if (object.attestTxs) {
+                if (!Array.isArray(object.attestTxs))
+                    throw TypeError(".common.AttestationBatch.attestTxs: array expected");
+                message.attestTxs = [];
+                for (var i = 0; i < object.attestTxs.length; ++i) {
+                    if (typeof object.attestTxs[i] !== "object")
+                        throw TypeError(".common.AttestationBatch.attestTxs: object expected");
+                    message.attestTxs[i] = $root.common.AttestTx.fromObject(object.attestTxs[i]);
+                }
+            }
+            if (object.attestNetworkFees) {
+                if (!Array.isArray(object.attestNetworkFees))
+                    throw TypeError(".common.AttestationBatch.attestNetworkFees: array expected");
+                message.attestNetworkFees = [];
+                for (var i = 0; i < object.attestNetworkFees.length; ++i) {
+                    if (typeof object.attestNetworkFees[i] !== "object")
+                        throw TypeError(".common.AttestationBatch.attestNetworkFees: object expected");
+                    message.attestNetworkFees[i] = $root.common.AttestNetworkFee.fromObject(object.attestNetworkFees[i]);
+                }
+            }
+            if (object.attestSolvencies) {
+                if (!Array.isArray(object.attestSolvencies))
+                    throw TypeError(".common.AttestationBatch.attestSolvencies: array expected");
+                message.attestSolvencies = [];
+                for (var i = 0; i < object.attestSolvencies.length; ++i) {
+                    if (typeof object.attestSolvencies[i] !== "object")
+                        throw TypeError(".common.AttestationBatch.attestSolvencies: object expected");
+                    message.attestSolvencies[i] = $root.common.AttestSolvency.fromObject(object.attestSolvencies[i]);
+                }
+            }
+            if (object.attestErrataTxs) {
+                if (!Array.isArray(object.attestErrataTxs))
+                    throw TypeError(".common.AttestationBatch.attestErrataTxs: array expected");
+                message.attestErrataTxs = [];
+                for (var i = 0; i < object.attestErrataTxs.length; ++i) {
+                    if (typeof object.attestErrataTxs[i] !== "object")
+                        throw TypeError(".common.AttestationBatch.attestErrataTxs: object expected");
+                    message.attestErrataTxs[i] = $root.common.AttestErrataTx.fromObject(object.attestErrataTxs[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from an AttestationBatch message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common.AttestationBatch
+         * @static
+         * @param {common.AttestationBatch} message AttestationBatch
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        AttestationBatch.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults) {
+                object.attestTxs = [];
+                object.attestNetworkFees = [];
+                object.attestSolvencies = [];
+                object.attestErrataTxs = [];
+            }
+            if (message.attestTxs && message.attestTxs.length) {
+                object.attestTxs = [];
+                for (var j = 0; j < message.attestTxs.length; ++j)
+                    object.attestTxs[j] = $root.common.AttestTx.toObject(message.attestTxs[j], options);
+            }
+            if (message.attestNetworkFees && message.attestNetworkFees.length) {
+                object.attestNetworkFees = [];
+                for (var j = 0; j < message.attestNetworkFees.length; ++j)
+                    object.attestNetworkFees[j] = $root.common.AttestNetworkFee.toObject(message.attestNetworkFees[j], options);
+            }
+            if (message.attestSolvencies && message.attestSolvencies.length) {
+                object.attestSolvencies = [];
+                for (var j = 0; j < message.attestSolvencies.length; ++j)
+                    object.attestSolvencies[j] = $root.common.AttestSolvency.toObject(message.attestSolvencies[j], options);
+            }
+            if (message.attestErrataTxs && message.attestErrataTxs.length) {
+                object.attestErrataTxs = [];
+                for (var j = 0; j < message.attestErrataTxs.length; ++j)
+                    object.attestErrataTxs[j] = $root.common.AttestErrataTx.toObject(message.attestErrataTxs[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this AttestationBatch to JSON.
+         * @function toJSON
+         * @memberof common.AttestationBatch
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        AttestationBatch.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return AttestationBatch;
     })();
 
     return common;

--- a/packages/xchain-thornode/package.json
+++ b/packages/xchain-thornode/package.json
@@ -9,6 +9,7 @@
   ],
   "author": "THORChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-thornode/package.json
+++ b/packages/xchain-thornode/package.json
@@ -31,7 +31,7 @@
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
-    "test": "jest --passWithNoTests",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
     "generate:types": "yarn clean:types:thornode && yarn generate:types:thornode",
     "generate:types:thornode": "TS_POST_PROCESS_FILE=./node_modules/.bin/prettier openapi-generator-cli generate -i https://thornode.ninerealms.com/thorchain/doc/openapi.yaml -g typescript-axios -o ./src/generated/thornodeApi --skip-validate-spec --generate-alias-as-model",
     "clean:types:thornode": "rimraf ./src/generated/thornodeApi"

--- a/packages/xchain-thornode/package.json
+++ b/packages/xchain-thornode/package.json
@@ -10,8 +10,10 @@
   "author": "THORChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-thornode/package.json
+++ b/packages/xchain-thornode/package.json
@@ -10,7 +10,7 @@
   "author": "THORChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-thornode/rollup.config.js
+++ b/packages/xchain-thornode/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-thornode/rollup.config.js
+++ b/packages/xchain-thornode/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-util/jest.config.mjs
+++ b/packages/xchain-util/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
 }

--- a/packages/xchain-util/package.json
+++ b/packages/xchain-util/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0"
   },
   "dependencies": {
-    "bignumber.js": "^9.0.0"
+    "bignumber.js": "^9.1.2"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/xchain-util/package.json
+++ b/packages/xchain-util/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-util/package.json
+++ b/packages/xchain-util/package.json
@@ -9,6 +9,7 @@
   "author": "THORChain",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-util/package.json
+++ b/packages/xchain-util/package.json
@@ -30,7 +30,7 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0"
   },
   "dependencies": {

--- a/packages/xchain-util/package.json
+++ b/packages/xchain-util/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-util/rollup.config.js
+++ b/packages/xchain-util/rollup.config.js
@@ -21,7 +21,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-util/rollup.config.js
+++ b/packages/xchain-util/rollup.config.js
@@ -14,14 +14,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-utxo-providers/jest.config.e2e.mjs
+++ b/packages/xchain-utxo-providers/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-utxo-providers/jest.config.mjs
+++ b/packages/xchain-utxo-providers/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
 }

--- a/packages/xchain-utxo-providers/package.json
+++ b/packages/xchain-utxo-providers/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.3",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-utxo-providers/package.json
+++ b/packages/xchain-utxo-providers/package.json
@@ -3,8 +3,10 @@
   "version": "2.0.3",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-utxo-providers/package.json
+++ b/packages/xchain-utxo-providers/package.json
@@ -23,8 +23,8 @@
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
     "clean": "rm -rf .turbo && rm -rf lib",
-    "e2e": "jest --config jest.config.e2e.mjs",
-    "test": "jest "
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest "
   },
   "publishConfig": {
     "access": "public",

--- a/packages/xchain-utxo-providers/package.json
+++ b/packages/xchain-utxo-providers/package.json
@@ -2,6 +2,7 @@
   "name": "@xchainjs/xchain-utxo-providers",
   "version": "2.0.3",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-utxo-providers/rollup.config.js
+++ b/packages/xchain-utxo-providers/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-utxo-providers/rollup.config.js
+++ b/packages/xchain-utxo-providers/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-utxo/jest.config.mjs
+++ b/packages/xchain-utxo/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
 }

--- a/packages/xchain-utxo/package.json
+++ b/packages/xchain-utxo/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-utxo/package.json
+++ b/packages/xchain-utxo/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-utxo/package.json
+++ b/packages/xchain-utxo/package.json
@@ -9,6 +9,7 @@
   "author": "XChainJS",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-utxo/package.json
+++ b/packages/xchain-utxo/package.json
@@ -31,7 +31,7 @@
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
     "lint": "eslint \"{src,__tests__, __mocks__}/**/*.ts\" --fix --max-warnings 0",
-    "test": "jest"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/xchain-utxo/rollup.config.js
+++ b/packages/xchain-utxo/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-utxo/rollup.config.js
+++ b/packages/xchain-utxo/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-wallet/jest.config.e2e.mjs
+++ b/packages/xchain-wallet/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-wallet/jest.config.mjs
+++ b/packages/xchain-wallet/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
 }

--- a/packages/xchain-wallet/package.json
+++ b/packages/xchain-wallet/package.json
@@ -4,7 +4,7 @@
   "version": "2.0.10",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-wallet/package.json
+++ b/packages/xchain-wallet/package.json
@@ -24,8 +24,8 @@
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
     "clean": "rm -rf .turbo && rm -rf lib",
-    "e2e": "jest --config jest.config.e2e.mjs",
-    "test": "jest"
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/xchain-wallet/package.json
+++ b/packages/xchain-wallet/package.json
@@ -36,7 +36,7 @@
     "@xchainjs/xchain-thorchain": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
     "@xchainjs/xchain-utxo": "workspace:*",
-    "bignumber.js": "^9.0.0",
+    "bignumber.js": "^9.1.2",
     "ethers": "^6.14.3"
   },
   "devDependencies": {

--- a/packages/xchain-wallet/package.json
+++ b/packages/xchain-wallet/package.json
@@ -4,8 +4,10 @@
   "version": "2.0.10",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-wallet/package.json
+++ b/packages/xchain-wallet/package.json
@@ -3,6 +3,7 @@
   "description": "XChainjs clients wrapper to work with several chains at the same time",
   "version": "2.0.10",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-wallet/rollup.config.js
+++ b/packages/xchain-wallet/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: false,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-wallet/rollup.config.js
+++ b/packages/xchain-wallet/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: false,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: false,

--- a/packages/xchain-zcash/jest.config.e2e.mjs
+++ b/packages/xchain-zcash/jest.config.e2e.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
   testMatch: ['<rootDir>/__e2e__/**/*.[jt]s?(x)'],

--- a/packages/xchain-zcash/jest.config.mjs
+++ b/packages/xchain-zcash/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/lib'],
 }

--- a/packages/xchain-zcash/package.json
+++ b/packages/xchain-zcash/package.json
@@ -10,8 +10,10 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "type": "module",
-  "main": "lib/index.js",
-  "exports": "./lib/index.esm.js",
+  "exports": {
+    "require": "./lib/index.cjs",
+    "import": "./lib/index.esm.js"
+  },
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-zcash/package.json
+++ b/packages/xchain-zcash/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "lib": "lib",

--- a/packages/xchain-zcash/package.json
+++ b/packages/xchain-zcash/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf .turbo && rm -rf lib",
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "build:release": "yarn exec rm -rf release && yarn pack && yarn exec \"mkdir release && tar zxvf package.tgz --directory release && rm package.tgz\"",
-    "test": "jest",
-    "e2e": "jest --config jest.config.e2e.mjs",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.e2e.mjs",
     "lint": "eslint \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "postversion": "git push --follow-tags"
   },

--- a/packages/xchain-zcash/package.json
+++ b/packages/xchain-zcash/package.json
@@ -9,6 +9,7 @@
   "author": "XChainJS",
   "homepage": "https://github.com/xchainjs/xchainjs-lib",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "exports": "./lib/index.esm.js",
   "typings": "lib/index.d.ts",

--- a/packages/xchain-zcash/rollup.config.js
+++ b/packages/xchain-zcash/rollup.config.js
@@ -22,7 +22,7 @@ export default {
       sourcemap: true,
     },
     {
-      file: pkg.module,
+      file: pkg.exports,
       format: 'es',
       exports: 'named',
       sourcemap: true,

--- a/packages/xchain-zcash/rollup.config.js
+++ b/packages/xchain-zcash/rollup.config.js
@@ -15,14 +15,14 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: pkg.exports.require,
       format: 'cjs',
       interop: 'auto',
       exports: 'named',
       sourcemap: true,
     },
     {
-      file: pkg.exports,
+      file: pkg.exports.import,
       format: 'es',
       exports: 'named',
       sourcemap: true,

--- a/tools/txJammer/package.json
+++ b/tools/txJammer/package.json
@@ -31,7 +31,7 @@
     "@xchainjs/xchain-thornode": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
     "@xchainjs/xchain-wallet": "workspace:*",
-    "bignumber.js": "^9.0.0",
+    "bignumber.js": "^9.1.2",
     "commander": "^9.4.1",
     "weighted": "^1.0.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3953,7 +3953,7 @@ __metadata:
     "@xchainjs/xchain-evm": "workspace:*"
     "@xchainjs/xchain-evm-providers": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    bignumber.js: "npm:^9.0.0"
+    bignumber.js: "npm:^9.1.2"
     ethers: "npm:^6.14.3"
   languageName: unknown
   linkType: soft
@@ -3968,7 +3968,7 @@ __metadata:
     "@xchainjs/xchain-evm": "workspace:*"
     "@xchainjs/xchain-evm-providers": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    bignumber.js: "npm:^9.0.0"
+    bignumber.js: "npm:^9.1.2"
     ethers: "npm:^6.14.3"
   languageName: unknown
   linkType: soft
@@ -3982,7 +3982,7 @@ __metadata:
     "@xchainjs/xchain-evm": "workspace:*"
     "@xchainjs/xchain-evm-providers": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    bignumber.js: "npm:^9.0.0"
+    bignumber.js: "npm:^9.1.2"
     ethers: "npm:^6.14.3"
   languageName: unknown
   linkType: soft
@@ -4040,7 +4040,7 @@ __metadata:
     "@xchainjs/xchain-evm": "workspace:*"
     "@xchainjs/xchain-evm-providers": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    bignumber.js: "npm:^9.0.0"
+    bignumber.js: "npm:^9.1.2"
     ethers: "npm:^6.14.3"
   languageName: unknown
   linkType: soft
@@ -4107,7 +4107,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     axios: "npm:1.8.4"
     bech32: "npm:^1.1.3"
-    bignumber.js: "npm:^9.0.0"
+    bignumber.js: "npm:^9.1.2"
     cosmjs-types: "npm:0.9.0"
     protobufjs: "npm:6.11.4"
   languageName: unknown
@@ -4184,7 +4184,7 @@ __metadata:
     "@xchainjs/xchain-evm": "workspace:*"
     "@xchainjs/xchain-evm-providers": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    bignumber.js: "npm:^9.0.0"
+    bignumber.js: "npm:^9.1.2"
     ethers: "npm:^6.14.3"
   languageName: unknown
   linkType: soft
@@ -4214,7 +4214,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     axios: "npm:1.8.4"
     axios-mock-adapter: "npm:2.1.0"
-    bignumber.js: "npm:^9.0.0"
+    bignumber.js: "npm:^9.1.2"
     ethers: "npm:^6.14.3"
   languageName: unknown
   linkType: soft
@@ -4299,7 +4299,7 @@ __metadata:
     axios: "npm:1.8.4"
     axios-mock-adapter: "npm:2.1.0"
     axios-retry: "npm:3.2.5"
-    bignumber.js: "npm:^9.0.0"
+    bignumber.js: "npm:^9.1.2"
   languageName: unknown
   linkType: soft
 
@@ -4320,7 +4320,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     axios: "npm:1.8.4"
     bech32: "npm:^1.1.3"
-    bignumber.js: "npm:^9.0.0"
+    bignumber.js: "npm:^9.1.2"
     cosmjs-types: "npm:0.9.0"
     protobufjs: "npm:6.11.4"
   languageName: unknown
@@ -4466,7 +4466,7 @@ __metadata:
     axios: "npm:1.8.4"
     axios-mock-adapter: "npm:2.1.0"
     axios-retry: "npm:3.2.5"
-    bignumber.js: "npm:^9.0.0"
+    bignumber.js: "npm:^9.1.2"
   languageName: unknown
   linkType: soft
 
@@ -4490,7 +4490,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     axios: "npm:1.8.4"
     bech32: "npm:^1.1.3"
-    bignumber.js: "npm:^9.0.0"
+    bignumber.js: "npm:^9.1.2"
     cosmjs-types: "npm:0.9.0"
     protobufjs: "npm:6.11.4"
   languageName: unknown
@@ -4510,7 +4510,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@xchainjs/xchain-util@workspace:packages/xchain-util"
   dependencies:
-    bignumber.js: "npm:^9.0.0"
+    bignumber.js: "npm:^9.1.2"
   languageName: unknown
   linkType: soft
 
@@ -4550,7 +4550,7 @@ __metadata:
     "@xchainjs/xchain-thorchain": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-utxo": "workspace:*"
-    bignumber.js: "npm:^9.0.0"
+    bignumber.js: "npm:^9.1.2"
     ethers: "npm:^6.14.3"
   languageName: unknown
   linkType: soft
@@ -5111,14 +5111,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bignumber.js@npm:^9.0.0, bignumber.js@npm:^9.1.2":
+"bignumber.js@npm:^9.0.0":
   version: 9.1.2
   resolution: "bignumber.js@npm:9.1.2"
   checksum: 10c0/e17786545433f3110b868725c449fa9625366a6e675cd70eb39b60938d6adbd0158cb4b3ad4f306ce817165d37e63f4aa3098ba4110db1d9a3b9f66abfbaf10d
   languageName: node
   linkType: hard
 
-"bignumber.js@npm:^9.0.1, bignumber.js@npm:^9.2.0, bignumber.js@npm:^9.3.0":
+"bignumber.js@npm:^9.0.1, bignumber.js@npm:^9.1.2, bignumber.js@npm:^9.2.0, bignumber.js@npm:^9.3.0":
   version: 9.3.0
   resolution: "bignumber.js@npm:9.3.0"
   checksum: 10c0/f54a79cd6fc98552ac0510c1cd9381650870ae443bdb20ba9b98e3548188d941506ac3c22a9f9c69b2cc60da9be5700e87d3f54d2825310a8b2ae999dfd6d99d
@@ -11862,7 +11862,7 @@ __metadata:
     "@xchainjs/xchain-thornode": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-wallet": "workspace:*"
-    bignumber.js: "npm:^9.0.0"
+    bignumber.js: "npm:^9.1.2"
     commander: "npm:^9.4.1"
     weighted: "npm:^1.0.0"
   languageName: unknown
@@ -12497,7 +12497,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     axios: "npm:1.8.4"
     axios-retry: "npm:^3.2.5"
-    bignumber.js: "npm:^9.0.0"
+    bignumber.js: "npm:^9.1.2"
     rimraf: "npm:~3.0.2"
     ts-node: "npm:10.9.2"
     typescript: "npm:^5.0.4"
@@ -12560,7 +12560,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     axios: "npm:1.8.4"
     axios-retry: "npm:^3.2.5"
-    bignumber.js: "npm:^9.0.0"
+    bignumber.js: "npm:^9.1.2"
     rimraf: "npm:~3.0.2"
     ts-node: "npm:10.9.2"
     typescript: "npm:^5.0.4"
@@ -12582,7 +12582,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     axios: "npm:1.8.4"
     axios-retry: "npm:^3.2.5"
-    bignumber.js: "npm:^9.0.0"
+    bignumber.js: "npm:^9.1.2"
     rimraf: "npm:~3.0.2"
     ts-node: "npm:10.9.2"
     typescript: "npm:^5.0.4"
@@ -12612,7 +12612,7 @@ __metadata:
     bchaddrjs: "npm:^0.5.2"
     bech32: "npm:^2.0.0"
     bech32-buffer: "npm:^0.2.0"
-    bignumber.js: "npm:^9.0.0"
+    bignumber.js: "npm:^9.1.2"
     bitcoinjs-lib: "npm:^6.1.7"
     coinselect: "npm:^3.1.12"
     ethers: "npm:^6.14.3"


### PR DESCRIPTION
https://nodejs.org/api/packages.html#exports

Without this field, Node.js import logic believes it's just a CJS package - node doesn't recognize the old non-standard `"module"` field (while transpilers like webpack do).