### PR TITLE
Replace bchaddrjs dependency

### DIFF
--- a/.changeset/slick-roses-wonder.md
+++ b/.changeset/slick-roses-wonder.md
@@ -1,0 +1,5 @@
+---
+'@xchainjs/xchain-bitcoincash': patch
+---
+
+Remove bchaddr dependency

--- a/examples/do-swap/package.json
+++ b/examples/do-swap/package.json
@@ -38,7 +38,6 @@
     "@xchainjs/xchain-wallet": "workspace:*",
     "axios": "1.8.4",
     "axios-retry": "^3.3.1",
-    "bchaddrjs": "^0.5.2",
     "bech32-buffer": "^0.2.0",
     "bitcoinjs-lib": "^6.1.7",
     "dotenv": "^16.0.0",

--- a/packages/xchain-bitcoincash/__tests__/utils.test.ts
+++ b/packages/xchain-bitcoincash/__tests__/utils.test.ts
@@ -1,6 +1,5 @@
 import { Network } from '@xchainjs/xchain-client'
-import * as bchaddr from 'bchaddrjs'
-
+import * as bchaddr from '../src/bchaddrjs'
 import mockHaskoinApi from '../__mocks__/haskoin'
 import * as Utils from '../src/utils'
 
@@ -14,6 +13,7 @@ describe('Bitcoin Cash Utils Test', () => {
 
   const testnet_address = 'bchtest:qpd7jmj0hltgxux06v9d9u6933vq7zd0kyjlapya0g'
   const mainnet_address = 'bitcoincash:qp4kjpk684c3d9qjk5a37vl2xn86wxl0f5j2ru0daj'
+  const legacy_mainnet = '1Anw7uzLwXxBykMLeKb2BPAyTKsSfVDA8A'
 
   describe('stripPrefix', () => {
     it('should strip out the prefix from the testnet address', () => {
@@ -21,7 +21,7 @@ describe('Bitcoin Cash Utils Test', () => {
       expect(strip_address).toEqual('qpd7jmj0hltgxux06v9d9u6933vq7zd0kyjlapya0g')
     })
 
-    it('should strip out the prefix from the testnet address', () => {
+    it('should strip out the prefix from the mainnet address', () => {
       const strip_address = Utils.stripPrefix(mainnet_address)
       expect(strip_address).toEqual('qp4kjpk684c3d9qjk5a37vl2xn86wxl0f5j2ru0daj')
     })
@@ -38,6 +38,47 @@ describe('Bitcoin Cash Utils Test', () => {
     })
     it('returns `bchaddr.Network.Testnet` in case of `testnet', () => {
       expect(Utils.toBCHAddressNetwork(Network.Testnet)).toEqual(bchaddr.Network.Testnet)
+    })
+  })
+
+  describe('toLegacyAddress', () => {
+    it('converts cashaddr to legacy', () => {
+      const legacy = Utils.toLegacyAddress(mainnet_address)
+      expect(legacy).toEqual(legacy_mainnet)
+    })
+  })
+  describe('toCashAddress', () => {
+    it('converts legacy to cashaddr', () => {
+      const cashaddr = Utils.toCashAddress(legacy_mainnet)
+      expect(cashaddr).toEqual(mainnet_address)
+    })
+  })
+
+  describe('isCashAddress', () => {
+    it('returns true for a valid cash address', () => {
+      expect(Utils.isCashAddress(mainnet_address)).toBe(true)
+    })
+
+    it('returns false for a legacy address', () => {
+      expect(Utils.isCashAddress(legacy_mainnet)).toBe(false)
+    })
+  })
+
+  describe('validateAddress', () => {
+    it('returns true for a valid testnet address and testnet network', () => {
+      expect(Utils.validateAddress(testnet_address, Network.Testnet)).toBe(true)
+    })
+
+    it('returns true for a valid mainnet address and mainnet network', () => {
+      expect(Utils.validateAddress(mainnet_address, Network.Mainnet)).toBe(true)
+    })
+
+    it('returns false if address network doesn’t match given network', () => {
+      expect(Utils.validateAddress(mainnet_address, Network.Testnet)).toBe(false)
+    })
+
+    it('throws error for invalid address', () => {
+      expect(() => Utils.validateAddress('invalid-address', Network.Mainnet)).toThrow()
     })
   })
 })

--- a/packages/xchain-bitcoincash/package.json
+++ b/packages/xchain-bitcoincash/package.json
@@ -41,14 +41,15 @@
     "@xchainjs/xchain-util": "workspace:*",
     "@xchainjs/xchain-utxo": "workspace:*",
     "@xchainjs/xchain-utxo-providers": "workspace:*",
-    "bchaddrjs": "0.5.2",
     "bitcore-lib-cash": "11.0.0",
+    "bs58check": "^4.0.0",
+    "cashaddrjs": "^0.4.4",
     "coinselect": "3.1.12"
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "@types/bchaddrjs": "0.4.0",
     "@types/bitcore-lib-cash": "^8.23.8",
+    "@types/cashaddrjs": "^0",
     "axios": "^1.8.4",
     "axios-mock-adapter": "^2.1.0"
   },

--- a/packages/xchain-bitcoincash/src/bchaddrjs/README.md
+++ b/packages/xchain-bitcoincash/src/bchaddrjs/README.md
@@ -1,0 +1,3 @@
+### 📦 Note on BCH Address Utilities
+
+This project replaces the original [`bchaddrjs`](https://www.npmjs.com/package/bchaddrjs) [`code`](https://github.com/ealmansi/bchaddrjs) dependency with a direct copy of its source code included in the repository. The decision was made to avoid unnecessary bundle size inflation caused by the original package's inclusion of outdated polyfills. Functionality remains unchanged, and only the delivery method has been optimized for modern environments.

--- a/packages/xchain-bitcoincash/src/bchaddrjs/index.ts
+++ b/packages/xchain-bitcoincash/src/bchaddrjs/index.ts
@@ -1,0 +1,458 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-use-before-define */
+// @ts-nocheck
+
+/***
+ * @license
+ * https://github.com/ealmansi/bchaddrjs
+ * Copyright (c) 2018-2020 Emilio Almansi
+ * Distributed under the MIT software license, see the accompanying
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+ */
+
+import bs58check from 'bs58check'
+import * as cashaddr from 'cashaddrjs'
+
+/**
+ * General purpose Bitcoin Cash address detection and translation.<br />
+ * Supports all major Bitcoin Cash address formats.<br />
+ * Currently:
+ * <ul>
+ *    <li> Legacy format </li>
+ *    <li> Bitpay format </li>
+ *    <li> Cashaddr format </li>
+ * </ul>
+ * @module bchaddr
+ */
+
+/**
+ * @static
+ * Supported Bitcoin Cash address formats.
+ */
+const Format = {} as any
+Format.Legacy = 'legacy'
+Format.Bitpay = 'bitpay'
+Format.Cashaddr = 'cashaddr'
+
+/**
+ * @static
+ * Supported networks.
+ */
+const Network = {} as any
+Network.Mainnet = 'mainnet'
+Network.Testnet = 'testnet'
+
+/**
+ * @static
+ * Supported address types.
+ */
+const Type = {} as any
+Type.P2PKH = 'p2pkh'
+Type.P2SH = 'p2sh'
+
+/**
+ * Returns a boolean indicating whether the given input is a valid Bitcoin Cash address.
+ * @static
+ * @param {*} input - Any input to check for validity.
+ * @returns {boolean}
+ */
+function isValidAddress(input) {
+  try {
+    decodeAddress(input)
+    return true
+  } catch (error) {
+    return false
+  }
+}
+
+/**
+ * Detects what is the given address' format.
+ * @static
+ * @param {string} address - A valid Bitcoin Cash address in any format.
+ * @return {string}
+ * @throws {InvalidAddressError}
+ */
+function detectAddressFormat(address) {
+  return decodeAddress(address).format
+}
+
+/**
+ * Detects what is the given address' network.
+ * @static
+ * @param {string} address - A valid Bitcoin Cash address in any format.
+ * @return {string}
+ * @throws {InvalidAddressError}
+ */
+function detectAddressNetwork(address) {
+  return decodeAddress(address).network
+}
+
+/**
+ * Detects what is the given address' type.
+ * @static
+ * @param {string} address - A valid Bitcoin Cash address in any format.
+ * @return {string}
+ * @throws {InvalidAddressError}
+ */
+function detectAddressType(address) {
+  return decodeAddress(address).type
+}
+
+/**
+ * Translates the given address into legacy format.
+ * @static
+ * @param {string} address - A valid Bitcoin Cash address in any format.
+ * @return {string}
+ * @throws {InvalidAddressError}
+ */
+function toLegacyAddress(address) {
+  const decoded = decodeAddress(address)
+  if (decoded.format === Format.Legacy) {
+    return address
+  }
+  return encodeAsLegacy(decoded)
+}
+
+/**
+ * Translates the given address into bitpay format.
+ * @static
+ * @param {string} address - A valid Bitcoin Cash address in any format.
+ * @return {string}
+ * @throws {InvalidAddressError}
+ */
+function toBitpayAddress(address) {
+  const decoded = decodeAddress(address)
+  if (decoded.format === Format.Bitpay) {
+    return address
+  }
+  return encodeAsBitpay(decoded)
+}
+
+/**
+ * Translates the given address into cashaddr format.
+ * @static
+ * @param {string} address - A valid Bitcoin Cash address in any format.
+ * @return {string}
+ * @throws {InvalidAddressError}
+ */
+function toCashAddress(address) {
+  const decoded = decodeAddress(address)
+  return encodeAsCashaddr(decoded)
+}
+
+/**
+ * Version byte table for base58 formats.
+ * @private
+ */
+const VERSION_BYTE = {} as any
+VERSION_BYTE[Format.Legacy] = {}
+VERSION_BYTE[Format.Legacy][Network.Mainnet] = {}
+VERSION_BYTE[Format.Legacy][Network.Mainnet][Type.P2PKH] = 0
+VERSION_BYTE[Format.Legacy][Network.Mainnet][Type.P2SH] = 5
+VERSION_BYTE[Format.Legacy][Network.Testnet] = {}
+VERSION_BYTE[Format.Legacy][Network.Testnet][Type.P2PKH] = 111
+VERSION_BYTE[Format.Legacy][Network.Testnet][Type.P2SH] = 196
+VERSION_BYTE[Format.Bitpay] = {}
+VERSION_BYTE[Format.Bitpay][Network.Mainnet] = {}
+VERSION_BYTE[Format.Bitpay][Network.Mainnet][Type.P2PKH] = 28
+VERSION_BYTE[Format.Bitpay][Network.Mainnet][Type.P2SH] = 40
+VERSION_BYTE[Format.Bitpay][Network.Testnet] = {}
+VERSION_BYTE[Format.Bitpay][Network.Testnet][Type.P2PKH] = 111
+VERSION_BYTE[Format.Bitpay][Network.Testnet][Type.P2SH] = 196
+
+/**
+ * Decodes the given address into its constituting hash, format, network and type.
+ * @private
+ * @param {string} address - A valid Bitcoin Cash address in any format.
+ * @return {object}
+ * @throws {InvalidAddressError}
+ */
+function decodeAddress(address) {
+  try {
+    return decodeBase58Address(address)
+  } catch (error) {}
+  try {
+    return decodeCashAddress(address)
+  } catch (error) {}
+  throw new InvalidAddressError()
+}
+
+/**
+ * Length of a valid base58check encoding payload: 1 byte for
+ * the version byte plus 20 bytes for a RIPEMD-160 hash.
+ * @private
+ */
+const BASE_58_CHECK_PAYLOAD_LENGTH = 21
+
+/**
+ * Attempts to decode the given address assuming it is a base58 address.
+ * @private
+ * @param {string} address - A valid Bitcoin Cash address in any format.
+ * @return {object}
+ * @throws {InvalidAddressError}
+ */
+function decodeBase58Address(address) {
+  try {
+    const payload = bs58check.decode(address)
+    if (payload.length !== BASE_58_CHECK_PAYLOAD_LENGTH) {
+      throw new InvalidAddressError()
+    }
+    const versionByte = payload[0]
+    const hash = Array.prototype.slice.call(payload, 1)
+    switch (versionByte) {
+      case VERSION_BYTE[Format.Legacy][Network.Mainnet][Type.P2PKH]:
+        return {
+          hash: hash,
+          format: Format.Legacy,
+          network: Network.Mainnet,
+          type: Type.P2PKH,
+        }
+      case VERSION_BYTE[Format.Legacy][Network.Mainnet][Type.P2SH]:
+        return {
+          hash: hash,
+          format: Format.Legacy,
+          network: Network.Mainnet,
+          type: Type.P2SH,
+        }
+      case VERSION_BYTE[Format.Legacy][Network.Testnet][Type.P2PKH]:
+        return {
+          hash: hash,
+          format: Format.Legacy,
+          network: Network.Testnet,
+          type: Type.P2PKH,
+        }
+      case VERSION_BYTE[Format.Legacy][Network.Testnet][Type.P2SH]:
+        return {
+          hash: hash,
+          format: Format.Legacy,
+          network: Network.Testnet,
+          type: Type.P2SH,
+        }
+      case VERSION_BYTE[Format.Bitpay][Network.Mainnet][Type.P2PKH]:
+        return {
+          hash: hash,
+          format: Format.Bitpay,
+          network: Network.Mainnet,
+          type: Type.P2PKH,
+        }
+      case VERSION_BYTE[Format.Bitpay][Network.Mainnet][Type.P2SH]:
+        return {
+          hash: hash,
+          format: Format.Bitpay,
+          network: Network.Mainnet,
+          type: Type.P2SH,
+        }
+    }
+  } catch (error) {}
+  throw new InvalidAddressError()
+}
+
+/**
+ * Attempts to decode the given address assuming it is a cashaddr address.
+ * @private
+ * @param {string} address - A valid Bitcoin Cash address in any format.
+ * @return {object}
+ * @throws {InvalidAddressError}
+ */
+function decodeCashAddress(address) {
+  if (address.indexOf(':') !== -1) {
+    try {
+      return decodeCashAddressWithPrefix(address)
+    } catch (error) {}
+  } else {
+    const prefixes = ['bitcoincash', 'bchtest', 'bchreg']
+    for (let i = 0; i < prefixes.length; ++i) {
+      try {
+        const prefix = prefixes[i]
+        return decodeCashAddressWithPrefix(prefix + ':' + address)
+      } catch (error) {}
+    }
+  }
+  throw new InvalidAddressError()
+}
+
+/**
+ * Attempts to decode the given address assuming it is a cashaddr address with explicit prefix.
+ * @private
+ * @param {string} address - A valid Bitcoin Cash address in any format.
+ * @return {object}
+ * @throws {InvalidAddressError}
+ */
+function decodeCashAddressWithPrefix(address) {
+  try {
+    const decoded = cashaddr.decode(address)
+    const hash = Array.prototype.slice.call(decoded.hash, 0)
+    const type = decoded.type === 'P2PKH' ? Type.P2PKH : Type.P2SH
+    switch (decoded.prefix) {
+      case 'bitcoincash':
+        return {
+          hash: hash,
+          format: Format.Cashaddr,
+          network: Network.Mainnet,
+          type: type,
+        }
+      case 'bchtest':
+      case 'bchreg':
+        return {
+          hash: hash,
+          format: Format.Cashaddr,
+          network: Network.Testnet,
+          type: type,
+        }
+    }
+  } catch (error) {}
+  throw new InvalidAddressError()
+}
+
+/**
+ * Encodes the given decoded address into legacy format.
+ * @private
+ * @param {object} decoded
+ * @returns {string}
+ */
+function encodeAsLegacy(decoded) {
+  const versionByte = VERSION_BYTE[Format.Legacy][decoded.network][decoded.type]
+  const buffer = Buffer.alloc(1 + decoded.hash.length)
+  buffer[0] = versionByte
+  buffer.set(decoded.hash, 1)
+  return bs58check.encode(buffer)
+}
+
+/**
+ * Encodes the given decoded address into bitpay format.
+ * @private
+ * @param {object} decoded
+ * @returns {string}
+ */
+function encodeAsBitpay(decoded) {
+  const versionByte = VERSION_BYTE[Format.Bitpay][decoded.network][decoded.type]
+  const buffer = Buffer.alloc(1 + decoded.hash.length)
+  buffer[0] = versionByte
+  buffer.set(decoded.hash, 1)
+  return bs58check.encode(buffer)
+}
+
+/**
+ * Encodes the given decoded address into cashaddr format.
+ * @private
+ * @param {object} decoded
+ * @returns {string}
+ */
+function encodeAsCashaddr(decoded) {
+  const prefix = decoded.network === Network.Mainnet ? 'bitcoincash' : 'bchtest'
+  const type = decoded.type === Type.P2PKH ? 'P2PKH' : 'P2SH'
+  const hash = new Uint8Array(decoded.hash)
+  return cashaddr.encode(prefix, type, hash)
+}
+
+/**
+ * Returns a boolean indicating whether the address is in legacy format.
+ * @static
+ * @param {string} address - A valid Bitcoin Cash address in any format.
+ * @returns {boolean}
+ * @throws {InvalidAddressError}
+ */
+function isLegacyAddress(address) {
+  return detectAddressFormat(address) === Format.Legacy
+}
+
+/**
+ * Returns a boolean indicating whether the address is in bitpay format.
+ * @static
+ * @param {string} address - A valid Bitcoin Cash address in any format.
+ * @returns {boolean}
+ * @throws {InvalidAddressError}
+ */
+function isBitpayAddress(address) {
+  return detectAddressFormat(address) === Format.Bitpay
+}
+
+/**
+ * Returns a boolean indicating whether the address is in cashaddr format.
+ * @static
+ * @param {string} address - A valid Bitcoin Cash address in any format.
+ * @returns {boolean}
+ * @throws {InvalidAddressError}
+ */
+function isCashAddress(address) {
+  return detectAddressFormat(address) === Format.Cashaddr
+}
+
+/**
+ * Returns a boolean indicating whether the address is a mainnet address.
+ * @static
+ * @param {string} address - A valid Bitcoin Cash address in any format.
+ * @returns {boolean}
+ * @throws {InvalidAddressError}
+ */
+function isMainnetAddress(address) {
+  return detectAddressNetwork(address) === Network.Mainnet
+}
+
+/**
+ * Returns a boolean indicating whether the address is a testnet address.
+ * @static
+ * @param {string} address - A valid Bitcoin Cash address in any format.
+ * @returns {boolean}
+ * @throws {InvalidAddressError}
+ */
+function isTestnetAddress(address) {
+  return detectAddressNetwork(address) === Network.Testnet
+}
+
+/**
+ * Returns a boolean indicating whether the address is a p2pkh address.
+ * @static
+ * @param {string} address - A valid Bitcoin Cash address in any format.
+ * @returns {boolean}
+ * @throws {InvalidAddressError}
+ */
+function isP2PKHAddress(address) {
+  return detectAddressType(address) === Type.P2PKH
+}
+
+/**
+ * Returns a boolean indicating whether the address is a p2sh address.
+ * @static
+ * @param {string} address - A valid Bitcoin Cash address in any format.
+ * @returns {boolean}
+ * @throws {InvalidAddressError}
+ */
+function isP2SHAddress(address) {
+  return detectAddressType(address) === Type.P2SH
+}
+
+/**
+ * Error thrown when the address given as input is not a valid Bitcoin Cash address.
+ * @constructor
+ * InvalidAddressError
+ */
+function InvalidAddressError() {
+  const error = new Error()
+  this.name = error.name = 'InvalidAddressError'
+  this.message = error.message = 'Received an invalid Bitcoin Cash address as input.'
+  this.stack = error.stack
+}
+
+InvalidAddressError.prototype = Object.create(Error.prototype)
+
+export {
+  Format,
+  Network,
+  Type,
+  isValidAddress,
+  detectAddressFormat,
+  detectAddressNetwork,
+  detectAddressType,
+  toLegacyAddress,
+  toBitpayAddress,
+  toCashAddress,
+  isLegacyAddress,
+  isBitpayAddress,
+  isCashAddress,
+  isMainnetAddress,
+  isTestnetAddress,
+  isP2PKHAddress,
+  isP2SHAddress,
+  InvalidAddressError,
+}

--- a/packages/xchain-bitcoincash/src/utils.ts
+++ b/packages/xchain-bitcoincash/src/utils.ts
@@ -4,7 +4,7 @@
 import { Network, TxType } from '@xchainjs/xchain-client' // Importing types related to network and transactions
 import { Address, baseAmount } from '@xchainjs/xchain-util' // Importing utilities related to addresses and amounts
 import { Tx, TxFrom, TxTo } from '@xchainjs/xchain-utxo' // Importing Bitcoin Cash address utilities
-import * as bchaddr from 'bchaddrjs' // Importing coin information utility
+import * as bchaddr from './bchaddrjs' // Importing coin information utility
 import * as bitcore from 'bitcore-lib-cash'
 import { AssetBCH, BCH_DECIMAL } from './const' // Importing BCH asset and decimal constants
 import { Transaction, TransactionInput, TransactionOutput } from './types' // Importing custom transaction types

--- a/yarn.lock
+++ b/yarn.lock
@@ -3270,13 +3270,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/bchaddrjs@npm:0.4.0":
-  version: 0.4.0
-  resolution: "@types/bchaddrjs@npm:0.4.0"
-  checksum: 10c0/f83528294d4921d93f2a6eb78e4d9d6730022ba9da72cfcb390fe5bf863301fe6188c8584a4d8865a81fc8e958ebe6f9b4f1a02326d5e007a42c8a07be11e617
-  languageName: node
-  linkType: hard
-
 "@types/bip39@npm:^3.0.0":
   version: 3.0.4
   resolution: "@types/bip39@npm:3.0.4"
@@ -3299,6 +3292,13 @@ __metadata:
   version: 2.4.3
   resolution: "@types/blake2b-wasm@npm:2.4.3"
   checksum: 10c0/9981b9d7b4718369fe7c8d9123c982e49fa376e9da31a3a338b623ee2c422c18500c665b4dea3217a30c31dd96919e9f361134a792bbc552be24cc2428682f47
+  languageName: node
+  linkType: hard
+
+"@types/cashaddrjs@npm:^0":
+  version: 0.3.3
+  resolution: "@types/cashaddrjs@npm:0.3.3"
+  checksum: 10c0/736ec69ae11f434daf19093f89fada29f6310d0262bbd6f10be2180c5a64726bc63d5ce26a2e0de41960772cfb318756c4eb74b5e5ee00a205e27261324afa9e
   languageName: node
   linkType: hard
 
@@ -3907,8 +3907,8 @@ __metadata:
     "@ledgerhq/hw-app-btc": "npm:^10.9.0"
     "@ledgerhq/hw-transport-node-hid": "npm:^6.28.6"
     "@scure/bip32": "npm:^1.7.0"
-    "@types/bchaddrjs": "npm:0.4.0"
     "@types/bitcore-lib-cash": "npm:^8.23.8"
+    "@types/cashaddrjs": "npm:^0"
     "@xchainjs/xchain-client": "workspace:*"
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
@@ -3916,8 +3916,9 @@ __metadata:
     "@xchainjs/xchain-utxo-providers": "workspace:*"
     axios: "npm:^1.8.4"
     axios-mock-adapter: "npm:^2.1.0"
-    bchaddrjs: "npm:0.5.2"
     bitcore-lib-cash: "npm:11.0.0"
+    bs58check: "npm:^4.0.0"
+    cashaddrjs: "npm:^0.4.4"
     coinselect: "npm:3.1.12"
   languageName: unknown
   linkType: soft
@@ -5021,18 +5022,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bchaddrjs@npm:0.5.2, bchaddrjs@npm:^0.5.2":
-  version: 0.5.2
-  resolution: "bchaddrjs@npm:0.5.2"
-  dependencies:
-    bs58check: "npm:2.1.2"
-    buffer: "npm:^6.0.3"
-    cashaddrjs: "npm:0.4.4"
-    stream-browserify: "npm:^3.0.0"
-  checksum: 10c0/c82312703a078e068c8414dedccd5b35eaeb42b2c060447be3b2e9319db6c5f746c18ada21a15c09b60ed5be01b3cc9a655a3b934a86658ed0767ee37a04958f
-  languageName: node
-  linkType: hard
-
 "bech32-buffer@npm:^0.2.0":
   version: 0.2.1
   resolution: "bech32-buffer@npm:0.2.1"
@@ -5444,7 +5433,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bs58check@npm:2.1.2, bs58check@npm:<3.0.0, bs58check@npm:^2.0.0, bs58check@npm:^2.1.1, bs58check@npm:^2.1.2":
+"bs58check@npm:<3.0.0, bs58check@npm:^2.0.0, bs58check@npm:^2.1.1, bs58check@npm:^2.1.2":
   version: 2.1.2
   resolution: "bs58check@npm:2.1.2"
   dependencies:
@@ -5654,7 +5643,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cashaddrjs@npm:0.4.4":
+"cashaddrjs@npm:^0.4.4":
   version: 0.4.4
   resolution: "cashaddrjs@npm:0.4.4"
   dependencies:
@@ -8071,7 +8060,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.4":
+"inherits@npm:2, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
@@ -11004,7 +10993,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.0":
+"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -11943,16 +11932,6 @@ __metadata:
     es-errors: "npm:^1.3.0"
     internal-slot: "npm:^1.1.0"
   checksum: 10c0/de4e45706bb4c0354a4b1122a2b8cc45a639e86206807ce0baf390ee9218d3ef181923fa4d2b67443367c491aa255c5fbaa64bb74648e3c5b48299928af86c09
-  languageName: node
-  linkType: hard
-
-"stream-browserify@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "stream-browserify@npm:3.0.0"
-  dependencies:
-    inherits: "npm:~2.0.4"
-    readable-stream: "npm:^3.5.0"
-  checksum: 10c0/ec3b975a4e0aa4b3dc5e70ffae3fc8fd29ac725353a14e72f213dff477b00330140ad014b163a8cbb9922dfe90803f81a5ea2b269e1bbfd8bd71511b88f889ad
   languageName: node
   linkType: hard
 
@@ -13403,7 +13382,6 @@ __metadata:
     "@xchainjs/xchain-wallet": "workspace:*"
     axios: "npm:1.8.4"
     axios-retry: "npm:^3.3.1"
-    bchaddrjs: "npm:^0.5.2"
     bech32-buffer: "npm:^0.2.0"
     bitcoinjs-lib: "npm:^6.1.7"
     dotenv: "npm:^16.0.0"


### PR DESCRIPTION
Related issue: https://github.com/xchainjs/xchainjs-lib/issues/1453

Removed bchaddrjs dependency and inlined core logic

I removed the bchaddrjs dependency after analyzing the current ecosystem and not finding a valid, actively maintained alternative. Upon inspection, I noticed that most of the package size came from unnecessary polyfills bundled with it.

Since the library only contained a single source file, I decided to copy that file directly into our codebase. This allows us to retain the same BCH address validation and conversion functionality while eliminating the excessive weight introduced by the external dependency.

You can verify the original bundle size here: https://bundlephobia.com/package/bchaddrjs@0.5.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a comprehensive Bitcoin Cash address utility supporting detection, validation, and conversion between Legacy, Bitpay, and Cashaddr formats.
  * Added new functions to check address validity, format, network, and type, as well as functions for format conversion.

* **Bug Fixes**
  * Improved test coverage for Bitcoin Cash address conversions and validation.

* **Chores**
  * Removed the external bchaddrjs dependency in favor of an optimized internal implementation, reducing bundle size.
  * Updated dependencies to use bs58check and cashaddrjs for address processing.

* **Documentation**
  * Added a README note explaining the change in address utility implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->