### PR TITLE
remove require() calls from tests

### DIFF
--- a/packages/xchain-aggregator/__mocks__/mayachain/mayanode/api.ts
+++ b/packages/xchain-aggregator/__mocks__/mayachain/mayanode/api.ts
@@ -5,13 +5,13 @@ export default {
   restore: mock.restore,
   init: () => {
     mock.onGet(/\/mayachain\/quote\/swap/).reply(async () => {
-      return [200, require('./responses/quoteSwap.json')]
+      return [200, (await import('./responses/quoteSwap.json', { with: { type: 'json' } })).default]
     })
     mock.onGet(/\/mayachain\/inbound_addresses/).reply(async () => {
-      return [200, require('./responses/inboundAddresses.json')]
+      return [200, (await import('./responses/inboundAddresses.json', { with: { type: 'json' } })).default]
     })
     mock.onGet(/\/mayachain\/mimir/).reply(async () => {
-      return [200, require('./responses/mimir.json')]
+      return [200, (await import('./responses/mimir.json', { with: { type: 'json' } })).default]
     })
   },
 }

--- a/packages/xchain-aggregator/__mocks__/mayachain/mayanode/api.ts
+++ b/packages/xchain-aggregator/__mocks__/mayachain/mayanode/api.ts
@@ -1,17 +1,19 @@
 import mock from '../../axios-adapter'
 
+const importjson = async (file) => (await import(file, { with: { type: 'json' } })).default
+
 export default {
   reset: mock.reset,
   restore: mock.restore,
   init: () => {
     mock.onGet(/\/mayachain\/quote\/swap/).reply(async () => {
-      return [200, (await import('./responses/quoteSwap.json', { with: { type: 'json' } })).default]
+      return [200, await importjson('./responses/quoteSwap.json')]
     })
     mock.onGet(/\/mayachain\/inbound_addresses/).reply(async () => {
-      return [200, (await import('./responses/inboundAddresses.json', { with: { type: 'json' } })).default]
+      return [200, await importjson('./responses/inboundAddresses.json')]
     })
     mock.onGet(/\/mayachain\/mimir/).reply(async () => {
-      return [200, (await import('./responses/mimir.json', { with: { type: 'json' } })).default]
+      return [200, await importjson('./responses/mimir.json')]
     })
   },
 }

--- a/packages/xchain-aggregator/__mocks__/mayachain/midgard/api.ts
+++ b/packages/xchain-aggregator/__mocks__/mayachain/midgard/api.ts
@@ -5,10 +5,10 @@ export default {
   restore: mock.restore,
   init: () => {
     mock.onGet(/v2\/pools/).reply(async () => {
-      return [200, require('./responses/pools.json')]
+      return [200, (await import('./responses/pools.json', { with: { type: 'json' } })).default]
     })
     mock.onGet(/\/v2\/actions?/).replyOnce(async () => {
-      const resp = require(`./responses/actions.json`)
+      const resp = (await import(`./responses/actions.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
   },

--- a/packages/xchain-aggregator/__mocks__/mayachain/midgard/api.ts
+++ b/packages/xchain-aggregator/__mocks__/mayachain/midgard/api.ts
@@ -1,14 +1,16 @@
 import mock from '../../axios-adapter'
 
+const importjson = async (file) => (await import(file, { with: { type: 'json' } })).default
+
 export default {
   reset: mock.reset,
   restore: mock.restore,
   init: () => {
     mock.onGet(/v2\/pools/).reply(async () => {
-      return [200, (await import('./responses/pools.json', { with: { type: 'json' } })).default]
+      return [200, await importjson('./responses/pools.json')]
     })
     mock.onGet(/\/v2\/actions?/).replyOnce(async () => {
-      const resp = (await import(`./responses/actions.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/actions.json`)
       return [200, resp]
     })
   },

--- a/packages/xchain-aggregator/__mocks__/thorchain/midgard/api.ts
+++ b/packages/xchain-aggregator/__mocks__/thorchain/midgard/api.ts
@@ -5,10 +5,10 @@ export default {
   restore: mock.restore,
   init: () => {
     mock.onGet(/v2\/pools/).reply(async () => {
-      return [200, require('./responses/pools.json')]
+      return [200, (await import('./responses/pools.json', { with: { type: 'json' } })).default]
     })
     mock.onGet(/\/v2\/actions?/).replyOnce(async () => {
-      const resp = require(`./responses/actions.json`)
+      const resp = (await import(`./responses/actions.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
   },

--- a/packages/xchain-aggregator/__mocks__/thorchain/midgard/api.ts
+++ b/packages/xchain-aggregator/__mocks__/thorchain/midgard/api.ts
@@ -1,14 +1,16 @@
 import mock from '../../axios-adapter'
 
+const importjson = async (file) => (await import(file, { with: { type: 'json' } })).default
+
 export default {
   reset: mock.reset,
   restore: mock.restore,
   init: () => {
     mock.onGet(/v2\/pools/).reply(async () => {
-      return [200, (await import('./responses/pools.json', { with: { type: 'json' } })).default]
+      return [200, await importjson('./responses/pools.json')]
     })
     mock.onGet(/\/v2\/actions?/).replyOnce(async () => {
-      const resp = (await import(`./responses/actions.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/actions.json`)
       return [200, resp]
     })
   },

--- a/packages/xchain-aggregator/__mocks__/thorchain/thornode/api.ts
+++ b/packages/xchain-aggregator/__mocks__/thorchain/thornode/api.ts
@@ -5,25 +5,25 @@ export default {
   restore: mock.restore,
   init: () => {
     mock.onGet(/\/pools/).reply(async () => {
-      return [200, require('./responses/pools.json')]
+      return [200, (await import('./responses/pools.json', { with: { type: 'json' } })).default]
     })
     mock.onGet(/\/thorchain\/quote\/swap/).reply(async (config) => {
       const parsedUrl = new URL(`${config.url}`)
       const from_asset = parsedUrl.searchParams.get('from_asset') ?? ''
       const to_asset = parsedUrl.searchParams.get('to_asset') ?? ''
       if (from_asset === 'AVAX~AVAX' && to_asset === 'ETH~ETH') {
-        return [200, require(`./responses/tradeSwap.json`)]
+        return [200, (await import(`./responses/tradeSwap.json`, { with: { type: 'json' } })).default]
       }
       if (from_asset === 'BTC.BTC' && to_asset === 'ETH.ETH') {
-        return [200, require('./responses/quoteSwap.json')]
+        return [200, (await import('./responses/quoteSwap.json', { with: { type: 'json' } })).default]
       }
       return [500, { error: 'Not found' }]
     })
     mock.onGet(/\/thorchain\/inbound_addresses/).reply(async () => {
-      return [200, require('./responses/inboundAddresses.json')]
+      return [200, (await import('./responses/inboundAddresses.json', { with: { type: 'json' } })).default]
     })
     mock.onGet(/\/thorchain\/mimir/).reply(async () => {
-      return [200, require('./responses/mimir.json')]
+      return [200, (await import('./responses/mimir.json', { with: { type: 'json' } })).default]
     })
   },
 }

--- a/packages/xchain-aggregator/__mocks__/thorchain/thornode/api.ts
+++ b/packages/xchain-aggregator/__mocks__/thorchain/thornode/api.ts
@@ -1,29 +1,31 @@
 import mock from '../../axios-adapter'
 
+const importjson = async (file) => (await import(file, { with: { type: 'json' } })).default
+
 export default {
   reset: mock.reset,
   restore: mock.restore,
   init: () => {
     mock.onGet(/\/pools/).reply(async () => {
-      return [200, (await import('./responses/pools.json', { with: { type: 'json' } })).default]
+      return [200, await importjson('./responses/pools.json')]
     })
     mock.onGet(/\/thorchain\/quote\/swap/).reply(async (config) => {
       const parsedUrl = new URL(`${config.url}`)
       const from_asset = parsedUrl.searchParams.get('from_asset') ?? ''
       const to_asset = parsedUrl.searchParams.get('to_asset') ?? ''
       if (from_asset === 'AVAX~AVAX' && to_asset === 'ETH~ETH') {
-        return [200, (await import(`./responses/tradeSwap.json`, { with: { type: 'json' } })).default]
+        return [200, await importjson(`./responses/tradeSwap.json`)]
       }
       if (from_asset === 'BTC.BTC' && to_asset === 'ETH.ETH') {
-        return [200, (await import('./responses/quoteSwap.json', { with: { type: 'json' } })).default]
+        return [200, await importjson('./responses/quoteSwap.json')]
       }
       return [500, { error: 'Not found' }]
     })
     mock.onGet(/\/thorchain\/inbound_addresses/).reply(async () => {
-      return [200, (await import('./responses/inboundAddresses.json', { with: { type: 'json' } })).default]
+      return [200, await importjson('./responses/inboundAddresses.json')]
     })
     mock.onGet(/\/thorchain\/mimir/).reply(async () => {
-      return [200, (await import('./responses/mimir.json', { with: { type: 'json' } })).default]
+      return [200, await importjson('./responses/mimir.json')]
     })
   },
 }

--- a/packages/xchain-bitcoin/__mocks__/axios-adapter.ts
+++ b/packages/xchain-bitcoin/__mocks__/axios-adapter.ts
@@ -4,3 +4,5 @@ import MockAdapter from 'axios-mock-adapter'
 const mock = new MockAdapter(axios)
 
 export default mock
+
+export const importjson = async (file) => (await import(file, { with: { type: 'json' } })).default

--- a/packages/xchain-bitcoin/__mocks__/bitgo.ts
+++ b/packages/xchain-bitcoin/__mocks__/bitgo.ts
@@ -5,7 +5,7 @@ export default {
   init: () => {
     //Mock GET https://{{bitgourl}}/api/v2/{{coin}}/tx/fee
     mock.onGet(/\/api\/v2\/\w+\/tx\/fee/).reply(async () => {
-      const resp = require(`./response/bitgo/get-fee-estimate.json`)
+      const resp = (await import(`./response/bitgo/get-fee-estimate.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
   },

--- a/packages/xchain-bitcoin/__mocks__/bitgo.ts
+++ b/packages/xchain-bitcoin/__mocks__/bitgo.ts
@@ -1,11 +1,11 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 export default {
   restore: mock.restore,
   init: () => {
     //Mock GET https://{{bitgourl}}/api/v2/{{coin}}/tx/fee
     mock.onGet(/\/api\/v2\/\w+\/tx\/fee/).reply(async () => {
-      const resp = (await import(`./response/bitgo/get-fee-estimate.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/bitgo/get-fee-estimate.json`)
       return [200, resp]
     })
   },

--- a/packages/xchain-bitcoin/__mocks__/haskoin.ts
+++ b/packages/xchain-bitcoin/__mocks__/haskoin.ts
@@ -10,13 +10,13 @@ export default {
     //Mock GET https://{haskoinurl}/{btc|btctest}/address/{address}/balance
     mock.onGet(/\/address\/\w+\/balance/).reply(async (config: MockConfig) => {
       const address = config.url?.split('/')?.[5] ?? ''
-      const resp = require(`./response/balances/${address}.json`)
+      const resp = (await import(`./response/balances/${address}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock Get utxo's
     mock.onGet(/\/address\/\w+\/unspent/).reply(async (config: MockConfig) => {
       const address = config.url?.split('/')?.[5] ?? ''
-      const resp = require(`./response/unspent-txs/${address}.json`)
+      const resp = (await import(`./response/unspent-txs/${address}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock POST https://{haskoinurl}/{btc|btctest}/transactions

--- a/packages/xchain-bitcoin/__mocks__/haskoin.ts
+++ b/packages/xchain-bitcoin/__mocks__/haskoin.ts
@@ -1,4 +1,4 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 type MockConfig = {
   url?: string
@@ -10,13 +10,13 @@ export default {
     //Mock GET https://{haskoinurl}/{btc|btctest}/address/{address}/balance
     mock.onGet(/\/address\/\w+\/balance/).reply(async (config: MockConfig) => {
       const address = config.url?.split('/')?.[5] ?? ''
-      const resp = (await import(`./response/balances/${address}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/balances/${address}.json`)
       return [200, resp]
     })
     //Mock Get utxo's
     mock.onGet(/\/address\/\w+\/unspent/).reply(async (config: MockConfig) => {
       const address = config.url?.split('/')?.[5] ?? ''
-      const resp = (await import(`./response/unspent-txs/${address}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/unspent-txs/${address}.json`)
       return [200, resp]
     })
     //Mock POST https://{haskoinurl}/{btc|btctest}/transactions

--- a/packages/xchain-bitcoin/__mocks__/sochain.ts
+++ b/packages/xchain-bitcoin/__mocks__/sochain.ts
@@ -10,14 +10,14 @@ export default {
     //Mock addresses summary
     mock.onGet(/\/address_summary\//).reply(async (config: MockConfig) => {
       const id: string = config.url?.split('/').pop() ?? ''
-      const resp = require(`./response/addresses/${id}.json`)
+      const resp = (await import(`./response/addresses/${id}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     //Mock get transaction data
     mock.onGet(/\/v3\/transaction\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = require(`./response/tx/${id}.json`)
+      const resp = (await import(`./response/tx/${id}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
@@ -25,14 +25,14 @@ export default {
     mock.onGet(/\/v3\/transactions\//).reply(async (config: MockConfig) => {
       const split = config.url?.split('/')
       const address = split?.[7] || ''
-      const resp = require(`./response/txs/${address}.json`)
+      const resp = (await import(`./response/txs/${address}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     //Mock get_address_balance
     mock.onGet(/\/balance\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = require(`./response/balances/${id}.json`)
+      const resp = (await import(`./response/balances/${id}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
@@ -49,14 +49,14 @@ export default {
         // this allows you to return utxos starting from a given page
         filePath = `./response/unspent-txs/${address}/${page}.json`
       }
-      const resp = require(filePath)
+      const resp = (await import(filePath, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     //Mock is_tx_confirmed
     mock.onGet(/\/is_tx_confirmed\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = require(`./response/is-tx-confirmed/${id}.json`)
+      const resp = (await import(`./response/is-tx-confirmed/${id}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
@@ -67,18 +67,19 @@ export default {
     //
     //Mock thorchain/inbound_addresses
     mock.onGet(/\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = require(`./response/thornode/inbound_addresses.json`)
+      const resp = (await import(`./response/thornode/inbound_addresses.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     //Mock thorchain/mimir
     mock.onGet(/\/thorchain\/mimir/).reply(async () => {
-      const resp = require(`./response/thornode/mimir.json`)
+      const resp = (await import(`./response/thornode/mimir.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     mock.onPost(/\/broadcast_transaction/).reply(async () => {
-      const resp = require(`./response/broadcast_tx/broadcast_transaction.json`)
+      const resp = (await import(`./response/broadcast_tx/broadcast_transaction.json`, { with: { type: 'json' } }))
+        .default
       return [200, resp]
     })
   },

--- a/packages/xchain-bitcoin/__mocks__/sochain.ts
+++ b/packages/xchain-bitcoin/__mocks__/sochain.ts
@@ -1,4 +1,4 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 type MockConfig = {
   url?: string
@@ -10,14 +10,14 @@ export default {
     //Mock addresses summary
     mock.onGet(/\/address_summary\//).reply(async (config: MockConfig) => {
       const id: string = config.url?.split('/').pop() ?? ''
-      const resp = (await import(`./response/addresses/${id}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/addresses/${id}.json`)
       return [200, resp]
     })
 
     //Mock get transaction data
     mock.onGet(/\/v3\/transaction\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = (await import(`./response/tx/${id}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/tx/${id}.json`)
       return [200, resp]
     })
 
@@ -25,14 +25,14 @@ export default {
     mock.onGet(/\/v3\/transactions\//).reply(async (config: MockConfig) => {
       const split = config.url?.split('/')
       const address = split?.[7] || ''
-      const resp = (await import(`./response/txs/${address}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/txs/${address}.json`)
       return [200, resp]
     })
 
     //Mock get_address_balance
     mock.onGet(/\/balance\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = (await import(`./response/balances/${id}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/balances/${id}.json`)
       return [200, resp]
     })
 
@@ -49,14 +49,14 @@ export default {
         // this allows you to return utxos starting from a given page
         filePath = `./response/unspent-txs/${address}/${page}.json`
       }
-      const resp = (await import(filePath, { with: { type: 'json' } })).default
+      const resp = await importjson(filePath)
       return [200, resp]
     })
 
     //Mock is_tx_confirmed
     mock.onGet(/\/is_tx_confirmed\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = (await import(`./response/is-tx-confirmed/${id}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/is-tx-confirmed/${id}.json`)
       return [200, resp]
     })
 
@@ -67,19 +67,18 @@ export default {
     //
     //Mock thorchain/inbound_addresses
     mock.onGet(/\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = (await import(`./response/thornode/inbound_addresses.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/thornode/inbound_addresses.json`)
       return [200, resp]
     })
 
     //Mock thorchain/mimir
     mock.onGet(/\/thorchain\/mimir/).reply(async () => {
-      const resp = (await import(`./response/thornode/mimir.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/thornode/mimir.json`)
       return [200, resp]
     })
 
     mock.onPost(/\/broadcast_transaction/).reply(async () => {
-      const resp = (await import(`./response/broadcast_tx/broadcast_transaction.json`, { with: { type: 'json' } }))
-        .default
+      const resp = await importjson(`./response/broadcast_tx/broadcast_transaction.json`)
       return [200, resp]
     })
   },

--- a/packages/xchain-bitcoincash/__mocks__/axios-adapter.ts
+++ b/packages/xchain-bitcoincash/__mocks__/axios-adapter.ts
@@ -4,3 +4,5 @@ import MockAdapter from 'axios-mock-adapter'
 const mock = new MockAdapter(axios)
 
 export default mock
+
+export const importjson = async (file) => (await import(file, { with: { type: 'json' } })).default

--- a/packages/xchain-bitcoincash/__mocks__/haskoin.ts
+++ b/packages/xchain-bitcoincash/__mocks__/haskoin.ts
@@ -10,31 +10,31 @@ export default {
     //Mock GET https://{haskoinurl}/{bch|bchtest}/address/{address}/balance
     mock.onGet(/\/address\/\w+\/balance/).reply(async (config: MockConfig) => {
       const address = config.url?.split('/')?.[5] ?? ''
-      const resp = require(`./response/balances/${address}.json`)
+      const resp = (await import(`./response/balances/${address}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     }),
       //Mock GET https://{haskoinurl}/{bch|bchtest}/transaction/{hash}/raw
       mock.onGet(/\/transaction\/\w+\/raw/).reply(async (config: MockConfig) => {
         const id = config.url?.split('/')?.[5] ?? ''
-        const resp = require(`./response/txs/raw-${id}.json`)
+        const resp = (await import(`./response/txs/raw-${id}.json`, { with: { type: 'json' } })).default
         return [200, resp]
       }),
       //Mock GET https://{haskoinurl}/{bch|bchtest}/address/{address}/unspent
       mock.onGet(/\/address\/\w+\/unspent/).reply(async (config: MockConfig) => {
         const address = config.url?.split('/')?.[5] ?? ''
-        const resp = require(`./response/balances/unspent-${address}.json`)
+        const resp = (await import(`./response/balances/unspent-${address}.json`, { with: { type: 'json' } })).default
         return [200, resp]
       }),
       //Mock GET https://{haskoinurl}/{bch|bchtest}/address/{address}/transactions/full
       mock.onGet(/\/address\/\w+\/transactions\/full/).reply(async (config: MockConfig) => {
         const address = config.url?.split('/')?.[5] ?? ''
-        const resp = require(`./response/txs/full-${address}.json`)
+        const resp = (await import(`./response/txs/full-${address}.json`, { with: { type: 'json' } })).default
         return [200, resp]
       }),
       //Mock GET https://{haskoinurl}/{bch|bchtest}/transactioin/{id}
       mock.onGet(/\/transaction\/\w+/).reply(async (config: MockConfig) => {
         const id = config.url?.split('/')?.[5] ?? ''
-        const resp = require(`./response/txs/${id}.json`)
+        const resp = (await import(`./response/txs/${id}.json`, { with: { type: 'json' } })).default
         return [200, resp]
       }),
       //Mock POST https://{haskoinurl}/{btc|btctest}/transactions

--- a/packages/xchain-bitcoincash/__mocks__/haskoin.ts
+++ b/packages/xchain-bitcoincash/__mocks__/haskoin.ts
@@ -1,4 +1,4 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 type MockConfig = {
   url?: string
@@ -10,31 +10,31 @@ export default {
     //Mock GET https://{haskoinurl}/{bch|bchtest}/address/{address}/balance
     mock.onGet(/\/address\/\w+\/balance/).reply(async (config: MockConfig) => {
       const address = config.url?.split('/')?.[5] ?? ''
-      const resp = (await import(`./response/balances/${address}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/balances/${address}.json`)
       return [200, resp]
     }),
       //Mock GET https://{haskoinurl}/{bch|bchtest}/transaction/{hash}/raw
       mock.onGet(/\/transaction\/\w+\/raw/).reply(async (config: MockConfig) => {
         const id = config.url?.split('/')?.[5] ?? ''
-        const resp = (await import(`./response/txs/raw-${id}.json`, { with: { type: 'json' } })).default
+        const resp = await importjson(`./response/txs/raw-${id}.json`)
         return [200, resp]
       }),
       //Mock GET https://{haskoinurl}/{bch|bchtest}/address/{address}/unspent
       mock.onGet(/\/address\/\w+\/unspent/).reply(async (config: MockConfig) => {
         const address = config.url?.split('/')?.[5] ?? ''
-        const resp = (await import(`./response/balances/unspent-${address}.json`, { with: { type: 'json' } })).default
+        const resp = await importjson(`./response/balances/unspent-${address}.json`)
         return [200, resp]
       }),
       //Mock GET https://{haskoinurl}/{bch|bchtest}/address/{address}/transactions/full
       mock.onGet(/\/address\/\w+\/transactions\/full/).reply(async (config: MockConfig) => {
         const address = config.url?.split('/')?.[5] ?? ''
-        const resp = (await import(`./response/txs/full-${address}.json`, { with: { type: 'json' } })).default
+        const resp = await importjson(`./response/txs/full-${address}.json`)
         return [200, resp]
       }),
       //Mock GET https://{haskoinurl}/{bch|bchtest}/transactioin/{id}
       mock.onGet(/\/transaction\/\w+/).reply(async (config: MockConfig) => {
         const id = config.url?.split('/')?.[5] ?? ''
-        const resp = (await import(`./response/txs/${id}.json`, { with: { type: 'json' } })).default
+        const resp = await importjson(`./response/txs/${id}.json`)
         return [200, resp]
       }),
       //Mock POST https://{haskoinurl}/{btc|btctest}/transactions

--- a/packages/xchain-bitcoincash/__mocks__/thornode.ts
+++ b/packages/xchain-bitcoincash/__mocks__/thornode.ts
@@ -5,19 +5,20 @@ export default {
   init: () => {
     //Mock testnet thorchain/inbound_addresses
     mock.onGet(/testnet(.*)\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = require(`./response/thornode/inbound_addresses_testnet.json`)
+      const resp = (await import(`./response/thornode/inbound_addresses_testnet.json`, { with: { type: 'json' } }))
+        .default
       return [200, resp]
     })
 
     //Mock thorchain/inbound_addresses
     mock.onGet(/\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = require(`./response/thornode/inbound_addresses.json`)
+      const resp = (await import(`./response/thornode/inbound_addresses.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     //Mock thorchain/mimir
     mock.onGet(/\/thorchain\/mimir/).reply(async () => {
-      const resp = require(`./response/thornode/mimir.json`)
+      const resp = (await import(`./response/thornode/mimir.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
   },

--- a/packages/xchain-bitcoincash/__mocks__/thornode.ts
+++ b/packages/xchain-bitcoincash/__mocks__/thornode.ts
@@ -1,24 +1,23 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 export default {
   restore: mock.restore,
   init: () => {
     //Mock testnet thorchain/inbound_addresses
     mock.onGet(/testnet(.*)\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = (await import(`./response/thornode/inbound_addresses_testnet.json`, { with: { type: 'json' } }))
-        .default
+      const resp = await importjson(`./response/thornode/inbound_addresses_testnet.json`)
       return [200, resp]
     })
 
     //Mock thorchain/inbound_addresses
     mock.onGet(/\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = (await import(`./response/thornode/inbound_addresses.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/thornode/inbound_addresses.json`)
       return [200, resp]
     })
 
     //Mock thorchain/mimir
     mock.onGet(/\/thorchain\/mimir/).reply(async () => {
-      const resp = (await import(`./response/thornode/mimir.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/thornode/mimir.json`)
       return [200, resp]
     })
   },

--- a/packages/xchain-dash/__mocks__/dash-mocks.ts
+++ b/packages/xchain-dash/__mocks__/dash-mocks.ts
@@ -11,12 +11,14 @@ const mocks = {
   restore: axiosMockAdapter.restore,
   mockThorchain: () => {
     axiosMockAdapter.onGet(/testnet(.*)\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = require(`./response/thornode-testnet-inbound-addresses.json`)
+      const resp = (await import(`./response/thornode-testnet-inbound-addresses.json`, { with: { type: 'json' } }))
+        .default
       return [200, resp]
     })
 
     axiosMockAdapter.onGet(/\/inbound_addresses/).reply(async () => {
-      const resp = require(`./response/thornode-mainnet-inbound-addresses.json`)
+      const resp = (await import(`./response/thornode-mainnet-inbound-addresses.json`, { with: { type: 'json' } }))
+        .default
       return [200, resp]
     })
   },
@@ -33,28 +35,33 @@ const mocks = {
     const getAddressPattern = /insight-api\/addr\/(\w+)$/
     axiosMockAdapter.onGet(getAddressPattern).reply(async (config: MockConfig) => {
       const address = config.url?.match(getAddressPattern)?.[1]
-      const resp = require(`./response/insight-addr-${address?.substr(0, 4)}.json`)
+      const resp = (await import(`./response/insight-addr-${address?.substr(0, 4)}.json`, { with: { type: 'json' } }))
+        .default
       return [200, resp]
     })
 
     const getAddressUnspentTransactionsPattern = /insight-api\/addr\/(\w+)\/utxo$/
     axiosMockAdapter.onGet(getAddressUnspentTransactionsPattern).reply(async (config: MockConfig) => {
       const address = config.url?.match(getAddressUnspentTransactionsPattern)?.[1]
-      const resp = require(`./response/insight-addr-utxos-${address?.substr(0, 4)}.json`)
+      const resp = (
+        await import(`./response/insight-addr-utxos-${address?.substr(0, 4)}.json`, { with: { type: 'json' } })
+      ).default
       return [200, resp]
     })
 
     const getAddressTransactionsPattern = /insight-api\/txs\?address=(\w+)/
     axiosMockAdapter.onGet(getAddressTransactionsPattern).reply(async (config: MockConfig) => {
       const address = config.url?.match(getAddressTransactionsPattern)?.[1]
-      const resp = require(`./response/insight-txs-${address?.substr(0, 4)}.json`)
+      const resp = (await import(`./response/insight-txs-${address?.substr(0, 4)}.json`, { with: { type: 'json' } }))
+        .default
       return [200, resp]
     })
 
     const getTransactionPattern = /insight-api\/tx\/(\w+)/
     axiosMockAdapter.onGet(getTransactionPattern).reply(async (config: MockConfig) => {
       const txid = config.url?.match(getTransactionPattern)?.[1]
-      const resp = require(`./response/insight-tx-${txid?.substr(0, 4)}.json`)
+      const resp = (await import(`./response/insight-tx-${txid?.substr(0, 4)}.json`, { with: { type: 'json' } }))
+        .default
       return [200, resp]
     })
   },

--- a/packages/xchain-dash/__mocks__/dash-mocks.ts
+++ b/packages/xchain-dash/__mocks__/dash-mocks.ts
@@ -7,18 +7,18 @@ type MockConfig = {
 
 const axiosMockAdapter = new MockAdapter(axios)
 
+const importjson = async (file) => (await import(file, { with: { type: 'json' } })).default
+
 const mocks = {
   restore: axiosMockAdapter.restore,
   mockThorchain: () => {
     axiosMockAdapter.onGet(/testnet(.*)\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = (await import(`./response/thornode-testnet-inbound-addresses.json`, { with: { type: 'json' } }))
-        .default
+      const resp = await importjson(`./response/thornode-testnet-inbound-addresses.json`)
       return [200, resp]
     })
 
     axiosMockAdapter.onGet(/\/inbound_addresses/).reply(async () => {
-      const resp = (await import(`./response/thornode-mainnet-inbound-addresses.json`, { with: { type: 'json' } }))
-        .default
+      const resp = await importjson(`./response/thornode-mainnet-inbound-addresses.json`)
       return [200, resp]
     })
   },
@@ -35,33 +35,28 @@ const mocks = {
     const getAddressPattern = /insight-api\/addr\/(\w+)$/
     axiosMockAdapter.onGet(getAddressPattern).reply(async (config: MockConfig) => {
       const address = config.url?.match(getAddressPattern)?.[1]
-      const resp = (await import(`./response/insight-addr-${address?.substr(0, 4)}.json`, { with: { type: 'json' } }))
-        .default
+      const resp = await importjson(`./response/insight-addr-${address?.substr(0, 4)}.json`)
       return [200, resp]
     })
 
     const getAddressUnspentTransactionsPattern = /insight-api\/addr\/(\w+)\/utxo$/
     axiosMockAdapter.onGet(getAddressUnspentTransactionsPattern).reply(async (config: MockConfig) => {
       const address = config.url?.match(getAddressUnspentTransactionsPattern)?.[1]
-      const resp = (
-        await import(`./response/insight-addr-utxos-${address?.substr(0, 4)}.json`, { with: { type: 'json' } })
-      ).default
+      const resp = await importjson(`./response/insight-addr-utxos-${address?.substr(0, 4)}.json`)
       return [200, resp]
     })
 
     const getAddressTransactionsPattern = /insight-api\/txs\?address=(\w+)/
     axiosMockAdapter.onGet(getAddressTransactionsPattern).reply(async (config: MockConfig) => {
       const address = config.url?.match(getAddressTransactionsPattern)?.[1]
-      const resp = (await import(`./response/insight-txs-${address?.substr(0, 4)}.json`, { with: { type: 'json' } }))
-        .default
+      const resp = await importjson(`./response/insight-txs-${address?.substr(0, 4)}.json`)
       return [200, resp]
     })
 
     const getTransactionPattern = /insight-api\/tx\/(\w+)/
     axiosMockAdapter.onGet(getTransactionPattern).reply(async (config: MockConfig) => {
       const txid = config.url?.match(getTransactionPattern)?.[1]
-      const resp = (await import(`./response/insight-tx-${txid?.substr(0, 4)}.json`, { with: { type: 'json' } }))
-        .default
+      const resp = await importjson(`./response/insight-tx-${txid?.substr(0, 4)}.json`)
       return [200, resp]
     })
   },

--- a/packages/xchain-doge/__mocks__/axios-adapter.ts
+++ b/packages/xchain-doge/__mocks__/axios-adapter.ts
@@ -4,3 +4,5 @@ import MockAdapter from 'axios-mock-adapter'
 const mock = new MockAdapter(axios)
 
 export default mock
+
+export const importjson = async (file) => (await import(file, { with: { type: 'json' } })).default

--- a/packages/xchain-doge/__mocks__/blockcypher.ts
+++ b/packages/xchain-doge/__mocks__/blockcypher.ts
@@ -9,7 +9,7 @@ export default {
   init: () => {
     mock.onGet(/\/addrs\//).reply(async (config: MockConfig) => {
       const id: string = config.url?.split('/').pop() ?? ''
-      const resp = require(`./response/addresses/${id}.json`)
+      const resp = (await import(`./response/addresses/${id}.json`, { with: { type: 'json' } })).default
       console.log(resp)
       return [200, resp]
     })
@@ -17,7 +17,7 @@ export default {
     //Mock get transaction data
     mock.onGet(/\/transaction\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = require(`./response/tx/${id}.json`)
+      const resp = (await import(`./response/tx/${id}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
@@ -25,14 +25,14 @@ export default {
     mock.onGet(/\/txs\//).reply(async (config: MockConfig) => {
       const split = config.url?.split('/')
       const address = split?.[7] || ''
-      const resp = require(`./response/txs/${address}.json`)
+      const resp = (await import(`./response/txs/${address}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     //Mock get balance for address
     mock.onGet(/\/balance\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = require(`./response/balances/${id}.json`)
+      const resp = (await import(`./response/balances/${id}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
@@ -48,7 +48,7 @@ export default {
         // this allows you to page utxos starting from a given txid
         filePath = `./response/unspent-txs/${address}/${startingfrompage}.json`
       }
-      const resp = require(filePath)
+      const resp = (await import(filePath, { with: { type: 'json' } })).default
       return [200, resp]
     })
     // Mock send tx

--- a/packages/xchain-doge/__mocks__/blockcypher.ts
+++ b/packages/xchain-doge/__mocks__/blockcypher.ts
@@ -1,4 +1,4 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 type MockConfig = {
   url?: string
@@ -9,7 +9,7 @@ export default {
   init: () => {
     mock.onGet(/\/addrs\//).reply(async (config: MockConfig) => {
       const id: string = config.url?.split('/').pop() ?? ''
-      const resp = (await import(`./response/addresses/${id}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/addresses/${id}.json`)
       console.log(resp)
       return [200, resp]
     })
@@ -17,7 +17,7 @@ export default {
     //Mock get transaction data
     mock.onGet(/\/transaction\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = (await import(`./response/tx/${id}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/tx/${id}.json`)
       return [200, resp]
     })
 
@@ -25,14 +25,14 @@ export default {
     mock.onGet(/\/txs\//).reply(async (config: MockConfig) => {
       const split = config.url?.split('/')
       const address = split?.[7] || ''
-      const resp = (await import(`./response/txs/${address}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/txs/${address}.json`)
       return [200, resp]
     })
 
     //Mock get balance for address
     mock.onGet(/\/balance\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = (await import(`./response/balances/${id}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/balances/${id}.json`)
       return [200, resp]
     })
 
@@ -48,7 +48,7 @@ export default {
         // this allows you to page utxos starting from a given txid
         filePath = `./response/unspent-txs/${address}/${startingfrompage}.json`
       }
-      const resp = (await import(filePath, { with: { type: 'json' } })).default
+      const resp = await importjson(filePath)
       return [200, resp]
     })
     // Mock send tx

--- a/packages/xchain-doge/__mocks__/sochain.ts
+++ b/packages/xchain-doge/__mocks__/sochain.ts
@@ -10,14 +10,14 @@ export default {
     //Mock address
     mock.onGet(/\/address_summary\//).reply(async (config: MockConfig) => {
       const id: string = config.url?.split('/').pop() ?? ''
-      const resp = require(`./response/addresses/${id}.json`)
+      const resp = (await import(`./response/addresses/${id}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     //Mock get transaction data
     mock.onGet(/\/transaction\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = require(`./response/tx/${id}.json`)
+      const resp = (await import(`./response/tx/${id}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
@@ -25,14 +25,14 @@ export default {
     mock.onGet(/\/v3\/transactions\//).reply(async (config: MockConfig) => {
       const split = config.url?.split('/')
       const address = split?.[7] || ''
-      const resp = require(`./response/txs/${address}.json`)
+      const resp = (await import(`./response/txs/${address}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     //Mock get balance for address
     mock.onGet(/\/balance\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = require(`./response/balances/${id}.json`)
+      const resp = (await import(`./response/balances/${id}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
@@ -48,13 +48,14 @@ export default {
         // this allows you to page utxos starting from a given txid
         filePath = `./response/unspent-txs/${address}/${startingfrompage}.json`
       }
-      const resp = require(filePath)
+      const resp = (await import(filePath, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     // Mock broad cast tx
     mock.onPost(/\/broadcast_transaction/).reply(async () => {
-      const resp = require(`./response/broadcast_tx/broadcast_transaction.json`)
+      const resp = (await import(`./response/broadcast_tx/broadcast_transaction.json`, { with: { type: 'json' } }))
+        .default
       return [200, resp]
     })
   },

--- a/packages/xchain-doge/__mocks__/sochain.ts
+++ b/packages/xchain-doge/__mocks__/sochain.ts
@@ -1,4 +1,4 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 type MockConfig = {
   url?: string
@@ -10,14 +10,14 @@ export default {
     //Mock address
     mock.onGet(/\/address_summary\//).reply(async (config: MockConfig) => {
       const id: string = config.url?.split('/').pop() ?? ''
-      const resp = (await import(`./response/addresses/${id}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/addresses/${id}.json`)
       return [200, resp]
     })
 
     //Mock get transaction data
     mock.onGet(/\/transaction\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = (await import(`./response/tx/${id}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/tx/${id}.json`)
       return [200, resp]
     })
 
@@ -25,14 +25,14 @@ export default {
     mock.onGet(/\/v3\/transactions\//).reply(async (config: MockConfig) => {
       const split = config.url?.split('/')
       const address = split?.[7] || ''
-      const resp = (await import(`./response/txs/${address}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/txs/${address}.json`)
       return [200, resp]
     })
 
     //Mock get balance for address
     mock.onGet(/\/balance\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = (await import(`./response/balances/${id}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/balances/${id}.json`)
       return [200, resp]
     })
 
@@ -48,14 +48,13 @@ export default {
         // this allows you to page utxos starting from a given txid
         filePath = `./response/unspent-txs/${address}/${startingfrompage}.json`
       }
-      const resp = (await import(filePath, { with: { type: 'json' } })).default
+      const resp = await importjson(filePath)
       return [200, resp]
     })
 
     // Mock broad cast tx
     mock.onPost(/\/broadcast_transaction/).reply(async () => {
-      const resp = (await import(`./response/broadcast_tx/broadcast_transaction.json`, { with: { type: 'json' } }))
-        .default
+      const resp = await importjson(`./response/broadcast_tx/broadcast_transaction.json`)
       return [200, resp]
     })
   },

--- a/packages/xchain-doge/__mocks__/thornode.ts
+++ b/packages/xchain-doge/__mocks__/thornode.ts
@@ -5,19 +5,20 @@ export default {
   init: () => {
     //Mock testnet thorchain/inbound_addresses
     mock.onGet(/testnet(.*)\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = require(`./response/thornode/inbound_addresses_testnet.json`)
+      const resp = (await import(`./response/thornode/inbound_addresses_testnet.json`, { with: { type: 'json' } }))
+        .default
       return [200, resp]
     })
 
     //Mock thorchain/inbound_addresses
     mock.onGet(/\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = require(`./response/thornode/inbound_addresses.json`)
+      const resp = (await import(`./response/thornode/inbound_addresses.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     //Mock thorchain/mimir
     mock.onGet(/\/thorchain\/mimir/).reply(async () => {
-      const resp = require(`./response/thornode/mimir.json`)
+      const resp = (await import(`./response/thornode/mimir.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
   },

--- a/packages/xchain-doge/__mocks__/thornode.ts
+++ b/packages/xchain-doge/__mocks__/thornode.ts
@@ -1,24 +1,23 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 export default {
   restore: mock.restore,
   init: () => {
     //Mock testnet thorchain/inbound_addresses
     mock.onGet(/testnet(.*)\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = (await import(`./response/thornode/inbound_addresses_testnet.json`, { with: { type: 'json' } }))
-        .default
+      const resp = await importjson(`./response/thornode/inbound_addresses_testnet.json`)
       return [200, resp]
     })
 
     //Mock thorchain/inbound_addresses
     mock.onGet(/\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = (await import(`./response/thornode/inbound_addresses.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/thornode/inbound_addresses.json`)
       return [200, resp]
     })
 
     //Mock thorchain/mimir
     mock.onGet(/\/thorchain\/mimir/).reply(async () => {
-      const resp = (await import(`./response/thornode/mimir.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/thornode/mimir.json`)
       return [200, resp]
     })
   },

--- a/packages/xchain-litecoin/__mocks__/axios-adapter.ts
+++ b/packages/xchain-litecoin/__mocks__/axios-adapter.ts
@@ -4,3 +4,5 @@ import MockAdapter from 'axios-mock-adapter'
 const mock = new MockAdapter(axios)
 
 export default mock
+
+export const importjson = async (file) => (await import(file, { with: { type: 'json' } })).default

--- a/packages/xchain-litecoin/__mocks__/sochain.ts
+++ b/packages/xchain-litecoin/__mocks__/sochain.ts
@@ -10,28 +10,28 @@ export default {
     //Mock address
     mock.onGet(/\/address_summary\//).reply(async (config: MockConfig) => {
       const id: string = config.url?.split('/').pop() ?? ''
-      const resp = require(`./response/addresses/${id}.json`)
+      const resp = (await import(`./response/addresses/${id}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     //Mock gettx
     mock.onGet(/\/transaction\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = require(`./response/tx/${id}.json`)
+      const resp = (await import(`./response/tx/${id}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock gettxs
     mock.onGet(/\/transactions\//).reply(async (config: MockConfig) => {
       const split = config.url?.split('/')
       const address = split?.[7] || ''
-      const resp = require(`./response/txs/${address}.json`)
+      const resp = (await import(`./response/txs/${address}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     //Mock get_address_balance
     mock.onGet(/\/balance\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = require(`./response/balances/${id}.json`)
+      const resp = (await import(`./response/balances/${id}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
@@ -48,7 +48,7 @@ export default {
         // this allows you to page utxos starting from a given txid
         filePath = `./response/unspent_outputs/${address}/${page}.json`
       }
-      const resp = require(filePath)
+      const resp = (await import(filePath, { with: { type: 'json' } })).default
       return [200, resp]
     })
   },

--- a/packages/xchain-litecoin/__mocks__/sochain.ts
+++ b/packages/xchain-litecoin/__mocks__/sochain.ts
@@ -1,4 +1,4 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 type MockConfig = {
   url?: string
@@ -10,28 +10,28 @@ export default {
     //Mock address
     mock.onGet(/\/address_summary\//).reply(async (config: MockConfig) => {
       const id: string = config.url?.split('/').pop() ?? ''
-      const resp = (await import(`./response/addresses/${id}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/addresses/${id}.json`)
       return [200, resp]
     })
 
     //Mock gettx
     mock.onGet(/\/transaction\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = (await import(`./response/tx/${id}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/tx/${id}.json`)
       return [200, resp]
     })
     //Mock gettxs
     mock.onGet(/\/transactions\//).reply(async (config: MockConfig) => {
       const split = config.url?.split('/')
       const address = split?.[7] || ''
-      const resp = (await import(`./response/txs/${address}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/txs/${address}.json`)
       return [200, resp]
     })
 
     //Mock get_address_balance
     mock.onGet(/\/balance\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = (await import(`./response/balances/${id}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/balances/${id}.json`)
       return [200, resp]
     })
 
@@ -48,7 +48,7 @@ export default {
         // this allows you to page utxos starting from a given txid
         filePath = `./response/unspent_outputs/${address}/${page}.json`
       }
-      const resp = (await import(filePath, { with: { type: 'json' } })).default
+      const resp = await importjson(filePath)
       return [200, resp]
     })
   },

--- a/packages/xchain-litecoin/__mocks__/thornode-api.ts
+++ b/packages/xchain-litecoin/__mocks__/thornode-api.ts
@@ -5,19 +5,19 @@ export default {
   init: () => {
     //Mock testnet thorchain/inbound_addresses
     mock.onGet(/testnet(.*)\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = require(`./response/inbound_addresses/testnet.json`)
+      const resp = (await import(`./response/inbound_addresses/testnet.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     // inbound_addresses
     mock.onGet(/\/inbound_addresses/).reply(async () => {
-      const resp = require(`./response/inbound_addresses/mainnet.json`)
+      const resp = (await import(`./response/inbound_addresses/mainnet.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     //Mock thorchain/mimir
     mock.onGet(/\/thorchain\/mimir/).reply(async () => {
-      const resp = require(`./response/thornode/mimir.json`)
+      const resp = (await import(`./response/thornode/mimir.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 

--- a/packages/xchain-litecoin/__mocks__/thornode-api.ts
+++ b/packages/xchain-litecoin/__mocks__/thornode-api.ts
@@ -1,23 +1,23 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 export default {
   restore: mock.restore,
   init: () => {
     //Mock testnet thorchain/inbound_addresses
     mock.onGet(/testnet(.*)\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = (await import(`./response/inbound_addresses/testnet.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/inbound_addresses/testnet.json`)
       return [200, resp]
     })
 
     // inbound_addresses
     mock.onGet(/\/inbound_addresses/).reply(async () => {
-      const resp = (await import(`./response/inbound_addresses/mainnet.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/inbound_addresses/mainnet.json`)
       return [200, resp]
     })
 
     //Mock thorchain/mimir
     mock.onGet(/\/thorchain\/mimir/).reply(async () => {
-      const resp = (await import(`./response/thornode/mimir.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/thornode/mimir.json`)
       return [200, resp]
     })
 

--- a/packages/xchain-mayachain-amm/__mocks__/mayanode-api/mayanode-api.ts
+++ b/packages/xchain-mayachain-amm/__mocks__/mayanode-api/mayanode-api.ts
@@ -5,12 +5,12 @@ export default {
   init: () => {
     // Mimir
     mock.onGet(/\/mayachain\/mimir/).reply(async () => {
-      const resp = require(`./responses/mimir.json`)
+      const resp = (await import(`./responses/mimir.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     // Inbound addresses
     mock.onGet(/\/mayachain\/inbound_addresses/).reply(async () => {
-      const resp = require(`./responses/inbound-addresses.json`)
+      const resp = (await import(`./responses/inbound-addresses.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     // Quote swap
@@ -19,18 +19,18 @@ export default {
       const from_asset = parsedUrl.searchParams.get('from_asset') ?? ''
       const to_asset = parsedUrl.searchParams.get('to_asset') ?? ''
       if (from_asset === 'THOR.RUNE' && to_asset === 'BTC.BTC') {
-        const resp = require(`./responses/quote-swap.json`)
+        const resp = (await import(`./responses/quote-swap.json`, { with: { type: 'json' } })).default
         return [200, resp]
       }
       if (from_asset === 'ETH.ETH' && to_asset === 'BTC.BTC') {
-        const resp = require(`./responses/quote-sswap.json`)
+        const resp = (await import(`./responses/quote-sswap.json`, { with: { type: 'json' } })).default
         return [200, resp]
       }
       return [200, {}]
     })
     // Latest block
     mock.onGet(/\/mayachain\/lastblock/).reply(async () => {
-      const resp = require(`./responses/latestBlock.json`)
+      const resp = (await import(`./responses/latestBlock.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
   },

--- a/packages/xchain-mayachain-amm/__mocks__/mayanode-api/mayanode-api.ts
+++ b/packages/xchain-mayachain-amm/__mocks__/mayanode-api/mayanode-api.ts
@@ -1,16 +1,18 @@
 import mock from '../axios-adapter'
 
+const importjson = async (file) => (await import(file, { with: { type: 'json' } })).default
+
 export default {
   restore: mock.restore,
   init: () => {
     // Mimir
     mock.onGet(/\/mayachain\/mimir/).reply(async () => {
-      const resp = (await import(`./responses/mimir.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/mimir.json`)
       return [200, resp]
     })
     // Inbound addresses
     mock.onGet(/\/mayachain\/inbound_addresses/).reply(async () => {
-      const resp = (await import(`./responses/inbound-addresses.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/inbound-addresses.json`)
       return [200, resp]
     })
     // Quote swap
@@ -19,18 +21,18 @@ export default {
       const from_asset = parsedUrl.searchParams.get('from_asset') ?? ''
       const to_asset = parsedUrl.searchParams.get('to_asset') ?? ''
       if (from_asset === 'THOR.RUNE' && to_asset === 'BTC.BTC') {
-        const resp = (await import(`./responses/quote-swap.json`, { with: { type: 'json' } })).default
+        const resp = await importjson(`./responses/quote-swap.json`)
         return [200, resp]
       }
       if (from_asset === 'ETH.ETH' && to_asset === 'BTC.BTC') {
-        const resp = (await import(`./responses/quote-sswap.json`, { with: { type: 'json' } })).default
+        const resp = await importjson(`./responses/quote-sswap.json`)
         return [200, resp]
       }
       return [200, {}]
     })
     // Latest block
     mock.onGet(/\/mayachain\/lastblock/).reply(async () => {
-      const resp = (await import(`./responses/latestBlock.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/latestBlock.json`)
       return [200, resp]
     })
   },

--- a/packages/xchain-mayachain-amm/__mocks__/midgard-api/midgard-api.ts
+++ b/packages/xchain-mayachain-amm/__mocks__/midgard-api/midgard-api.ts
@@ -11,13 +11,13 @@ export default {
     mock.onGet(/\/v2\/mayaname\/lookup\/\w+/).reply(async (config: MockConfig) => {
       const mayaname = config.url?.split('/')?.[6] ?? ''
       if (mayaname === 'eld') {
-        const resp = require(`./responses/mayaname-details.json`)
+        const resp = (await import(`./responses/mayaname-details.json`, { with: { type: 'json' } })).default
         return [200, resp]
       }
       return [404, 'Not found']
     })
     mock.onGet(/\/v2\/mayaname\/rlookup\/maya1gnehec7mf4uytuw3wj4uwpptvkyvzclgq2lj09/).reply(async () => {
-      const resp = require(`./responses/owner.json`)
+      const resp = (await import(`./responses/owner.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
   },

--- a/packages/xchain-mayachain-amm/__mocks__/midgard-api/midgard-api.ts
+++ b/packages/xchain-mayachain-amm/__mocks__/midgard-api/midgard-api.ts
@@ -4,6 +4,8 @@ type MockConfig = {
   url?: string
 }
 
+const importjson = async (file) => (await import(file, { with: { type: 'json' } })).default
+
 export default {
   restore: mock.restore,
   init: () => {
@@ -11,13 +13,13 @@ export default {
     mock.onGet(/\/v2\/mayaname\/lookup\/\w+/).reply(async (config: MockConfig) => {
       const mayaname = config.url?.split('/')?.[6] ?? ''
       if (mayaname === 'eld') {
-        const resp = (await import(`./responses/mayaname-details.json`, { with: { type: 'json' } })).default
+        const resp = await importjson(`./responses/mayaname-details.json`)
         return [200, resp]
       }
       return [404, 'Not found']
     })
     mock.onGet(/\/v2\/mayaname\/rlookup\/maya1gnehec7mf4uytuw3wj4uwpptvkyvzclgq2lj09/).reply(async () => {
-      const resp = (await import(`./responses/owner.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/owner.json`)
       return [200, resp]
     })
   },

--- a/packages/xchain-mayachain-query/__mocks__/axios-adapter.ts
+++ b/packages/xchain-mayachain-query/__mocks__/axios-adapter.ts
@@ -4,3 +4,5 @@ import MockAdapter from 'axios-mock-adapter'
 const mock = new MockAdapter(axios)
 
 export default mock
+
+export const importjson = async (file) => (await import(file, { with: { type: 'json' } })).default

--- a/packages/xchain-mayachain-query/__mocks__/mayanode-api.ts
+++ b/packages/xchain-mayachain-query/__mocks__/mayanode-api.ts
@@ -11,29 +11,29 @@ export default {
 
       // Should fetch BTC to ETH swap
       if (from_asset === 'BTC.BTC' && to_asset === 'ETH.ETH') {
-        const resp = require(`./responses/mayanode/QuoteSwapBtcEth.json`)
+        const resp = (await import(`./responses/mayanode/QuoteSwapBtcEth.json`, { with: { type: 'json' } })).default
         return [200, resp]
       }
 
       // Should fetch RUNE to BTC swap
       if (from_asset === 'THOR.RUNE' && to_asset === 'BTC.BTC') {
-        const resp = require(`./responses/mayanode/QuoteSwapRuneBtc.json`)
+        const resp = (await import(`./responses/mayanode/QuoteSwapRuneBtc.json`, { with: { type: 'json' } })).default
         return [200, resp]
       }
 
       if (from_asset === 'ETH.ETH' && to_asset === 'BTC.BTC') {
-        const resp = require(`./responses/mayanode/QuoteSSwapEthBtc.json`)
+        const resp = (await import(`./responses/mayanode/QuoteSSwapEthBtc.json`, { with: { type: 'json' } })).default
         return [200, resp]
       }
 
       return [200, {}]
     })
     mock.onGet(/\/mayachain\/mimir/).reply(async () => {
-      const resp = require(`./responses/mayanode/mimir.json`)
+      const resp = (await import(`./responses/mayanode/mimir.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     mock.onGet(/\/mayachain\/lastblock/).reply(async () => {
-      const resp = require(`./responses/mayanode/latestBlock.json`)
+      const resp = (await import(`./responses/mayanode/latestBlock.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
   },

--- a/packages/xchain-mayachain-query/__mocks__/mayanode-api.ts
+++ b/packages/xchain-mayachain-query/__mocks__/mayanode-api.ts
@@ -1,4 +1,4 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 export default {
   reset: mock.reset,
@@ -11,29 +11,29 @@ export default {
 
       // Should fetch BTC to ETH swap
       if (from_asset === 'BTC.BTC' && to_asset === 'ETH.ETH') {
-        const resp = (await import(`./responses/mayanode/QuoteSwapBtcEth.json`, { with: { type: 'json' } })).default
+        const resp = await importjson(`./responses/mayanode/QuoteSwapBtcEth.json`)
         return [200, resp]
       }
 
       // Should fetch RUNE to BTC swap
       if (from_asset === 'THOR.RUNE' && to_asset === 'BTC.BTC') {
-        const resp = (await import(`./responses/mayanode/QuoteSwapRuneBtc.json`, { with: { type: 'json' } })).default
+        const resp = await importjson(`./responses/mayanode/QuoteSwapRuneBtc.json`)
         return [200, resp]
       }
 
       if (from_asset === 'ETH.ETH' && to_asset === 'BTC.BTC') {
-        const resp = (await import(`./responses/mayanode/QuoteSSwapEthBtc.json`, { with: { type: 'json' } })).default
+        const resp = await importjson(`./responses/mayanode/QuoteSSwapEthBtc.json`)
         return [200, resp]
       }
 
       return [200, {}]
     })
     mock.onGet(/\/mayachain\/mimir/).reply(async () => {
-      const resp = (await import(`./responses/mayanode/mimir.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/mayanode/mimir.json`)
       return [200, resp]
     })
     mock.onGet(/\/mayachain\/lastblock/).reply(async () => {
-      const resp = (await import(`./responses/mayanode/latestBlock.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/mayanode/latestBlock.json`)
       return [200, resp]
     })
   },

--- a/packages/xchain-mayachain-query/__mocks__/midgard-api.ts
+++ b/packages/xchain-mayachain-query/__mocks__/midgard-api.ts
@@ -5,19 +5,19 @@ export default {
   restore: mock.restore,
   init: () => {
     mock.onGet(/\/v2\/actions/).reply(async () => {
-      const resp = require(`./responses/midgard/actions.json`)
+      const resp = (await import(`./responses/midgard/actions.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     mock.onGet(/\/v2\/pools/).reply(async () => {
-      const resp = require(`./responses/midgard/pools.json`)
+      const resp = (await import(`./responses/midgard/pools.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     mock.onGet(/\/v2\/mayaname\/lookup\/eld/).reply(async () => {
-      const resp = require(`./responses/midgard/mayaname.json`)
+      const resp = (await import(`./responses/midgard/mayaname.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     mock.onGet(/\/v2\/mayaname\/rlookup\/maya13x0f2r0jltfplmxe40cc67hhca27np34ezmcjn/).reply(async () => {
-      const resp = require(`./responses/midgard/owner.json`)
+      const resp = (await import(`./responses/midgard/owner.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
   },

--- a/packages/xchain-mayachain-query/__mocks__/midgard-api.ts
+++ b/packages/xchain-mayachain-query/__mocks__/midgard-api.ts
@@ -1,23 +1,23 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 export default {
   reset: mock.reset,
   restore: mock.restore,
   init: () => {
     mock.onGet(/\/v2\/actions/).reply(async () => {
-      const resp = (await import(`./responses/midgard/actions.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/midgard/actions.json`)
       return [200, resp]
     })
     mock.onGet(/\/v2\/pools/).reply(async () => {
-      const resp = (await import(`./responses/midgard/pools.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/midgard/pools.json`)
       return [200, resp]
     })
     mock.onGet(/\/v2\/mayaname\/lookup\/eld/).reply(async () => {
-      const resp = (await import(`./responses/midgard/mayaname.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/midgard/mayaname.json`)
       return [200, resp]
     })
     mock.onGet(/\/v2\/mayaname\/rlookup\/maya13x0f2r0jltfplmxe40cc67hhca27np34ezmcjn/).reply(async () => {
-      const resp = (await import(`./responses/midgard/owner.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/midgard/owner.json`)
       return [200, resp]
     })
   },

--- a/packages/xchain-mayamidgard-query/__mocks__/midgard/axios-adapter.ts
+++ b/packages/xchain-mayamidgard-query/__mocks__/midgard/axios-adapter.ts
@@ -4,3 +4,5 @@ import MockAdapter from 'axios-mock-adapter'
 const mock = new MockAdapter(axios)
 
 export default mock
+
+export const importjson = async (file) => (await import(file, { with: { type: 'json' } })).default

--- a/packages/xchain-mayamidgard-query/__mocks__/midgard/midgardApi.ts
+++ b/packages/xchain-mayamidgard-query/__mocks__/midgard/midgardApi.ts
@@ -5,11 +5,11 @@ export default {
   init: () => {
     //Mock GET https://{{midgard}}/v2/pools
     mock.onGet(/\/v2\/pools/).reply(async () => {
-      const resp = require(`./responses/pools.json`)
+      const resp = (await import(`./responses/pools.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     mock.onGet(/\/v2\/actions/).reply(async () => {
-      const resp = require(`./responses/actions.json`)
+      const resp = (await import(`./responses/actions.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
   },

--- a/packages/xchain-mayamidgard-query/__mocks__/midgard/midgardApi.ts
+++ b/packages/xchain-mayamidgard-query/__mocks__/midgard/midgardApi.ts
@@ -1,15 +1,15 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 export default {
   restore: mock.restore,
   init: () => {
     //Mock GET https://{{midgard}}/v2/pools
     mock.onGet(/\/v2\/pools/).reply(async () => {
-      const resp = (await import(`./responses/pools.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/pools.json`)
       return [200, resp]
     })
     mock.onGet(/\/v2\/actions/).reply(async () => {
-      const resp = (await import(`./responses/actions.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/actions.json`)
       return [200, resp]
     })
   },

--- a/packages/xchain-midgard-query/__mocks__/axios-adapter.ts
+++ b/packages/xchain-midgard-query/__mocks__/axios-adapter.ts
@@ -4,3 +4,5 @@ import MockAdapter from 'axios-mock-adapter'
 const mock = new MockAdapter(axios)
 
 export default mock
+
+export const importjson = async (file) => (await import(file, { with: { type: 'json' } })).default

--- a/packages/xchain-midgard-query/__mocks__/midgard-api.ts
+++ b/packages/xchain-midgard-query/__mocks__/midgard-api.ts
@@ -6,32 +6,32 @@ export default {
   init: () => {
     //Mock midgard pools
     mock.onGet(/\/v2\/pools/).reply(async () => {
-      const resp = require(`./responses/midgard/pools.json`)
+      const resp = (await import(`./responses/midgard/pools.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock thorchain/mimir
     mock.onGet(/\/v2\/thorchain\/mimir/).reply(async () => {
-      const resp = require(`./responses/mimir/mimirConstants.json`)
+      const resp = (await import(`./responses/mimir/mimirConstants.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock thorchain/mimir
     mock.onGet(/\/v2\/thorchain\/constants/).reply(async () => {
-      const resp = require(`./responses/thorchain/thorchainConstants.json`)
+      const resp = (await import(`./responses/thorchain/thorchainConstants.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock thorchain/mimir
     mock.onGet(/\/v2\/thorchain\/queue/).reply(async () => {
-      const resp = require(`./responses/thorchain/outboundQueue.json`)
+      const resp = (await import(`./responses/thorchain/outboundQueue.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock midgard health
     mock.onGet(/\/v2\/health/).reply(async () => {
-      const resp = require(`./responses/midgard/health.json`)
+      const resp = (await import(`./responses/midgard/health.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock midgard actions
     mock.onGet(/\/v2\/actions?/).reply(async () => {
-      const resp = require(`./responses/midgard/actions.json`)
+      const resp = (await import(`./responses/midgard/actions.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
   },

--- a/packages/xchain-midgard-query/__mocks__/midgard-api.ts
+++ b/packages/xchain-midgard-query/__mocks__/midgard-api.ts
@@ -1,4 +1,4 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 export default {
   reset: mock.reset,
@@ -6,32 +6,32 @@ export default {
   init: () => {
     //Mock midgard pools
     mock.onGet(/\/v2\/pools/).reply(async () => {
-      const resp = (await import(`./responses/midgard/pools.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/midgard/pools.json`)
       return [200, resp]
     })
     //Mock thorchain/mimir
     mock.onGet(/\/v2\/thorchain\/mimir/).reply(async () => {
-      const resp = (await import(`./responses/mimir/mimirConstants.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/mimir/mimirConstants.json`)
       return [200, resp]
     })
     //Mock thorchain/mimir
     mock.onGet(/\/v2\/thorchain\/constants/).reply(async () => {
-      const resp = (await import(`./responses/thorchain/thorchainConstants.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thorchain/thorchainConstants.json`)
       return [200, resp]
     })
     //Mock thorchain/mimir
     mock.onGet(/\/v2\/thorchain\/queue/).reply(async () => {
-      const resp = (await import(`./responses/thorchain/outboundQueue.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thorchain/outboundQueue.json`)
       return [200, resp]
     })
     //Mock midgard health
     mock.onGet(/\/v2\/health/).reply(async () => {
-      const resp = (await import(`./responses/midgard/health.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/midgard/health.json`)
       return [200, resp]
     })
     //Mock midgard actions
     mock.onGet(/\/v2\/actions?/).reply(async () => {
-      const resp = (await import(`./responses/midgard/actions.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/midgard/actions.json`)
       return [200, resp]
     })
   },

--- a/packages/xchain-thorchain-amm/__mocks__/axios-adapter.ts
+++ b/packages/xchain-thorchain-amm/__mocks__/axios-adapter.ts
@@ -4,3 +4,5 @@ import MockAdapter from 'axios-mock-adapter'
 const mock = new MockAdapter(axios)
 
 export default mock
+
+export const importjson = async (file) => (await import(file, { with: { type: 'json' } })).default

--- a/packages/xchain-thorchain-amm/__mocks__/midgard-api.ts
+++ b/packages/xchain-thorchain-amm/__mocks__/midgard-api.ts
@@ -5,32 +5,32 @@ export default {
   init: () => {
     //Mock midgard pools
     mock.onGet(/\/v2\/pools/).reply(async () => {
-      const resp = require(`./responses/midgard/pools.json`)
+      const resp = (await import(`./responses/midgard/pools.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock thorchain/mimir
     mock.onGet(/\/thorchain\/mimir/).reply(async () => {
-      const resp = require(`./responses/mimir/mimirConstants.json`)
+      const resp = (await import(`./responses/mimir/mimirConstants.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock thorchain/mimir
     mock.onGet(/\/thorchain\/constants/).reply(async () => {
-      const resp = require(`./responses/thorchain/thorchainConstants.json`)
+      const resp = (await import(`./responses/thorchain/thorchainConstants.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock thorchain/mimir
     mock.onGet(/\/thorchain\/queue/).reply(async () => {
-      const resp = require(`./responses/thorchain/outboundQueue.json`)
+      const resp = (await import(`./responses/thorchain/outboundQueue.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock midgard health
     mock.onGet(/\/v2\/health/).reply(async () => {
-      const resp = require(`./responses/midgard/health.json`)
+      const resp = (await import(`./responses/midgard/health.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock midgard health
     mock.onGet(/\/v2\/thorname\/lookup\/odin/).reply(async () => {
-      const resp = require(`./responses/midgard/thorname.json`)
+      const resp = (await import(`./responses/midgard/thorname.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
   },

--- a/packages/xchain-thorchain-amm/__mocks__/midgard-api.ts
+++ b/packages/xchain-thorchain-amm/__mocks__/midgard-api.ts
@@ -1,36 +1,36 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 export default {
   restore: mock.restore,
   init: () => {
     //Mock midgard pools
     mock.onGet(/\/v2\/pools/).reply(async () => {
-      const resp = (await import(`./responses/midgard/pools.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/midgard/pools.json`)
       return [200, resp]
     })
     //Mock thorchain/mimir
     mock.onGet(/\/thorchain\/mimir/).reply(async () => {
-      const resp = (await import(`./responses/mimir/mimirConstants.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/mimir/mimirConstants.json`)
       return [200, resp]
     })
     //Mock thorchain/mimir
     mock.onGet(/\/thorchain\/constants/).reply(async () => {
-      const resp = (await import(`./responses/thorchain/thorchainConstants.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thorchain/thorchainConstants.json`)
       return [200, resp]
     })
     //Mock thorchain/mimir
     mock.onGet(/\/thorchain\/queue/).reply(async () => {
-      const resp = (await import(`./responses/thorchain/outboundQueue.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thorchain/outboundQueue.json`)
       return [200, resp]
     })
     //Mock midgard health
     mock.onGet(/\/v2\/health/).reply(async () => {
-      const resp = (await import(`./responses/midgard/health.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/midgard/health.json`)
       return [200, resp]
     })
     //Mock midgard health
     mock.onGet(/\/v2\/thorname\/lookup\/odin/).reply(async () => {
-      const resp = (await import(`./responses/midgard/thorname.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/midgard/thorname.json`)
       return [200, resp]
     })
   },

--- a/packages/xchain-thorchain-amm/__mocks__/thornode-api.ts
+++ b/packages/xchain-thorchain-amm/__mocks__/thornode-api.ts
@@ -4,55 +4,55 @@ export default {
   restore: mock.restore,
   init: () => {
     mock.onGet(/\/thorchain\/pools/).reply(async () => {
-      const resp = require(`./responses/thornode/thornodePools.json`)
+      const resp = (await import(`./responses/thornode/thornodePools.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock thorchain/inbound_addresses
     mock.onGet(/\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = require(`./responses/thornode/inbound_addresses.json`)
+      const resp = (await import(`./responses/thornode/inbound_addresses.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock thornode observed tx
     mock.onGet(/\/thorchain\/tx\/276CE5005FF822294773C549E74513636808A6A9817FE7ADCE1709EE06BC7F52/).reply(async () => {
-      const resp = require(`./responses/thornode/thornodeObservedTx.json`)
+      const resp = (await import(`./responses/thornode/thornodeObservedTx.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock thornode unobserved tx
     mock.onGet(/\/276CE5005FF822294773C549E74513636808A6A9817FE7ADCE1709EE06BC/).reply(async () => {
-      const resp = require(`./responses/thornode/unobservedTx.json`)
+      const resp = (await import(`./responses/thornode/unobservedTx.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     // Mock thornode incomplete tx
     mock.onGet(/\/thorchain\/tx\/28833B25B58B1907A3E4171E991DEB5E168A98829810F1215E0959D59BDD7CF5/).reply(async () => {
-      const resp = require('./responses/thornode/thornodeIncompleteTx.json')
+      const resp = (await import('./responses/thornode/thornodeIncompleteTx.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
     // Mock thornode block height difference
     mock.onGet(/\/thorchain\/tx\/E64875F5EF8B4EA94900EC86E7790A40D5397ED0AEAFA68EEB05964CAFB18BAE/).reply(async () => {
-      const resp = require('./responses/thornode/blockHeightDiff.json')
+      const resp = (await import('./responses/thornode/blockHeightDiff.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
     // Mock scheduled queue
     mock.onGet(/\/thorchain\/queue\/scheduled/).reply(async () => {
-      const resp = require(`./responses/thornode/scheduledQueue.json`)
+      const resp = (await import(`./responses/thornode/scheduledQueue.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     // Mock last block
     mock.onGet(/\/thorchain\/lastblock/).reply(async () => {
-      const resp = require(`./responses/thornode/lastBlock.json`)
+      const resp = (await import(`./responses/thornode/lastBlock.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     // Mock Outbound Confirmed tx
     mock.onGet(/\/thorchain\/tx\/776CE5005FF822294773C549E74513636808A6A9817FE7ADCE1709EE06BC7F53/).reply(async () => {
-      const resp = require('./responses/thornode/thornodeTx.json')
+      const resp = (await import('./responses/thornode/thornodeTx.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
     mock.onGet(/\/thorchain\/thorname\/odin/).reply(async () => {
-      const resp = require('./responses/thornode/thorname.json')
+      const resp = (await import('./responses/thornode/thorname.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
     mock.onGet(/\/thorchain\/constants/).reply(async () => {
-      const resp = require(`./responses/thornode/constants.json`)
+      const resp = (await import(`./responses/thornode/constants.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     mock.onGet(/\/thorchain\/quote\/swap/).reply(async (config) => {
@@ -60,7 +60,7 @@ export default {
       const from_asset = parsedUrl.searchParams.get('from_asset') ?? ''
       const to_asset = parsedUrl.searchParams.get('to_asset') ?? ''
       if (from_asset === 'AVAX~AVAX' && to_asset === 'ETH~ETH') {
-        const resp = require(`./responses/thornode/tradeSwap.json`)
+        const resp = (await import(`./responses/thornode/tradeSwap.json`, { with: { type: 'json' } })).default
         return [200, resp]
       }
       return [500, { error: 'Not found' }]

--- a/packages/xchain-thorchain-amm/__mocks__/thornode-api.ts
+++ b/packages/xchain-thorchain-amm/__mocks__/thornode-api.ts
@@ -1,58 +1,58 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 export default {
   restore: mock.restore,
   init: () => {
     mock.onGet(/\/thorchain\/pools/).reply(async () => {
-      const resp = (await import(`./responses/thornode/thornodePools.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thornode/thornodePools.json`)
       return [200, resp]
     })
     //Mock thorchain/inbound_addresses
     mock.onGet(/\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = (await import(`./responses/thornode/inbound_addresses.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thornode/inbound_addresses.json`)
       return [200, resp]
     })
     //Mock thornode observed tx
     mock.onGet(/\/thorchain\/tx\/276CE5005FF822294773C549E74513636808A6A9817FE7ADCE1709EE06BC7F52/).reply(async () => {
-      const resp = (await import(`./responses/thornode/thornodeObservedTx.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thornode/thornodeObservedTx.json`)
       return [200, resp]
     })
     //Mock thornode unobserved tx
     mock.onGet(/\/276CE5005FF822294773C549E74513636808A6A9817FE7ADCE1709EE06BC/).reply(async () => {
-      const resp = (await import(`./responses/thornode/unobservedTx.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thornode/unobservedTx.json`)
       return [200, resp]
     })
     // Mock thornode incomplete tx
     mock.onGet(/\/thorchain\/tx\/28833B25B58B1907A3E4171E991DEB5E168A98829810F1215E0959D59BDD7CF5/).reply(async () => {
-      const resp = (await import('./responses/thornode/thornodeIncompleteTx.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./responses/thornode/thornodeIncompleteTx.json')
       return [200, resp]
     })
     // Mock thornode block height difference
     mock.onGet(/\/thorchain\/tx\/E64875F5EF8B4EA94900EC86E7790A40D5397ED0AEAFA68EEB05964CAFB18BAE/).reply(async () => {
-      const resp = (await import('./responses/thornode/blockHeightDiff.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./responses/thornode/blockHeightDiff.json')
       return [200, resp]
     })
     // Mock scheduled queue
     mock.onGet(/\/thorchain\/queue\/scheduled/).reply(async () => {
-      const resp = (await import(`./responses/thornode/scheduledQueue.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thornode/scheduledQueue.json`)
       return [200, resp]
     })
     // Mock last block
     mock.onGet(/\/thorchain\/lastblock/).reply(async () => {
-      const resp = (await import(`./responses/thornode/lastBlock.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thornode/lastBlock.json`)
       return [200, resp]
     })
     // Mock Outbound Confirmed tx
     mock.onGet(/\/thorchain\/tx\/776CE5005FF822294773C549E74513636808A6A9817FE7ADCE1709EE06BC7F53/).reply(async () => {
-      const resp = (await import('./responses/thornode/thornodeTx.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./responses/thornode/thornodeTx.json')
       return [200, resp]
     })
     mock.onGet(/\/thorchain\/thorname\/odin/).reply(async () => {
-      const resp = (await import('./responses/thornode/thorname.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./responses/thornode/thorname.json')
       return [200, resp]
     })
     mock.onGet(/\/thorchain\/constants/).reply(async () => {
-      const resp = (await import(`./responses/thornode/constants.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thornode/constants.json`)
       return [200, resp]
     })
     mock.onGet(/\/thorchain\/quote\/swap/).reply(async (config) => {
@@ -60,7 +60,7 @@ export default {
       const from_asset = parsedUrl.searchParams.get('from_asset') ?? ''
       const to_asset = parsedUrl.searchParams.get('to_asset') ?? ''
       if (from_asset === 'AVAX~AVAX' && to_asset === 'ETH~ETH') {
-        const resp = (await import(`./responses/thornode/tradeSwap.json`, { with: { type: 'json' } })).default
+        const resp = await importjson(`./responses/thornode/tradeSwap.json`)
         return [200, resp]
       }
       return [500, { error: 'Not found' }]

--- a/packages/xchain-thorchain-query/__mocks__/axios-adapter.ts
+++ b/packages/xchain-thorchain-query/__mocks__/axios-adapter.ts
@@ -4,3 +4,5 @@ import MockAdapter from 'axios-mock-adapter'
 const mock = new MockAdapter(axios)
 
 export default mock
+
+export const importjson = async (file) => (await import(file, { with: { type: 'json' } })).default

--- a/packages/xchain-thorchain-query/__mocks__/midgard-api.ts
+++ b/packages/xchain-thorchain-query/__mocks__/midgard-api.ts
@@ -6,32 +6,32 @@ export default {
   init: () => {
     //Mock midgard pools
     mock.onGet(/\/v2\/pools/).reply(async () => {
-      const resp = require(`./responses/midgard/pools.json`)
+      const resp = (await import(`./responses/midgard/pools.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock thorchain/mimir
     mock.onGet(/\/v2\/thorchain\/mimir/).reply(async () => {
-      const resp = require(`./responses/mimir/mimirConstants.json`)
+      const resp = (await import(`./responses/mimir/mimirConstants.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock thorchain/mimir
     mock.onGet(/\/v2\/thorchain\/constants/).reply(async () => {
-      const resp = require(`./responses/thorchain/thorchainConstants.json`)
+      const resp = (await import(`./responses/thorchain/thorchainConstants.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock thorchain/mimir
     mock.onGet(/\/v2\/thorchain\/queue/).reply(async () => {
-      const resp = require(`./responses/thorchain/outboundQueue.json`)
+      const resp = (await import(`./responses/thorchain/outboundQueue.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock midgard health
     mock.onGet(/\/v2\/health/).reply(async () => {
-      const resp = require(`./responses/midgard/health.json`)
+      const resp = (await import(`./responses/midgard/health.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock midgard actions
     mock.onGet(/\/v2\/actions?/).reply(async () => {
-      const resp = require(`./responses/midgard/actions.json`)
+      const resp = (await import(`./responses/midgard/actions.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
   },

--- a/packages/xchain-thorchain-query/__mocks__/midgard-api.ts
+++ b/packages/xchain-thorchain-query/__mocks__/midgard-api.ts
@@ -1,4 +1,4 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 export default {
   reset: mock.reset,
@@ -6,32 +6,32 @@ export default {
   init: () => {
     //Mock midgard pools
     mock.onGet(/\/v2\/pools/).reply(async () => {
-      const resp = (await import(`./responses/midgard/pools.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/midgard/pools.json`)
       return [200, resp]
     })
     //Mock thorchain/mimir
     mock.onGet(/\/v2\/thorchain\/mimir/).reply(async () => {
-      const resp = (await import(`./responses/mimir/mimirConstants.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/mimir/mimirConstants.json`)
       return [200, resp]
     })
     //Mock thorchain/mimir
     mock.onGet(/\/v2\/thorchain\/constants/).reply(async () => {
-      const resp = (await import(`./responses/thorchain/thorchainConstants.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thorchain/thorchainConstants.json`)
       return [200, resp]
     })
     //Mock thorchain/mimir
     mock.onGet(/\/v2\/thorchain\/queue/).reply(async () => {
-      const resp = (await import(`./responses/thorchain/outboundQueue.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thorchain/outboundQueue.json`)
       return [200, resp]
     })
     //Mock midgard health
     mock.onGet(/\/v2\/health/).reply(async () => {
-      const resp = (await import(`./responses/midgard/health.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/midgard/health.json`)
       return [200, resp]
     })
     //Mock midgard actions
     mock.onGet(/\/v2\/actions?/).reply(async () => {
-      const resp = (await import(`./responses/midgard/actions.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/midgard/actions.json`)
       return [200, resp]
     })
   },

--- a/packages/xchain-thorchain-query/__mocks__/thornode-api.ts
+++ b/packages/xchain-thorchain-query/__mocks__/thornode-api.ts
@@ -6,7 +6,7 @@ export default {
   init: () => {
     //Mock thorchain/inbound_addresses
     mock.onGet(/\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = require(`./responses/thornode/inbound_addresses.json`)
+      const resp = (await import(`./responses/thornode/inbound_addresses.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
@@ -16,103 +16,111 @@ export default {
       const from_asset = parsedUrl.searchParams.get('from_asset') ?? ''
       const to_asset = parsedUrl.searchParams.get('to_asset') ?? ''
       if (from_asset.match('/')) {
-        const resp = require(`./responses/thornode/s${from_asset.split('/')[0]}SwapTos${to_asset.split('/')[0]}.json`)
+        const resp = (
+          await import(`./responses/thornode/s${from_asset.split('/')[0]}SwapTos${to_asset.split('/')[0]}.json`, {
+            with: { type: 'json' },
+          })
+        ).default
         return [200, resp]
       } else {
-        const resp = require(`./responses/thornode/${from_asset.split('.')[0]}SwapTo${to_asset.split('.')[0]}.json`)
+        const resp = (
+          await import(`./responses/thornode/${from_asset.split('.')[0]}SwapTo${to_asset.split('.')[0]}.json`, {
+            with: { type: 'json' },
+          })
+        ).default
         return [200, resp]
       }
     })
 
     //Mock thornode pools
     mock.onGet(/\/thorchain\/pools/).reply(async () => {
-      const resp = require(`./responses/thornode/thornodePools.json`)
+      const resp = (await import(`./responses/thornode/thornodePools.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock thornode observed tx
     mock.onGet(/\/thorchain\/tx\/276CE5005FF822294773C549E74513636808A6A9817FE7ADCE1709EE06BC7F52/).reply(async () => {
-      const resp = require(`./responses/thornode/thornodeObservedTx.json`)
+      const resp = (await import(`./responses/thornode/thornodeObservedTx.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock thornode unobserved tx
     mock.onGet(/\/thorchain\/tx\/276CE5005FF822294773C549E74513636808A6A9817FE7ADCE1709EE06BC/).reply(async () => {
-      const resp = require(`./responses/thornode/unobservedTx.json`)
+      const resp = (await import(`./responses/thornode/unobservedTx.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     // Mock thornode incomplete tx
     mock.onGet(/\/thorchain\/tx\/28833B25B58B1907A3E4171E991DEB5E168A98829810F1215E0959D59BDD7CF5/).reply(async () => {
-      const resp = require('./responses/thornode/thornodeIncompleteTx.json')
+      const resp = (await import('./responses/thornode/thornodeIncompleteTx.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
     // Mock thornode block height difference
     mock.onGet(/\/thorchain\/tx\/E64875F5EF8B4EA94900EC86E7790A40D5397ED0AEAFA68EEB05964CAFB18BAE/).reply(async () => {
-      const resp = require('./responses/thornode/blockHeightDiff.json')
+      const resp = (await import('./responses/thornode/blockHeightDiff.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
     // Mock scheduled queue
     mock.onGet(/\/thorchain\/queue\/scheduled/).reply(async () => {
-      const resp = require(`./responses/thornode/scheduledQueue.json`)
+      const resp = (await import(`./responses/thornode/scheduledQueue.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     // Mock scheduled queue
     mock.onGet(/\/thorchain\/queue/).reply(async () => {
-      const resp = require(`./responses/thornode/queue.json`)
+      const resp = (await import(`./responses/thornode/queue.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     // Mock last block
     mock.onGet(/\/thorchain\/lastblock/).reply(async () => {
-      const resp = require(`./responses/thornode/lastBlock.json`)
+      const resp = (await import(`./responses/thornode/lastBlock.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     // Mock Outbound Confirmed tx
     mock.onGet(/\/thorchain\/tx\/776CE5005FF822294773C549E74513636808A6A9817FE7ADCE1709EE06BC7F53/).reply(async () => {
-      const resp = require('./responses/thornode/thornodeTx.json')
+      const resp = (await import('./responses/thornode/thornodeTx.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
     // Mock constants tx
     mock.onGet(/\/thorchain\/constants/).reply(async () => {
-      const resp = require('./responses/thornode/constants.json')
+      const resp = (await import('./responses/thornode/constants.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
     // Mock mimir tx
     mock.onGet(/\/thorchain\/mimir/).reply(async () => {
-      const resp = require('./responses/thornode/mimir.json')
+      const resp = (await import('./responses/thornode/mimir.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     mock.onGet(/\/thorchain\/trade\/units/).reply(async () => {
-      const resp = require('./responses/thornode/tradeAssetUnits.json')
+      const resp = (await import('./responses/thornode/tradeAssetUnits.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     mock.onGet(/\/thorchain\/trade\/unit/).reply(async () => {
-      const resp = require('./responses/thornode/tradeAssetUnit.json')
+      const resp = (await import('./responses/thornode/tradeAssetUnit.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     mock.onGet(/\/thorchain\/trade\/accounts/).reply(async () => {
-      const resp = require('./responses/thornode/tradeAssetAccounts.json')
+      const resp = (await import('./responses/thornode/tradeAssetAccounts.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     mock.onGet(/\/thorchain\/trade\/account/).reply(async () => {
-      const resp = require('./responses/thornode/tradeAssetAccount.json')
+      const resp = (await import('./responses/thornode/tradeAssetAccount.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     mock.onGet(/\/thorchain\/runepool/).reply(async () => {
-      const resp = require('./responses/thornode/runePool.json')
+      const resp = (await import('./responses/thornode/runePool.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     mock.onGet(/\/thorchain\/rune_providers/).reply(async () => {
-      const resp = require('./responses/thornode/runePoolProviders.json')
+      const resp = (await import('./responses/thornode/runePoolProviders.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     mock.onGet(/\/thorchain\/rune_provider/).reply(async () => {
-      const resp = require('./responses/thornode/runePoolProvider.json')
+      const resp = (await import('./responses/thornode/runePoolProvider.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
   },

--- a/packages/xchain-thorchain-query/__mocks__/thornode-api.ts
+++ b/packages/xchain-thorchain-query/__mocks__/thornode-api.ts
@@ -1,4 +1,4 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 export default {
   reset: mock.reset,
@@ -6,7 +6,7 @@ export default {
   init: () => {
     //Mock thorchain/inbound_addresses
     mock.onGet(/\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = (await import(`./responses/thornode/inbound_addresses.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thornode/inbound_addresses.json`)
       return [200, resp]
     })
 
@@ -16,111 +16,103 @@ export default {
       const from_asset = parsedUrl.searchParams.get('from_asset') ?? ''
       const to_asset = parsedUrl.searchParams.get('to_asset') ?? ''
       if (from_asset.match('/')) {
-        const resp = (
-          await import(`./responses/thornode/s${from_asset.split('/')[0]}SwapTos${to_asset.split('/')[0]}.json`, {
-            with: { type: 'json' },
-          })
-        ).default
+        const resp = await importjson(`./responses/thornode/s${from_asset.split('/')[0]}SwapTos${to_asset.split('/')[0]}.json`)
         return [200, resp]
       } else {
-        const resp = (
-          await import(`./responses/thornode/${from_asset.split('.')[0]}SwapTo${to_asset.split('.')[0]}.json`, {
-            with: { type: 'json' },
-          })
-        ).default
+        const resp = await importjson(`./responses/thornode/${from_asset.split('.')[0]}SwapTo${to_asset.split('.')[0]}.json`)
         return [200, resp]
       }
     })
 
     //Mock thornode pools
     mock.onGet(/\/thorchain\/pools/).reply(async () => {
-      const resp = (await import(`./responses/thornode/thornodePools.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thornode/thornodePools.json`)
       return [200, resp]
     })
     //Mock thornode observed tx
     mock.onGet(/\/thorchain\/tx\/276CE5005FF822294773C549E74513636808A6A9817FE7ADCE1709EE06BC7F52/).reply(async () => {
-      const resp = (await import(`./responses/thornode/thornodeObservedTx.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thornode/thornodeObservedTx.json`)
       return [200, resp]
     })
     //Mock thornode unobserved tx
     mock.onGet(/\/thorchain\/tx\/276CE5005FF822294773C549E74513636808A6A9817FE7ADCE1709EE06BC/).reply(async () => {
-      const resp = (await import(`./responses/thornode/unobservedTx.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thornode/unobservedTx.json`)
       return [200, resp]
     })
     // Mock thornode incomplete tx
     mock.onGet(/\/thorchain\/tx\/28833B25B58B1907A3E4171E991DEB5E168A98829810F1215E0959D59BDD7CF5/).reply(async () => {
-      const resp = (await import('./responses/thornode/thornodeIncompleteTx.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./responses/thornode/thornodeIncompleteTx.json')
       return [200, resp]
     })
     // Mock thornode block height difference
     mock.onGet(/\/thorchain\/tx\/E64875F5EF8B4EA94900EC86E7790A40D5397ED0AEAFA68EEB05964CAFB18BAE/).reply(async () => {
-      const resp = (await import('./responses/thornode/blockHeightDiff.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./responses/thornode/blockHeightDiff.json')
       return [200, resp]
     })
     // Mock scheduled queue
     mock.onGet(/\/thorchain\/queue\/scheduled/).reply(async () => {
-      const resp = (await import(`./responses/thornode/scheduledQueue.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thornode/scheduledQueue.json`)
       return [200, resp]
     })
     // Mock scheduled queue
     mock.onGet(/\/thorchain\/queue/).reply(async () => {
-      const resp = (await import(`./responses/thornode/queue.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thornode/queue.json`)
       return [200, resp]
     })
     // Mock last block
     mock.onGet(/\/thorchain\/lastblock/).reply(async () => {
-      const resp = (await import(`./responses/thornode/lastBlock.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./responses/thornode/lastBlock.json`)
       return [200, resp]
     })
 
     // Mock Outbound Confirmed tx
     mock.onGet(/\/thorchain\/tx\/776CE5005FF822294773C549E74513636808A6A9817FE7ADCE1709EE06BC7F53/).reply(async () => {
-      const resp = (await import('./responses/thornode/thornodeTx.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./responses/thornode/thornodeTx.json')
       return [200, resp]
     })
     // Mock constants tx
     mock.onGet(/\/thorchain\/constants/).reply(async () => {
-      const resp = (await import('./responses/thornode/constants.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./responses/thornode/constants.json')
       return [200, resp]
     })
     // Mock mimir tx
     mock.onGet(/\/thorchain\/mimir/).reply(async () => {
-      const resp = (await import('./responses/thornode/mimir.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./responses/thornode/mimir.json')
       return [200, resp]
     })
 
     mock.onGet(/\/thorchain\/trade\/units/).reply(async () => {
-      const resp = (await import('./responses/thornode/tradeAssetUnits.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./responses/thornode/tradeAssetUnits.json')
       return [200, resp]
     })
 
     mock.onGet(/\/thorchain\/trade\/unit/).reply(async () => {
-      const resp = (await import('./responses/thornode/tradeAssetUnit.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./responses/thornode/tradeAssetUnit.json')
       return [200, resp]
     })
 
     mock.onGet(/\/thorchain\/trade\/accounts/).reply(async () => {
-      const resp = (await import('./responses/thornode/tradeAssetAccounts.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./responses/thornode/tradeAssetAccounts.json')
       return [200, resp]
     })
 
     mock.onGet(/\/thorchain\/trade\/account/).reply(async () => {
-      const resp = (await import('./responses/thornode/tradeAssetAccount.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./responses/thornode/tradeAssetAccount.json')
       return [200, resp]
     })
 
     mock.onGet(/\/thorchain\/runepool/).reply(async () => {
-      const resp = (await import('./responses/thornode/runePool.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./responses/thornode/runePool.json')
       return [200, resp]
     })
 
     mock.onGet(/\/thorchain\/rune_providers/).reply(async () => {
-      const resp = (await import('./responses/thornode/runePoolProviders.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./responses/thornode/runePoolProviders.json')
       return [200, resp]
     })
 
     mock.onGet(/\/thorchain\/rune_provider/).reply(async () => {
-      const resp = (await import('./responses/thornode/runePoolProvider.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./responses/thornode/runePoolProvider.json')
       return [200, resp]
     })
   },

--- a/packages/xchain-utxo-providers/__mocks__/axios-adapter.ts
+++ b/packages/xchain-utxo-providers/__mocks__/axios-adapter.ts
@@ -4,3 +4,5 @@ import MockAdapter from 'axios-mock-adapter'
 const mock = new MockAdapter(axios)
 
 export default mock
+
+export const importjson = async (file) => (await import(file, { with: { type: 'json' } })).default

--- a/packages/xchain-utxo-providers/__mocks__/haskoin.ts
+++ b/packages/xchain-utxo-providers/__mocks__/haskoin.ts
@@ -10,13 +10,13 @@ export default {
     //Mock GET https://{haskoinurl}/{btc|btctest}/address/{address}/balance
     mock.onGet(/\/address\/\w+\/balance/).reply(async (config: MockConfig) => {
       const address = config.url?.split('/')?.[6] ?? ''
-      const resp = require(`./response/balances/haskoin-${address}.json`)
+      const resp = (await import(`./response/balances/haskoin-${address}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock Get utxo's
     mock.onGet(/\/address\/\w+\/unspent/).reply(async (config: MockConfig) => {
       const address = config.url?.split('/')?.[6] ?? ''
-      const resp = require(`./response/unspent-txs/${address}.json`)
+      const resp = (await import(`./response/unspent-txs/${address}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
     //Mock POST https://{haskoinurl}/{btc|btctest}/transactions

--- a/packages/xchain-utxo-providers/__mocks__/haskoin.ts
+++ b/packages/xchain-utxo-providers/__mocks__/haskoin.ts
@@ -1,4 +1,4 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 type MockConfig = {
   url?: string
@@ -10,13 +10,13 @@ export default {
     //Mock GET https://{haskoinurl}/{btc|btctest}/address/{address}/balance
     mock.onGet(/\/address\/\w+\/balance/).reply(async (config: MockConfig) => {
       const address = config.url?.split('/')?.[6] ?? ''
-      const resp = (await import(`./response/balances/haskoin-${address}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/balances/haskoin-${address}.json`)
       return [200, resp]
     })
     //Mock Get utxo's
     mock.onGet(/\/address\/\w+\/unspent/).reply(async (config: MockConfig) => {
       const address = config.url?.split('/')?.[6] ?? ''
-      const resp = (await import(`./response/unspent-txs/${address}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/unspent-txs/${address}.json`)
       return [200, resp]
     })
     //Mock POST https://{haskoinurl}/{btc|btctest}/transactions

--- a/packages/xchain-utxo-providers/__mocks__/sochain.ts
+++ b/packages/xchain-utxo-providers/__mocks__/sochain.ts
@@ -10,14 +10,14 @@ export default {
     //Mock addresses summary
     mock.onGet(/\/address_summary\//).reply(async (config: MockConfig) => {
       const id: string = config.url?.split('/').pop() ?? ''
-      const resp = require(`./response/addresses/${id}.json`)
+      const resp = (await import(`./response/addresses/${id}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     //Mock get transaction data
     mock.onGet(/\/v3\/transaction\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = require(`./response/tx/${id}.json`)
+      const resp = (await import(`./response/tx/${id}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
@@ -25,14 +25,14 @@ export default {
     mock.onGet(/\/v3\/transactions\//).reply(async (config: MockConfig) => {
       const split = config.url?.split('/')
       const address = split?.[7] || ''
-      const resp = require(`./response/txs/${address}.json`)
+      const resp = (await import(`./response/txs/${address}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     //Mock get_address_balance
     mock.onGet(/\/balance\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = require(`./response/balances/${id}.json`)
+      const resp = (await import(`./response/balances/${id}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
@@ -49,14 +49,14 @@ export default {
         // this allows you to return utxos starting from a given page
         filePath = `./response/unspent-txs/${address}/${page}.json`
       }
-      const resp = require(filePath)
+      const resp = (await import(filePath, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     //Mock is_tx_confirmed
     mock.onGet(/\/is_tx_confirmed\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = require(`./response/is-tx-confirmed/${id}.json`)
+      const resp = (await import(`./response/is-tx-confirmed/${id}.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
@@ -67,13 +67,13 @@ export default {
     //
     //Mock thorchain/inbound_addresses
     mock.onGet(/\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = require(`./response/thornode/inbound_addresses.json`)
+      const resp = (await import(`./response/thornode/inbound_addresses.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
 
     //Mock thorchain/mimir
     mock.onGet(/\/thorchain\/mimir/).reply(async () => {
-      const resp = require(`./response/thornode/mimir.json`)
+      const resp = (await import(`./response/thornode/mimir.json`, { with: { type: 'json' } })).default
       return [200, resp]
     })
   },

--- a/packages/xchain-utxo-providers/__mocks__/sochain.ts
+++ b/packages/xchain-utxo-providers/__mocks__/sochain.ts
@@ -1,4 +1,4 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 type MockConfig = {
   url?: string
@@ -10,14 +10,14 @@ export default {
     //Mock addresses summary
     mock.onGet(/\/address_summary\//).reply(async (config: MockConfig) => {
       const id: string = config.url?.split('/').pop() ?? ''
-      const resp = (await import(`./response/addresses/${id}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/addresses/${id}.json`)
       return [200, resp]
     })
 
     //Mock get transaction data
     mock.onGet(/\/v3\/transaction\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = (await import(`./response/tx/${id}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/tx/${id}.json`)
       return [200, resp]
     })
 
@@ -25,14 +25,14 @@ export default {
     mock.onGet(/\/v3\/transactions\//).reply(async (config: MockConfig) => {
       const split = config.url?.split('/')
       const address = split?.[7] || ''
-      const resp = (await import(`./response/txs/${address}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/txs/${address}.json`)
       return [200, resp]
     })
 
     //Mock get_address_balance
     mock.onGet(/\/balance\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = (await import(`./response/balances/${id}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/balances/${id}.json`)
       return [200, resp]
     })
 
@@ -49,14 +49,14 @@ export default {
         // this allows you to return utxos starting from a given page
         filePath = `./response/unspent-txs/${address}/${page}.json`
       }
-      const resp = (await import(filePath, { with: { type: 'json' } })).default
+      const resp = await importjson(filePath)
       return [200, resp]
     })
 
     //Mock is_tx_confirmed
     mock.onGet(/\/is_tx_confirmed\//).reply(async (config: MockConfig) => {
       const id = config.url?.split('/').pop() ?? ''
-      const resp = (await import(`./response/is-tx-confirmed/${id}.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/is-tx-confirmed/${id}.json`)
       return [200, resp]
     })
 
@@ -67,13 +67,13 @@ export default {
     //
     //Mock thorchain/inbound_addresses
     mock.onGet(/\/thorchain\/inbound_addresses/).reply(async () => {
-      const resp = (await import(`./response/thornode/inbound_addresses.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/thornode/inbound_addresses.json`)
       return [200, resp]
     })
 
     //Mock thorchain/mimir
     mock.onGet(/\/thorchain\/mimir/).reply(async () => {
-      const resp = (await import(`./response/thornode/mimir.json`, { with: { type: 'json' } })).default
+      const resp = await importjson(`./response/thornode/mimir.json`)
       return [200, resp]
     })
   },

--- a/packages/xchain-zcash/__mocks__/axios-adapter.ts
+++ b/packages/xchain-zcash/__mocks__/axios-adapter.ts
@@ -4,3 +4,5 @@ import MockAdapter from 'axios-mock-adapter'
 const mock = new MockAdapter(axios)
 
 export default mock
+
+export const importjson = async (file) => (await import(file, { with: { type: 'json' } })).default

--- a/packages/xchain-zcash/__mocks__/nownodes.ts
+++ b/packages/xchain-zcash/__mocks__/nownodes.ts
@@ -4,23 +4,23 @@ export default {
   restore: mock.restore,
   init: () => {
     mock.onGet(/\/api\/v2\/address\/[^/]+/).reply(async () => {
-      const resp = require('./response/nownodes/get-txs.json')
+      const resp = (await import('./response/nownodes/get-txs.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
     mock.onGet(/\/api\/v2\/tx\/[^/]+/).reply(async () => {
-      const resp = require('./response/nownodes/get-tx.json')
+      const resp = (await import('./response/nownodes/get-tx.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
     mock.onGet(/\/api\/v2\/txs\/[^/]+/).reply(async () => {
-      const resp = require('./response/nownodes/get-txs.json')
+      const resp = (await import('./response/nownodes/get-txs.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
     mock.onGet(/\/api\/v2\/utxo\/[^/]+/).reply(async () => {
-      const resp = require('./response/nownodes/get-utxos.json')
+      const resp = (await import('./response/nownodes/get-utxos.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
     mock.onGet(/\/api\/v2\/sendtx\/[^/]+/).reply(async () => {
-      const resp = require('./response/nownodes/broadcast.json')
+      const resp = (await import('./response/nownodes/broadcast.json', { with: { type: 'json' } })).default
       return [200, resp]
     })
   },

--- a/packages/xchain-zcash/__mocks__/nownodes.ts
+++ b/packages/xchain-zcash/__mocks__/nownodes.ts
@@ -1,26 +1,26 @@
-import mock from './axios-adapter'
+import mock, { importjson } from './axios-adapter'
 
 export default {
   restore: mock.restore,
   init: () => {
     mock.onGet(/\/api\/v2\/address\/[^/]+/).reply(async () => {
-      const resp = (await import('./response/nownodes/get-txs.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./response/nownodes/get-txs.json')
       return [200, resp]
     })
     mock.onGet(/\/api\/v2\/tx\/[^/]+/).reply(async () => {
-      const resp = (await import('./response/nownodes/get-tx.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./response/nownodes/get-tx.json')
       return [200, resp]
     })
     mock.onGet(/\/api\/v2\/txs\/[^/]+/).reply(async () => {
-      const resp = (await import('./response/nownodes/get-txs.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./response/nownodes/get-txs.json')
       return [200, resp]
     })
     mock.onGet(/\/api\/v2\/utxo\/[^/]+/).reply(async () => {
-      const resp = (await import('./response/nownodes/get-utxos.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./response/nownodes/get-utxos.json')
       return [200, resp]
     })
     mock.onGet(/\/api\/v2\/sendtx\/[^/]+/).reply(async () => {
-      const resp = (await import('./response/nownodes/broadcast.json', { with: { type: 'json' } })).default
+      const resp = await importjson('./response/nownodes/broadcast.json')
       return [200, resp]
     })
   },


### PR DESCRIPTION
This removes the last traces of CommonJS from the codebase.

https://typescript-eslint.io/rules/no-require-imports/
https://typescript-eslint.io/rules/no-var-requires/