### PR TITLE
Update elliptic dependency to address security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "micromatch": "4.0.8",
     "word-wrap": "1.2.4",
     "undici": "5.29.0",
-    "form-data": "4.0.4"
+    "form-data": "4.0.4",
+    "elliptic": "^6.6.1"
   },
   "devDependencies": {
     "@actions/core": "1.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6450,37 +6450,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:6.5.4":
-  version: 6.5.4
-  resolution: "elliptic@npm:6.5.4"
-  dependencies:
-    bn.js: "npm:^4.11.9"
-    brorand: "npm:^1.1.0"
-    hash.js: "npm:^1.0.0"
-    hmac-drbg: "npm:^1.0.1"
-    inherits: "npm:^2.0.4"
-    minimalistic-assert: "npm:^1.0.1"
-    minimalistic-crypto-utils: "npm:^1.0.1"
-  checksum: 10c0/5f361270292c3b27cf0843e84526d11dec31652f03c2763c6c2b8178548175ff5eba95341dd62baff92b2265d1af076526915d8af6cc9cb7559c44a62f8ca6e2
-  languageName: node
-  linkType: hard
-
-"elliptic@npm:^6.4.0, elliptic@npm:^6.5.4":
-  version: 6.5.7
-  resolution: "elliptic@npm:6.5.7"
-  dependencies:
-    bn.js: "npm:^4.11.9"
-    brorand: "npm:^1.1.0"
-    hash.js: "npm:^1.0.0"
-    hmac-drbg: "npm:^1.0.1"
-    inherits: "npm:^2.0.4"
-    minimalistic-assert: "npm:^1.0.1"
-    minimalistic-crypto-utils: "npm:^1.0.1"
-  checksum: 10c0/799959b6c54ea3564e8961f35abdf8c77e37617f3051614b05ab1fb6a04ddb65bd1caa75ed1bae375b15dda312a0f79fed26ebe76ecf05c5a7af244152a601b8
-  languageName: node
-  linkType: hard
-
-"elliptic@npm:^6.5.3, elliptic@npm:^6.6.1":
+"elliptic@npm:^6.6.1":
   version: 6.6.1
   resolution: "elliptic@npm:6.6.1"
   dependencies:


### PR DESCRIPTION
  - Add yarn resolution to force elliptic@^6.6.1 across all dependencies

 Fixes critical security vulnerabilities:
  - CVE-2024-42460: Private key extraction risk in elliptic < 6.6.1
  - CVE-2024-42461: BER-encoded signature acceptance in elliptic < 6.5.7