### PR TITLE
fix(mayachain-query): add TradeAsset to CompatibleAsset type

### DIFF
--- a/packages/xchain-mayachain-query/src/types.ts
+++ b/packages/xchain-mayachain-query/src/types.ts
@@ -12,7 +12,7 @@ import {
 } from '@xchainjs/xchain-util'
 import type BigNumber from 'bignumber.js'
 
-export type CompatibleAsset = Asset | TokenAsset | SynthAsset
+export type CompatibleAsset = Asset | TokenAsset | SynthAsset | TradeAsset
 
 /**
  * Represents fees associated with a swap.


### PR DESCRIPTION
## Summary

The `CompatibleAsset` type in `@xchainjs/xchain-mayachain-query` is missing `TradeAsset`, causing TypeScript errors when using trade assets with the MayaChain AMM.

**Current:**
```typescript
export type CompatibleAsset = Asset | TokenAsset | SynthAsset
```

**After this fix:**
```typescript
export type CompatibleAsset = Asset | TokenAsset | SynthAsset | TradeAsset
```

## Problem

- `TradeAsset` is already imported in `types.ts` but not included in the `CompatibleAsset` union
- The package has trade asset methods (`getTradeAssetUnits`, `getAddressTradeAccounts`, etc.)
- `mayachain-amm` uses `CryptoAmount<CompatibleAsset>` in function signatures, causing type errors when passing trade assets

## Solution

Add `TradeAsset` to the `CompatibleAsset` type union, aligning with `@xchainjs/xchain-thorchain-query` which already includes it.

## Testing

This is a type-only change. No runtime behavior is affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended asset compatibility to include TradeAsset, broadening the range of supported assets in the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->