### PR TITLE
update for native thor.rujis support

### DIFF
--- a/.changeset/easy-crabs-relate.md
+++ b/.changeset/easy-crabs-relate.md
@@ -1,0 +1,6 @@
+---
+'@xchainjs/xchain-thorchain': patch
+'@xchainjs/xchain-util': patch
+---
+
+Update for native thor.ruji support

--- a/packages/xchain-thorchain/src/const.ts
+++ b/packages/xchain-thorchain/src/const.ts
@@ -29,6 +29,11 @@ export const RUNE_DENOM = 'rune'
 export const TCY_DENOM = 'tcy'
 
 /**
+ * Denomination of the ruji asset
+ */
+export const RUJI_DENOM = 'x/ruji'
+
+/**
  * Ticker symbol for the RUNE asset
  */
 export const RUNE_TICKER = 'RUNE'
@@ -37,6 +42,11 @@ export const RUNE_TICKER = 'RUNE'
  * Ticker symbol for the TCY asset
  */
 export const TCY_TICKER = 'TCY'
+
+/**
+ * Ticker symbol for the RUJI asset
+ */
+export const RUJI_TICKER = 'RUJI'
 
 /**
  * Default fee used by the client to make transactions
@@ -76,6 +86,16 @@ export const AssetTCY: TokenAsset = {
   symbol: TCY_TICKER,
   ticker: TCY_TICKER,
   type: AssetType.TOKEN,
+}
+
+/**
+ * Native asset representation for TCY in Thorchain
+ */
+export const AssetRUJI: Asset = {
+  chain: THORChain,
+  symbol: RUJI_TICKER,
+  ticker: RUJI_TICKER,
+  type: AssetType.NATIVE,
 }
 
 /**

--- a/packages/xchain-thorchain/src/utils.ts
+++ b/packages/xchain-thorchain/src/utils.ts
@@ -6,7 +6,15 @@ import { Network, RootDerivationPaths, TxHash } from '@xchainjs/xchain-client'
 import { Address, AssetType, assetToString, isSecuredAsset, isSynthAsset } from '@xchainjs/xchain-util' // Import axios for making HTTP requests
 import axios from 'axios'
 //Import necessary constants for default client URLs
-import { AssetRuneNative as AssetRUNE, AssetTCY, DEFAULT_EXPLORER_URL, RUNE_DENOM, TCY_DENOM } from './const'
+import {
+  AssetRUJI,
+  AssetRuneNative as AssetRUNE,
+  AssetTCY,
+  DEFAULT_EXPLORER_URL,
+  RUJI_DENOM,
+  RUNE_DENOM,
+  TCY_DENOM,
+} from './const'
 import { CompatibleAsset } from './types'
 
 /**
@@ -69,6 +77,14 @@ export const isAssetRuneNative = (asset: CompatibleAsset): boolean => assetToStr
 export const isTCYAsset = (asset: CompatibleAsset): boolean => assetToString(asset) === assetToString(AssetTCY)
 
 /**
+ * Checks whether an asset is the native RUJI asset
+ *
+ * @param {CompatibleAsset} asset
+ * @returns {boolean} `true` or `false`
+ */
+export const isRUJIAsset = (asset: CompatibleAsset): boolean => assetToString(asset) === assetToString(AssetRUJI)
+
+/**
  * Get denomination from Asset
  *
  * @param {CompatibleAsset} asset
@@ -79,6 +95,7 @@ export const getDenom = (asset: CompatibleAsset) => {
   if (isSynthAsset(asset)) return assetToString(asset).toLowerCase()
   if (isSecuredAsset(asset)) return assetToString(asset).toLowerCase()
   if (isTCYAsset(asset)) return TCY_DENOM
+  if (isRUJIAsset(asset)) return RUJI_DENOM
   return assetToString(asset).toLowerCase()
 }
 

--- a/packages/xchain-util/src/asset.ts
+++ b/packages/xchain-util/src/asset.ts
@@ -276,6 +276,7 @@ const assetConfigs = new Map<string, AnyAsset>([
   ['KUJI.USK', { chain: 'KUJI', symbol: 'USK', ticker: 'USK', type: AssetType.TOKEN }],
   ['MAYA.MAYA', { chain: 'MAYA', symbol: 'MAYA', ticker: 'MAYA', type: AssetType.TOKEN }],
   ['RUNE', { chain: 'THOR', symbol: 'RUNE', ticker: 'RUNE', type: AssetType.NATIVE }],
+  ['X/RUJI', { chain: 'THOR', symbol: 'RUJI', ticker: 'RUJI', type: AssetType.NATIVE }],
 ])
 
 // Helper function to create an asset from its components


### PR DESCRIPTION
balances were being returned like so.
<img width="191" alt="Screenshot 2025-06-30 at 4 29 59 PM" src="https://github.com/user-attachments/assets/931d50f5-1c1f-4adf-895e-8653c4689115" />

 since `X/RUJI` is unique it needs to be handled like so. Asset should be `THOR.RUJI` to work with thorchain's deposit & pool functions. 
 
 

