### PR TITLE
remove @types/bitcoinjs-lib

### DIFF
--- a/packages/xchain-bitcoin/package.json
+++ b/packages/xchain-bitcoin/package.json
@@ -47,7 +47,6 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "6.28.6",
-    "@types/bitcoinjs-lib": "^5.0.4",
     "axios": "1.8.4",
     "axios-mock-adapter": "2.1.0"
   },

--- a/packages/xchain-dash/package.json
+++ b/packages/xchain-dash/package.json
@@ -48,7 +48,6 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "6.28.6",
-    "@types/bitcoinjs-lib": "^5.0.4",
     "axios": "1.8.4",
     "axios-mock-adapter": "2.1.0"
   },

--- a/packages/xchain-doge/package.json
+++ b/packages/xchain-doge/package.json
@@ -47,7 +47,6 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "6.28.6",
-    "@types/bitcoinjs-lib": "^5.0.4",
     "axios": "1.8.4",
     "axios-mock-adapter": "2.1.0"
   },

--- a/packages/xchain-litecoin/package.json
+++ b/packages/xchain-litecoin/package.json
@@ -48,7 +48,6 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "6.28.6",
-    "@types/bitcoinjs-lib": "^5.0.4",
     "axios-mock-adapter": "2.1.0"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3359,15 +3359,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/bitcoinjs-lib@npm:^5.0.4":
-  version: 5.0.4
-  resolution: "@types/bitcoinjs-lib@npm:5.0.4"
-  dependencies:
-    bitcoinjs-lib: "npm:*"
-  checksum: 10c0/87b3c731305374a513cbcfc3bbf410e5b12301ec7d86068303c664b3da3a8fda96b4db9de34d557492193e5cfc26fe52d9931323406a50f503b28bd6907b2301
-  languageName: node
-  linkType: hard
-
 "@types/bitcore-lib-cash@npm:^8.23.8":
   version: 8.23.8
   resolution: "@types/bitcore-lib-cash@npm:8.23.8"
@@ -3985,7 +3976,6 @@ __metadata:
     "@ledgerhq/hw-app-btc": "npm:10.9.0"
     "@ledgerhq/hw-transport-node-hid": "npm:6.28.6"
     "@scure/bip32": "npm:^1.7.0"
-    "@types/bitcoinjs-lib": "npm:^5.0.4"
     "@xchainjs/xchain-client": "workspace:*"
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
@@ -4129,7 +4119,6 @@ __metadata:
     "@ledgerhq/hw-app-btc": "npm:10.9.0"
     "@ledgerhq/hw-transport-node-hid": "npm:6.28.6"
     "@scure/bip32": "npm:^1.7.0"
-    "@types/bitcoinjs-lib": "npm:^5.0.4"
     "@xchainjs/xchain-client": "workspace:*"
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
@@ -4151,7 +4140,6 @@ __metadata:
     "@ledgerhq/hw-app-btc": "npm:10.9.0"
     "@ledgerhq/hw-transport-node-hid": "npm:6.28.6"
     "@scure/bip32": "npm:^1.7.0"
-    "@types/bitcoinjs-lib": "npm:^5.0.4"
     "@xchainjs/xchain-client": "workspace:*"
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
@@ -4237,7 +4225,6 @@ __metadata:
     "@ledgerhq/hw-app-btc": "npm:10.9.0"
     "@ledgerhq/hw-transport-node-hid": "npm:6.28.6"
     "@scure/bip32": "npm:^1.7.0"
-    "@types/bitcoinjs-lib": "npm:^5.0.4"
     "@xchainjs/xchain-client": "workspace:*"
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
@@ -5310,20 +5297,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bitcoinjs-lib@npm:*, bitcoinjs-lib@npm:^6.1.7":
-  version: 6.1.7
-  resolution: "bitcoinjs-lib@npm:6.1.7"
-  dependencies:
-    "@noble/hashes": "npm:^1.2.0"
-    bech32: "npm:^2.0.0"
-    bip174: "npm:^2.1.1"
-    bs58check: "npm:^3.0.1"
-    typeforce: "npm:^1.11.3"
-    varuint-bitcoin: "npm:^1.1.2"
-  checksum: 10c0/1ce7415cc967bfc5ea7cba0032e73eaba8e3dd7683dffcc90c020d0dba92de6cf1dc92359733c9efa186a4c3ae9547cc379fa4b4a7fb106c0b126c226dec2a40
-  languageName: node
-  linkType: hard
-
 "bitcoinjs-lib@npm:7.0.0-rc.0":
   version: 7.0.0-rc.0
   resolution: "bitcoinjs-lib@npm:7.0.0-rc.0"
@@ -5359,6 +5332,20 @@ __metadata:
     varuint-bitcoin: "npm:^1.0.4"
     wif: "npm:^2.0.1"
   checksum: 10c0/08722efd645deaff1caea62a9df3f69ca12fc169e975f6d7fac9982b00437200a5333a591bce2971e580a4fc32960f28cd9f682841b43db94905c1f6eea601fd
+  languageName: node
+  linkType: hard
+
+"bitcoinjs-lib@npm:^6.1.7":
+  version: 6.1.7
+  resolution: "bitcoinjs-lib@npm:6.1.7"
+  dependencies:
+    "@noble/hashes": "npm:^1.2.0"
+    bech32: "npm:^2.0.0"
+    bip174: "npm:^2.1.1"
+    bs58check: "npm:^3.0.1"
+    typeforce: "npm:^1.11.3"
+    varuint-bitcoin: "npm:^1.1.2"
+  checksum: 10c0/1ce7415cc967bfc5ea7cba0032e73eaba8e3dd7683dffcc90c020d0dba92de6cf1dc92359733c9efa186a4c3ae9547cc379fa4b4a7fb106c0b126c226dec2a40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://www.npmjs.com/package/@types/bitcoinjs-lib

Looks like it hasn't been used since version 4.0. bitcoinjs-lib was rewritten in TypeScript in 5.0.