### PR TITLE
Add type TradeAsset to compatible Asset

### DIFF
--- a/.changeset/wise-rocks-peel.md
+++ b/.changeset/wise-rocks-peel.md
@@ -1,0 +1,5 @@
+---
+'@xchainjs/xchain-mayachain-query': patch
+---
+
+Add type TradeAsset to Compatible Asset types

--- a/packages/xchain-mayachain-query/src/types.ts
+++ b/packages/xchain-mayachain-query/src/types.ts
@@ -12,7 +12,7 @@ import {
 } from '@xchainjs/xchain-util'
 import type BigNumber from 'bignumber.js'
 
-export type CompatibleAsset = Asset | TokenAsset | SynthAsset
+export type CompatibleAsset = Asset | TokenAsset | SynthAsset | TradeAsset
 
 /**
  * Represents fees associated with a swap.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TradeAsset to the supported asset types, expanding the range of compatible assets in the mayachain-query package.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->