### PR TITLE
Override midgard decimals

### DIFF
--- a/.changeset/wide-states-stay.md
+++ b/.changeset/wide-states-stay.md
@@ -1,0 +1,5 @@
+---
+'@xchainjs/xchain-midgard-query': patch
+---
+
+Option override midgard decimals

--- a/packages/xchain-midgard-query/__tests__/midgard-query.test.ts
+++ b/packages/xchain-midgard-query/__tests__/midgard-query.test.ts
@@ -1,0 +1,86 @@
+import { AssetType, assetFromStringEx } from '@xchainjs/xchain-util'
+
+import mockMidgardApi from '../__mocks__/midgard-api'
+import { MidgardCache } from '../src/midgard-cache'
+import { MidgardQuery } from '../src/midgard-query'
+import { AssetATOM, AssetAVAX, AssetBTC } from '../src/utils/const'
+import { Midgard } from '../src/utils/midgard'
+
+const mainnetMidgard = new Midgard()
+const midgardCache = new MidgardCache(mainnetMidgard)
+
+describe('MidgardQuery Test', () => {
+  beforeAll(() => {
+    mockMidgardApi.init()
+  })
+  afterEach(() => {
+    mockMidgardApi.restore()
+  })
+
+  it(`Should return default THORChain decimals for RUNE native asset`, async () => {
+    const midgardQuery = new MidgardQuery(midgardCache)
+    const runeAsset = { chain: 'THOR', symbol: 'RUNE', ticker: 'RUNE', type: AssetType.NATIVE }
+    const decimals = await midgardQuery.getDecimalForAsset(runeAsset)
+    expect(decimals).toBe(8)
+  })
+
+  it(`Should return default THORChain decimals for synth asset`, async () => {
+    const midgardQuery = new MidgardQuery(midgardCache)
+    const synthAsset = assetFromStringEx('BTC/BTC')
+    const decimals = await midgardQuery.getDecimalForAsset(synthAsset)
+    expect(decimals).toBe(8)
+  })
+
+  it(`Should return default THORChain decimals for trade asset`, async () => {
+    const midgardQuery = new MidgardQuery(midgardCache)
+    const tradeAsset = assetFromStringEx('BTC~BTC')
+    const decimals = await midgardQuery.getDecimalForAsset(tradeAsset)
+    expect(decimals).toBe(8)
+  })
+
+  it(`Should return default THORChain decimals for secured asset`, async () => {
+    const midgardQuery = new MidgardQuery(midgardCache)
+    const securedAsset = assetFromStringEx('BTC-BTC')
+    const decimals = await midgardQuery.getDecimalForAsset(securedAsset)
+    expect(decimals).toBe(8)
+  })
+
+  it(`Should return override decimals when provided in constructor`, async () => {
+    const overrideDecimals = { 'GAIA.ATOM': 18 }
+    const midgardQueryWithOverride = new MidgardQuery(midgardCache, overrideDecimals)
+
+    const decimals = await midgardQueryWithOverride.getDecimalForAsset(AssetATOM)
+    expect(decimals).toBe(18)
+  })
+
+  it(`Should return pool native decimals when no override is provided`, async () => {
+    const midgardQuery = new MidgardQuery(midgardCache)
+    const decimals = await midgardQuery.getDecimalForAsset(AssetATOM)
+    expect(decimals).toBe(6)
+  })
+
+  it(`Should prioritize override decimals over pool decimals`, async () => {
+    const overrideDecimals = { 'GAIA.ATOM': 12 }
+    const midgardQueryWithOverride = new MidgardQuery(midgardCache, overrideDecimals)
+
+    const decimals = await midgardQueryWithOverride.getDecimalForAsset(AssetATOM)
+    expect(decimals).toBe(12)
+  })
+
+  it(`Should handle multiple assets with different override decimals`, async () => {
+    const overrideDecimals = {
+      'GAIA.ATOM': 18,
+      'AVAX.AVAX': 12,
+      'BTC.BTC': 4,
+    }
+    const midgardQueryWithOverride = new MidgardQuery(midgardCache, overrideDecimals)
+
+    const atomDecimals = await midgardQueryWithOverride.getDecimalForAsset(AssetATOM)
+    const avaxDecimals = await midgardQueryWithOverride.getDecimalForAsset(AssetAVAX)
+    const btcDecimals = await midgardQueryWithOverride.getDecimalForAsset(AssetBTC)
+
+    expect(atomDecimals).toBe(18)
+    expect(avaxDecimals).toBe(12)
+    expect(btcDecimals).toBe(4)
+  })
+})

--- a/packages/xchain-midgard-query/src/midgard-query.ts
+++ b/packages/xchain-midgard-query/src/midgard-query.ts
@@ -30,6 +30,7 @@ const defaultCache = new MidgardCache()
  */
 export class MidgardQuery {
   readonly midgardCache: MidgardCache
+  readonly overrideDecimals: Record<string, number>
 
   /**
    * Constructor to create a MidgardQuery.
@@ -37,8 +38,9 @@ export class MidgardQuery {
    * @param midgardCache - An instance of the MidgardCache (could be pointing to stagenet, testnet, mainnet).
    * @returns MidgardQuery
    */
-  constructor(midgardCache = defaultCache) {
+  constructor(midgardCache = defaultCache, overrideDecimals: Record<string, number> = {}) {
     this.midgardCache = midgardCache
+    this.overrideDecimals = overrideDecimals
   }
 
   /**
@@ -108,6 +110,10 @@ export class MidgardQuery {
    * @returns {number} - Number of decimals from Midgard. Reference: https://gitlab.com/thorchain/midgard#refresh-native-decimals
    */
   public async getDecimalForAsset(asset: CompatibleAsset): Promise<number> {
+    if (this.overrideDecimals[assetToString(asset)]) {
+      return this.overrideDecimals[assetToString(asset)]
+    }
+
     if (isAssetRuneNative(asset) || isSynthAsset(asset) || isTradeAsset(asset) || isSecuredAsset(asset))
       return DEFAULT_THORCHAIN_DECIMALS
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support per-asset decimal overrides via an optional overrides map when initializing the query client.
  - Overrides take precedence over pool/default decimals; default behavior remains for native, synth, trade, and secured assets when no override is provided.
- Tests
  - Added comprehensive tests covering overrides, default resolution, and multiple asset formats (including synth/trade/secured) and multi-asset scenarios.
- Chores
  - Added a changeset declaring a patch release with the summary “Option override midgard decimals.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->