### PR TITLE
consistent type exports

### DIFF
--- a/packages/xchain-aggregator/src/index.ts
+++ b/packages/xchain-aggregator/src/index.ts
@@ -1,5 +1,5 @@
 export { Aggregator } from './aggregator'
-export {
+export type {
   IProtocol,
   QuoteSwapParams,
   QuoteSwap,

--- a/packages/xchain-aggregator/src/types.ts
+++ b/packages/xchain-aggregator/src/types.ts
@@ -169,7 +169,7 @@ interface IProtocol {
   shouldBeApproved(params: IsApprovedParams): Promise<boolean>
 }
 
-export {
+export type {
   IProtocol,
   QuoteSwapParams,
   QuoteSwap,

--- a/packages/xchain-cosmos-sdk/src/index.ts
+++ b/packages/xchain-cosmos-sdk/src/index.ts
@@ -10,4 +10,4 @@ export * from './client'
  */
 export { base64ToBech32, bech32ToBase64, makeClientPath } from './utils'
 
-export { Balance, Tx, TxFrom, TxTo, TxsPage, CompatibleAsset, TxParams } from './types'
+export type { Balance, Tx, TxFrom, TxTo, TxsPage, CompatibleAsset, TxParams } from './types'

--- a/packages/xchain-cosmos/src/types/index.ts
+++ b/packages/xchain-cosmos/src/types/index.ts
@@ -1,3 +1,3 @@
 import { CompatibleAsset, TxOfflineParams, TxParams } from './types'
 
-export { TxOfflineParams, CompatibleAsset, TxParams }
+export type { TxOfflineParams, CompatibleAsset, TxParams }

--- a/packages/xchain-dash/src/types/index.ts
+++ b/packages/xchain-dash/src/types/index.ts
@@ -1,1 +1,1 @@
-export { DashPreparedTx, NodeAuth, NodeUrls } from './client-types'
+export type { DashPreparedTx, NodeAuth, NodeUrls } from './client-types'

--- a/packages/xchain-evm-providers/src/providers/index.ts
+++ b/packages/xchain-evm-providers/src/providers/index.ts
@@ -17,7 +17,7 @@ import {
 import { RoutescanProvider } from './routescan'
 
 export * from './covalent/covalent-data-provider'
-export {
+export type {
   GetBalanceResponse as CovalentGetBalanceResponse,
   LogEventParam as CovalentLogEventParam,
   LogEvent as CovalentLogEvent,
@@ -26,5 +26,5 @@ export {
   GetTransactionsResponse as CovalentGetTransactionsResponse,
   GetTransactionResponse as CovalentGetTransactionResponse,
   getTxsParams as CovalentgetTxsParams,
-  RoutescanProvider,
 }
+export { RoutescanProvider }

--- a/packages/xchain-evm/src/clients/index.ts
+++ b/packages/xchain-evm/src/clients/index.ts
@@ -1,2 +1,2 @@
-export { Client as ClientLedger, EVMClientParams } from './client'
-export { ClientKeystore, EVMKeystoreClientParams } from './clientKeystore'
+export { Client as ClientLedger, type EVMClientParams } from './client'
+export { ClientKeystore, type EVMKeystoreClientParams } from './clientKeystore'

--- a/packages/xchain-evm/src/index.ts
+++ b/packages/xchain-evm/src/index.ts
@@ -7,14 +7,14 @@ export {
   ClientLedger,
   ClientKeystore,
   ClientKeystore as Client,
-  EVMKeystoreClientParams,
-  EVMClientParams,
+  type EVMKeystoreClientParams,
+  type EVMClientParams,
 } from './clients'
 export default ClientKeystore
 
 export * from './types'
 
-export { KeystoreSigner, KeystoreSignerParams, LedgerSigner, LedgerSignerParams } from './signers'
+export { KeystoreSigner, type KeystoreSignerParams, LedgerSigner, type LedgerSignerParams } from './signers'
 
 // Exporting utility functions
 export {

--- a/packages/xchain-evm/src/signers/index.ts
+++ b/packages/xchain-evm/src/signers/index.ts
@@ -1,2 +1,2 @@
-export { KeystoreSigner, KeystoreSignerParams } from './keystoreSigner'
-export { LedgerSigner, LedgerSignerParams } from './ledgerSigner'
+export { KeystoreSigner, type KeystoreSignerParams } from './keystoreSigner'
+export { LedgerSigner, type LedgerSignerParams } from './ledgerSigner'

--- a/packages/xchain-evm/src/types/client-types.ts
+++ b/packages/xchain-evm/src/types/client-types.ts
@@ -73,4 +73,4 @@ export type TxParams = BaseTxParams & {
   isMemoEncoded?: boolean
 }
 
-export { CompatibleAsset, Balance, Tx, TxsPage }
+export type { CompatibleAsset, Balance, Tx, TxsPage }

--- a/packages/xchain-kujira/src/types/index.ts
+++ b/packages/xchain-kujira/src/types/index.ts
@@ -1,3 +1,3 @@
 import { CompatibleAsset, TxParams } from './types'
 
-export { CompatibleAsset, TxParams }
+export type { CompatibleAsset, TxParams }

--- a/packages/xchain-litecoin/src/index.ts
+++ b/packages/xchain-litecoin/src/index.ts
@@ -6,7 +6,7 @@ export * from './types'
 /**
  * Export the 'Client' class from the 'client' module.
  */
-export { NodeUrls, defaultLtcParams } from './client'
+export { type NodeUrls, defaultLtcParams } from './client'
 export { ClientKeystore, ClientKeystore as Client } from './ClientKeystore'
 export { ClientLedger } from './ClientLedger'
 

--- a/packages/xchain-mayachain/src/types/client-types.ts
+++ b/packages/xchain-mayachain/src/types/client-types.ts
@@ -21,4 +21,4 @@ export type TxParams = BaseTxParams & {
   asset?: CompatibleAsset
 }
 
-export { CompatibleAsset }
+export type { CompatibleAsset }

--- a/packages/xchain-thorchain/src/types/client-types.ts
+++ b/packages/xchain-thorchain/src/types/client-types.ts
@@ -21,4 +21,4 @@ export type TxOfflineParams = TxParams & {
   gasLimit?: BigNumber
 }
 
-export { CompatibleAsset }
+export type { CompatibleAsset }

--- a/packages/xchain-utxo-providers/src/providers/index.ts
+++ b/packages/xchain-utxo-providers/src/providers/index.ts
@@ -2,18 +2,18 @@ export * from './sochainv3/sochain-api-types'
 export * from './sochainv3/sochain-api'
 export * from './sochainv3/sochain-data-provider'
 
-export {
+export type {
   AddressDTO,
   AddressParams,
   AddressUTXO,
   BalanceData,
   GetTxsDTO,
-  HaskoinNetwork,
   HaskoinResponse,
   Transaction,
   TxConfirmedStatus,
   TxHashParams,
 } from './haskoin/haskoin-api-types'
+export { HaskoinNetwork } from './haskoin/haskoin-api-types'
 export {
   getAddress,
   getBalance,

--- a/packages/xchain-utxo/src/index.ts
+++ b/packages/xchain-utxo/src/index.ts
@@ -5,17 +5,5 @@ import { Balance, PreparedTx, Tx, TxFrom, TxParams, TxTo, TxsPage, UTXO, UtxoCli
 /**
  * Exported symbols from the `Client`, `UTXO`, `UtxoClientParams`, `Witness`, and `PreparedTx` modules.
  */
-export {
-  Client,
-  UTXO,
-  UtxoClientParams,
-  Witness,
-  PreparedTx,
-  Balance,
-  Tx,
-  TxsPage,
-  TxParams,
-  TxTo,
-  TxFrom,
-  toBitcoinJS,
-}
+export { Client, toBitcoinJS }
+export type { UTXO, UtxoClientParams, Witness, PreparedTx, Balance, Tx, TxsPage, TxParams, TxTo, TxFrom }

--- a/packages/xchain-utxo/src/types/index.ts
+++ b/packages/xchain-utxo/src/types/index.ts
@@ -1,3 +1,3 @@
 import { Balance, PreparedTx, Tx, TxFrom, TxParams, TxTo, TxsPage, UTXO, UtxoClientParams, Witness } from './types'
 
-export { UTXO, UtxoClientParams, Witness, PreparedTx, Balance, Tx, TxsPage, TxParams, TxFrom, TxTo }
+export type { UTXO, UtxoClientParams, Witness, PreparedTx, Balance, Tx, TxsPage, TxParams, TxFrom, TxTo }

--- a/packages/xchain-utxo/src/types/types.ts
+++ b/packages/xchain-utxo/src/types/types.ts
@@ -33,4 +33,4 @@ export type TxParams = BaseTxParams & {
 
 export type UtxoOnlineDataProviders = Record<Network, UtxoOnlineDataProvider | undefined>
 
-export { UTXO, Witness, Balance, Tx, TxsPage, TxFrom, TxTo }
+export type { UTXO, Witness, Balance, Tx, TxsPage, TxFrom, TxTo }

--- a/packages/xchain-wallet/src/index.ts
+++ b/packages/xchain-wallet/src/index.ts
@@ -8,4 +8,4 @@ import { Wallet } from './wallet'
  */
 export { Wallet }
 
-export { ChainBalances, EvmTxParams, UtxoTxParams, CosmosTxParams } from './types'
+export type { ChainBalances, EvmTxParams, UtxoTxParams, CosmosTxParams } from './types'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
       "es2017"
     ],
     "importHelpers": true,
+    "isolatedModules": true,
     "declaration": true,
     "strict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
https://www.typescriptlang.org/tsconfig/#isolatedModules

`jest` will automatically respect the local tsconfig.json, but seemingly only if it has this option set to `true`, because it transpiles 1 file at a time in isolation and can't know what's just a type and what isn't.