### PR TITLE
feat: add network configuration support to aggr

### DIFF
--- a/.changeset/famous-terms-tickle.md
+++ b/.changeset/famous-terms-tickle.md
@@ -1,0 +1,5 @@
+---
+'@xchainjs/xchain-aggregator': patch
+---
+
+Added network param to aggregator config

--- a/packages/xchain-aggregator/NETWORK_CONFIG.md
+++ b/packages/xchain-aggregator/NETWORK_CONFIG.md
@@ -1,0 +1,106 @@
+# Network Configuration
+
+The XChain Aggregator now supports network configuration to work with different environments (mainnet, stagenet, testnet).
+
+## Usage
+
+### Explicit Network Configuration
+
+```typescript
+import { Aggregator } from '@xchainjs/xchain-aggregator'
+import { Network } from '@xchainjs/xchain-client'
+
+// Configure aggregator for stagenet
+const stagenetAggregator = new Aggregator({
+  protocols: ['Thorchain', 'Mayachain'],
+  network: Network.Stagenet
+})
+
+// Configure aggregator for mainnet
+const mainnetAggregator = new Aggregator({
+  protocols: ['Thorchain', 'Mayachain'],
+  network: Network.Mainnet
+})
+```
+
+### Network Inference from Wallet
+
+```typescript
+import { Wallet } from '@xchainjs/xchain-wallet'
+import { Client as ThorClient } from '@xchainjs/xchain-thorchain'
+
+// Create wallet with stagenet clients
+const stagenetWallet = new Wallet({
+  THOR: new ThorClient({ network: Network.Stagenet }),
+  // ... other clients with Network.Stagenet
+})
+
+// Aggregator will automatically use stagenet
+const aggregator = new Aggregator({
+  protocols: ['Thorchain'],
+  wallet: stagenetWallet
+  // network will be inferred as Network.Stagenet
+})
+```
+
+### Network Priority
+
+The aggregator determines the network in the following priority order:
+
+1. **Explicit `network` parameter** - highest priority
+2. **Network from wallet clients** - if no explicit network set
+3. **Default to mainnet** - fallback if neither above are available
+
+```typescript
+// Explicit network takes precedence over wallet
+const aggregator = new Aggregator({
+  protocols: ['Thorchain'],
+  wallet: mainnetWallet,        // wallet has mainnet clients
+  network: Network.Stagenet     // but this takes precedence
+})
+// Result: aggregator uses stagenet
+```
+
+## TRON Support
+
+TRON pools are only available on stagenet, so to access TRON swaps:
+
+```typescript
+const tronAggregator = new Aggregator({
+  protocols: ['Thorchain'],
+  network: Network.Stagenet  // Required for TRON support
+})
+
+// Now you can quote TRON swaps
+const tronQuotes = await tronAggregator.estimateSwap({
+  fromAsset: AssetTRX,
+  destinationAsset: AssetBTC,
+  amount: new CryptoAmount(assetToBase(assetAmount('100', 6)), AssetTRX)
+})
+```
+
+## Getting Current Configuration
+
+```typescript
+const config = aggregator.getConfiguration()
+console.log('Current network:', config.network)
+console.log('Active protocols:', config.protocols)
+```
+
+## Network Endpoints
+
+The aggregator automatically uses the correct endpoints for each network:
+
+- **Mainnet**: `https://thornode.ninerealms.com`
+- **Stagenet**: `https://stagenet-thornode.ninerealms.com`
+- **Testnet**: `https://testnet.thornode.thorchain.info`
+
+## Supported Networks by Protocol
+
+| Protocol  | Mainnet | Stagenet | Testnet |
+|-----------|---------|----------|---------|
+| Thorchain | ✅      | ✅       | ✅      |
+| Mayachain | ✅      | ✅       | ✅      |
+| Chainflip | ✅      | ❌       | ❌      |
+
+*Note: Chainflip only supports mainnet*

--- a/packages/xchain-aggregator/__tests__/network-config.test.ts
+++ b/packages/xchain-aggregator/__tests__/network-config.test.ts
@@ -1,0 +1,84 @@
+import { Network } from '@xchainjs/xchain-client'
+import { Wallet } from '@xchainjs/xchain-wallet'
+import { Client as ThorClient } from '@xchainjs/xchain-thorchain'
+
+import { Aggregator } from '../src'
+
+describe('Network Configuration Tests', () => {
+  it('Should create aggregator with explicit network configuration', () => {
+    // Test that aggregator accepts network parameter
+    const stagenetAggregator = new Aggregator({
+      protocols: ['Thorchain'],
+      network: Network.Stagenet,
+    })
+
+    expect(stagenetAggregator).toBeDefined()
+
+    const mainnetAggregator = new Aggregator({
+      protocols: ['Thorchain'],
+      network: Network.Mainnet,
+    })
+
+    expect(mainnetAggregator).toBeDefined()
+  })
+
+  it('Should infer network from wallet when network not explicitly set', () => {
+    // Create a wallet with stagenet clients
+    const stagenetWallet = new Wallet({
+      THOR: new ThorClient({ network: Network.Stagenet }),
+    })
+
+    // Create aggregator without explicit network - should infer from wallet
+    const aggregator = new Aggregator({
+      protocols: ['Thorchain'],
+      wallet: stagenetWallet,
+    })
+
+    expect(aggregator).toBeDefined()
+  })
+
+  it('Should prefer explicit network over wallet network', () => {
+    // Create wallet with mainnet
+    const mainnetWallet = new Wallet({
+      THOR: new ThorClient({ network: Network.Mainnet }),
+    })
+
+    // Create aggregator with explicit stagenet - should use stagenet, not mainnet from wallet
+    const aggregator = new Aggregator({
+      protocols: ['Thorchain'],
+      wallet: mainnetWallet,
+      network: Network.Stagenet, // This should take precedence
+    })
+
+    expect(aggregator).toBeDefined()
+  })
+
+  it('Should default to mainnet when no network or wallet provided', () => {
+    const aggregator = new Aggregator({
+      protocols: ['Thorchain'],
+    })
+
+    expect(aggregator).toBeDefined()
+  })
+
+  it('Should access protocol configurations without errors', () => {
+    const aggregator = new Aggregator({
+      protocols: ['Thorchain'],
+      network: Network.Stagenet,
+    })
+
+    const config = aggregator.getConfiguration()
+    expect(config.protocols).toContain('Thorchain')
+    expect(config.protocols.length).toBe(1)
+  })
+
+  it('Should return network in configuration', () => {
+    const stagenetAggregator = new Aggregator({
+      protocols: ['Thorchain'],
+      network: Network.Stagenet,
+    })
+
+    const config = stagenetAggregator.getConfiguration()
+    expect(config.network).toBe(Network.Stagenet)
+  })
+})

--- a/packages/xchain-aggregator/src/aggregator.ts
+++ b/packages/xchain-aggregator/src/aggregator.ts
@@ -23,10 +23,10 @@ export class Aggregator {
   constructor(config?: Config) {
     const fConfig = { ...DEFAULT_CONFIG, ...config }
 
-    // Determine network: explicit network > wallet network > mainnet default
-    let network = fConfig.network || Network.Mainnet
-    if (!fConfig.network && fConfig.wallet) {
-      network = fConfig.wallet.getNetwork()
+    // Determine network: explicit config.network > wallet network > default
+    let network = config?.network || Network.Mainnet
+    if (!config?.network && config?.wallet) {
+      network = config.wallet.getNetwork()
     }
     const configWithNetwork = { ...fConfig, network }
 
@@ -51,10 +51,10 @@ export class Aggregator {
   public setConfiguration(config: Config) {
     const fConfig = { ...DEFAULT_CONFIG, ...config }
 
-    // Determine network: explicit network > wallet network > mainnet default
-    let network = fConfig.network || Network.Mainnet
-    if (!fConfig.network && fConfig.wallet) {
-      network = fConfig.wallet.getNetwork()
+    // Determine network: explicit config.network > wallet network > mainnet default
+    let network = config.network || Network.Mainnet
+    if (!config.network && config.wallet) {
+      network = config.wallet.getNetwork()
     }
     const configWithNetwork = { ...fConfig, network }
 

--- a/packages/xchain-aggregator/src/const.ts
+++ b/packages/xchain-aggregator/src/const.ts
@@ -1,7 +1,9 @@
+import { Network } from '@xchainjs/xchain-client'
 import { Config, Protocol } from './types'
 
 export const SupportedProtocols: Protocol[] = ['Thorchain', 'Mayachain', 'Chainflip']
 
 export const DEFAULT_CONFIG: Required<Omit<Config, 'wallet' | 'affiliate'>> = {
   protocols: SupportedProtocols,
+  network: Network.Mainnet,
 }

--- a/packages/xchain-aggregator/src/protocols/mayachain/mayachainProtocol.ts
+++ b/packages/xchain-aggregator/src/protocols/mayachain/mayachainProtocol.ts
@@ -2,7 +2,7 @@ import { Network } from '@xchainjs/xchain-client'
 import { AssetCacao, MAYAChain } from '@xchainjs/xchain-mayachain'
 import { ApproveParams, IsApprovedParams, MayachainAMM } from '@xchainjs/xchain-mayachain-amm'
 import { MayachainCache, MayachainQuery, Mayanode } from '@xchainjs/xchain-mayachain-query'
-import { MidgardQuery } from '@xchainjs/xchain-mayamidgard-query'
+import { MidgardCache, MidgardQuery, MidgardApi } from '@xchainjs/xchain-mayamidgard-query'
 import {
   AnyAsset,
   Chain,
@@ -39,8 +39,8 @@ export class MayachainProtocol implements IProtocol {
 
     // Create MayachainQuery with proper network configuration
     // TODO: Fix MidgardQuery constructor to accept network parameter
-    // For now, create with defaults and update Mayanode with network
-    const mayachainCache = new MayachainCache(new MidgardQuery(), new Mayanode(network))
+    const midgardCache = new MidgardCache(new MidgardApi(network))
+    const mayachainCache = new MayachainCache(new MidgardQuery(midgardCache), new Mayanode(network))
     this.mayachainQuery = new MayachainQuery(mayachainCache)
     this.mayachainAmm = new MayachainAMM(this.mayachainQuery, configuration?.wallet)
     this.configuration = configuration

--- a/packages/xchain-aggregator/src/protocols/mayachain/mayachainProtocol.ts
+++ b/packages/xchain-aggregator/src/protocols/mayachain/mayachainProtocol.ts
@@ -1,6 +1,8 @@
+import { Network } from '@xchainjs/xchain-client'
 import { AssetCacao, MAYAChain } from '@xchainjs/xchain-mayachain'
 import { ApproveParams, IsApprovedParams, MayachainAMM } from '@xchainjs/xchain-mayachain-amm'
-import { MayachainQuery } from '@xchainjs/xchain-mayachain-query'
+import { MayachainCache, MayachainQuery, Mayanode } from '@xchainjs/xchain-mayachain-query'
+import { MidgardQuery } from '@xchainjs/xchain-mayamidgard-query'
 import {
   AnyAsset,
   Chain,
@@ -32,7 +34,14 @@ export class MayachainProtocol implements IProtocol {
   private wallet?: Wallet
 
   constructor(configuration?: ProtocolConfig) {
-    this.mayachainQuery = new MayachainQuery()
+    // Use network from configuration, fallback to wallet network, or default to mainnet
+    const network = configuration?.network || configuration?.wallet?.getNetwork() || Network.Mainnet
+
+    // Create MayachainQuery with proper network configuration
+    // TODO: Fix MidgardQuery constructor to accept network parameter
+    // For now, create with defaults and update Mayanode with network
+    const mayachainCache = new MayachainCache(new MidgardQuery(), new Mayanode(network))
+    this.mayachainQuery = new MayachainQuery(mayachainCache)
     this.mayachainAmm = new MayachainAMM(this.mayachainQuery, configuration?.wallet)
     this.configuration = configuration
     this.wallet = configuration?.wallet

--- a/packages/xchain-aggregator/src/protocols/protocolFactory.ts
+++ b/packages/xchain-aggregator/src/protocols/protocolFactory.ts
@@ -9,6 +9,7 @@ const getProtocolConfig = (name: Protocol, configuration: Config): ProtocolConfi
     wallet: configuration.wallet,
     affiliateAddress: configuration.affiliate?.affiliates[name],
     affiliateBps: configuration.affiliate?.affiliates[name] ? configuration.affiliate.basisPoints : undefined,
+    network: configuration.network,
   }
 }
 

--- a/packages/xchain-aggregator/src/protocols/thorchain/thorchainProtocol.ts
+++ b/packages/xchain-aggregator/src/protocols/thorchain/thorchainProtocol.ts
@@ -1,6 +1,7 @@
+import { Network } from '@xchainjs/xchain-client'
 import { AssetRuneNative, THORChain } from '@xchainjs/xchain-thorchain'
 import { ApproveParams, IsApprovedParams, ThorchainAMM } from '@xchainjs/xchain-thorchain-amm'
-import { ThorchainQuery } from '@xchainjs/xchain-thorchain-query'
+import { ThorchainCache, ThorchainQuery, Thornode } from '@xchainjs/xchain-thorchain-query'
 import {
   AnyAsset,
   Chain,
@@ -30,7 +31,12 @@ export class ThorchainProtocol implements IProtocol {
   private wallet?: Wallet
 
   constructor(configuration?: ProtocolConfig) {
-    this.thorchainQuery = new ThorchainQuery()
+    // Use network from configuration, fallback to wallet network, or default to mainnet
+    const network = configuration?.network || configuration?.wallet?.getNetwork() || Network.Mainnet
+
+    // Create ThorchainQuery with proper network configuration
+    const thorchainCache = new ThorchainCache(new Thornode(network))
+    this.thorchainQuery = new ThorchainQuery(thorchainCache)
     this.thorchainAmm = new ThorchainAMM(this.thorchainQuery, configuration?.wallet)
     this.configuration = configuration
     this.wallet = configuration?.wallet

--- a/packages/xchain-aggregator/src/protocols/thorchain/thorchainProtocol.ts
+++ b/packages/xchain-aggregator/src/protocols/thorchain/thorchainProtocol.ts
@@ -23,6 +23,8 @@ import {
   TxSubmitted,
 } from '../../types'
 
+import { Midgard, MidgardCache, MidgardQuery } from '@xchainjs/xchain-midgard-query'
+
 export class ThorchainProtocol implements IProtocol {
   public readonly name = 'Thorchain'
   private thorchainQuery: ThorchainQuery
@@ -35,7 +37,8 @@ export class ThorchainProtocol implements IProtocol {
     const network = configuration?.network || configuration?.wallet?.getNetwork() || Network.Mainnet
 
     // Create ThorchainQuery with proper network configuration
-    const thorchainCache = new ThorchainCache(new Thornode(network))
+    const midgardCache = new MidgardCache(new Midgard(network))
+    const thorchainCache = new ThorchainCache(new Thornode(network), new MidgardQuery(midgardCache))
     this.thorchainQuery = new ThorchainQuery(thorchainCache)
     this.thorchainAmm = new ThorchainAMM(this.thorchainQuery, configuration?.wallet)
     this.configuration = configuration

--- a/packages/xchain-aggregator/src/types.ts
+++ b/packages/xchain-aggregator/src/types.ts
@@ -1,4 +1,4 @@
-import { TxHash } from '@xchainjs/xchain-client'
+import { TxHash, Network } from '@xchainjs/xchain-client'
 import {
   Address,
   AnyAsset,
@@ -64,6 +64,10 @@ export type Config = Partial<{
    * Wallet
    */
   wallet: Wallet
+  /**
+   * Network to use for protocols. If not specified, will be inferred from wallet or default to mainnet
+   */
+  network: Network
 }>
 
 /**
@@ -73,6 +77,7 @@ export type ProtocolConfig = Partial<{
   wallet: Wallet
   affiliateBps: number
   affiliateAddress: string
+  network: Network
 }>
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Aggregator now supports configurable network selection (explicit config, wallet inference, or default to mainnet) and exposes the active network in its configuration; protocols are network-aware.

* Documentation
  * Added NETWORK_CONFIG guide with precedence rules, examples, endpoints, and TRON stagenet notes.

* Tests
  * Added tests for explicit, inferred, and default network behavior and protocol configuration exposure.

* Chores
  * Added a patch release entry for the aggregator package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->