### PR TITLE
remove dependency on foundry-primitives fork

### DIFF
--- a/.changeset/rich-moons-poke.md
+++ b/.changeset/rich-moons-poke.md
@@ -1,0 +1,5 @@
+---
+'@xchainjs/xchain-crypto': patch
+---
+
+drop dependency on foundry-primitives fork

--- a/packages/xchain-crypto/package.json
+++ b/packages/xchain-crypto/package.json
@@ -45,10 +45,10 @@
     "@types/uuid": "^9.0.1"
   },
   "dependencies": {
+    "@noble/hashes": "^1.8.0",
     "@scure/base": "^1.2.6",
     "bip39": "^3.1.0",
     "crypto-js": "4.2.0",
-    "foundry-primitives-xchainjs": "github:xchainjs/foundry-primitives-js#master",
     "uuid": "^9.0.0"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4057,6 +4057,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@xchainjs/xchain-crypto@workspace:packages/xchain-crypto"
   dependencies:
+    "@noble/hashes": "npm:^1.8.0"
     "@scure/base": "npm:^1.2.6"
     "@types/bip39": "npm:^3.0.0"
     "@types/crypto-js": "npm:^4.1.1"
@@ -4064,7 +4065,6 @@ __metadata:
     "@types/uuid": "npm:^9.0.1"
     bip39: "npm:^3.1.0"
     crypto-js: "npm:4.2.0"
-    foundry-primitives-xchainjs: "github:xchainjs/foundry-primitives-js#master"
     uuid: "npm:^9.0.0"
   languageName: unknown
   linkType: soft
@@ -5129,13 +5129,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bignumber.js@npm:^7.2.1":
-  version: 7.2.1
-  resolution: "bignumber.js@npm:7.2.1"
-  checksum: 10c0/7e2cb10cdc1991696666b129f3b888c44a5e35bd3a5e990b2d2c934c7bc6863fb42b45fdea830484ca0d9e0b9a70d15e1d43fcd03a0e04326612b8e3ac76a0ae
-  languageName: node
-  linkType: hard
-
 "bignumber.js@npm:^9.0.0, bignumber.js@npm:^9.1.2":
   version: 9.1.2
   resolution: "bignumber.js@npm:9.1.2"
@@ -5348,7 +5341,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"blakejs@npm:1.2.1, blakejs@npm:^1.1.0":
+"blakejs@npm:1.2.1":
   version: 1.2.1
   resolution: "blakejs@npm:1.2.1"
   checksum: 10c0/c284557ce55b9c70203f59d381f1b85372ef08ee616a90162174d1291a45d3e5e809fdf9edab6e998740012538515152471dc4f1f9dbfa974ba2b9c1f7b9aad7
@@ -5571,7 +5564,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:^5.2.1, buffer@npm:^5.5.0":
+"buffer@npm:^5.5.0":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
   dependencies:
@@ -7492,25 +7485,6 @@ __metadata:
     combined-stream: "npm:^1.0.8"
     mime-types: "npm:^2.1.12"
   checksum: 10c0/cb6f3ac49180be03ff07ba3ff125f9eba2ff0b277fb33c7fc47569fc5e616882c5b1c69b9904c4c4187e97dd0419dd03b134174756f296dec62041e6527e2c6e
-  languageName: node
-  linkType: hard
-
-"foundry-primitives-xchainjs@github:xchainjs/foundry-primitives-js#master":
-  version: 0.2.1
-  resolution: "foundry-primitives-xchainjs@https://github.com/xchainjs/foundry-primitives-js.git#commit=7daeca67840d95bda9afb8f527e9d5a397d67ac9"
-  dependencies:
-    bignumber.js: "npm:^7.2.1"
-    blakejs: "npm:^1.1.0"
-    bn.js: "npm:^4.11.8"
-    buffer: "npm:^5.2.1"
-    crypto-js: "npm:4.2.0"
-    elliptic: "npm:^6.6.1"
-    hmac-drbg: "npm:^1.0.1"
-    lodash: "npm:^4.17.21"
-    node-forge: "npm:^1.3.1"
-    rlp: "npm:^2.1.0"
-    tweetnacl: "npm:^1.0.3"
-  checksum: 10c0/1c0adb408012a4c35a63d043503e515595ca7310ab1dccb3e143071e44a20fb655a596a8caa097f4ba5d3d7a46682a8bffd76203784a6d25e29b4a6dff949009
   languageName: node
   linkType: hard
 
@@ -10230,13 +10204,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-forge@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "node-forge@npm:1.3.1"
-  checksum: 10c0/e882819b251a4321f9fc1d67c85d1501d3004b4ee889af822fd07f64de3d1a8e272ff00b689570af0465d65d6bf5074df9c76e900e0aff23e60b847f2a46fbe8
-  languageName: node
-  linkType: hard
-
 "node-gyp-build@npm:^4.2.0, node-gyp-build@npm:^4.3.0, node-gyp-build@npm:^4.5.0":
   version: 4.7.1
   resolution: "node-gyp-build@npm:4.7.1"
@@ -11376,17 +11343,6 @@ __metadata:
     "@xrplf/isomorphic": "npm:^1.0.0"
     ripple-address-codec: "npm:^5.0.0"
   checksum: 10c0/10eecf822d80eb1fe97bf7c21e4be7e11e6c82b51e0d7b984d5c803f1706dc8fd3578dc14d8b756e8f321ad0e0ec7bee3b57053721083ccc693fc2488270e180
-  languageName: node
-  linkType: hard
-
-"rlp@npm:^2.1.0":
-  version: 2.2.7
-  resolution: "rlp@npm:2.2.7"
-  dependencies:
-    bn.js: "npm:^5.2.0"
-  bin:
-    rlp: bin/rlp
-  checksum: 10c0/166c449f4bc794d47f8e337bf0ffbcfdb26c33109030aac4b6e5a33a91fa85783f2290addeb7b3c89d6d9b90c8276e719494d193129bed0a60a2d4a6fd658277
   languageName: node
   linkType: hard
 
@@ -12693,7 +12649,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tweetnacl@npm:1.0.3, tweetnacl@npm:^1.0.3":
+"tweetnacl@npm:1.0.3":
   version: 1.0.3
   resolution: "tweetnacl@npm:1.0.3"
   checksum: 10c0/069d9df51e8ad4a89fbe6f9806c68e06c65be3c7d42f0701cc43dba5f0d6064686b238bbff206c5addef8854e3ce00c643bff59432ea2f2c639feab0ee1a93f9


### PR DESCRIPTION
https://github.com/xchainjs/foundry-primitives-js

Replacement available in `@noble/hashes` [1.7.1](https://github.com/paulmillr/noble-hashes/releases/tag/1.7.1)

Part of #1449

This also silences a security alert about foundry-primitives-xchainjs depending on a very old version of `crypto-js`.

https://github.com/asgardex/asgardex-desktop/security/dependabot/4