### PR TITLE
feat(aggregator): add OneClick (NEAR Intents) protocol for cross-chai…

### DIFF
--- a/packages/xchain-aggregator/__tests__/oneclickProtocol.test.ts
+++ b/packages/xchain-aggregator/__tests__/oneclickProtocol.test.ts
@@ -1,0 +1,364 @@
+import { AssetBTC } from '@xchainjs/xchain-bitcoin'
+import { AssetETH } from '@xchainjs/xchain-ethereum'
+import { AssetCacao } from '@xchainjs/xchain-mayachain'
+import { AssetRuneNative } from '@xchainjs/xchain-thorchain'
+import { CryptoAmount, assetAmount, assetFromStringEx, assetToBase, assetToString } from '@xchainjs/xchain-util'
+
+import { OneClickProtocol } from '../src/protocols/oneclick'
+import { OneClickApi } from '../src/protocols/oneclick/api'
+import { OneClickToken } from '../src/protocols/oneclick/types'
+import {
+  findOneClickToken,
+  oneClickBlockchainToXChain,
+  xChainToOneClickBlockchain,
+} from '../src/protocols/oneclick/utils'
+
+// Mock fetch globally
+const mockFetch = jest.fn()
+global.fetch = mockFetch as unknown as typeof fetch
+
+const mockTokens: OneClickToken[] = [
+  { assetId: 'nep141:btc.omft.near', blockchain: 'btc', symbol: 'BTC', decimals: 8 },
+  { assetId: 'nep141:eth.omft.near', blockchain: 'eth', symbol: 'ETH', decimals: 18 },
+  {
+    assetId: 'nep141:eth-0xdac17f958d2ee523a2206206994597c13d831ec7.omft.near',
+    blockchain: 'eth',
+    symbol: 'USDT',
+    decimals: 6,
+    contractAddress: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  },
+  { assetId: 'nep141:sol.omft.near', blockchain: 'sol', symbol: 'SOL', decimals: 9 },
+  { assetId: 'nep141:doge.omft.near', blockchain: 'doge', symbol: 'DOGE', decimals: 8 },
+  { assetId: 'nep141:avax.omft.near', blockchain: 'avax', symbol: 'AVAX', decimals: 18 },
+]
+
+describe('OneClick utils', () => {
+  describe('xChainToOneClickBlockchain', () => {
+    it('should map known chains', () => {
+      expect(xChainToOneClickBlockchain('BTC')).toBe('btc')
+      expect(xChainToOneClickBlockchain('ETH')).toBe('eth')
+      expect(xChainToOneClickBlockchain('SOL')).toBe('sol')
+      expect(xChainToOneClickBlockchain('DOGE')).toBe('doge')
+      expect(xChainToOneClickBlockchain('AVAX')).toBe('avax')
+      expect(xChainToOneClickBlockchain('ARB')).toBe('arb')
+      expect(xChainToOneClickBlockchain('BSC')).toBe('bsc')
+      expect(xChainToOneClickBlockchain('ADA')).toBe('cardano')
+      expect(xChainToOneClickBlockchain('SUI')).toBe('sui')
+    })
+
+    it('should return null for unsupported chains', () => {
+      expect(xChainToOneClickBlockchain('THOR')).toBeNull()
+      expect(xChainToOneClickBlockchain('MAYA')).toBeNull()
+      expect(xChainToOneClickBlockchain('GAIA')).toBeNull()
+    })
+  })
+
+  describe('oneClickBlockchainToXChain', () => {
+    it('should reverse map known blockchains', () => {
+      expect(oneClickBlockchainToXChain('btc')).toBe('BTC')
+      expect(oneClickBlockchainToXChain('eth')).toBe('ETH')
+      expect(oneClickBlockchainToXChain('sol')).toBe('SOL')
+      expect(oneClickBlockchainToXChain('cardano')).toBe('ADA')
+    })
+
+    it('should return null for unknown blockchains', () => {
+      expect(oneClickBlockchainToXChain('near')).toBeNull()
+      expect(oneClickBlockchainToXChain('ton')).toBeNull()
+    })
+  })
+
+  describe('findOneClickToken', () => {
+    it('should find native token by chain and symbol', () => {
+      const token = findOneClickToken(AssetBTC, mockTokens)
+      expect(token).toBeDefined()
+      expect(token?.assetId).toBe('nep141:btc.omft.near')
+    })
+
+    it('should find ERC20 token by contract address', () => {
+      const usdt = assetFromStringEx('ETH.USDT-0xdAC17F958D2ee523a2206206994597C13D831ec7')
+      const token = findOneClickToken(usdt, mockTokens)
+      expect(token).toBeDefined()
+      expect(token?.assetId).toBe('nep141:eth-0xdac17f958d2ee523a2206206994597c13d831ec7.omft.near')
+    })
+
+    it('should match contract address case-insensitively', () => {
+      const usdt = assetFromStringEx('ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7')
+      const token = findOneClickToken(usdt, mockTokens)
+      expect(token).toBeDefined()
+      expect(token?.assetId).toBe('nep141:eth-0xdac17f958d2ee523a2206206994597c13d831ec7.omft.near')
+    })
+
+    it('should return undefined for synth assets', () => {
+      const synth = assetFromStringEx('BTC/BTC')
+      expect(findOneClickToken(synth, mockTokens)).toBeUndefined()
+    })
+
+    it('should return undefined for trade assets', () => {
+      const trade = assetFromStringEx('BTC~BTC')
+      expect(findOneClickToken(trade, mockTokens)).toBeUndefined()
+    })
+
+    it('should return undefined for unsupported chain', () => {
+      expect(findOneClickToken(AssetRuneNative, mockTokens)).toBeUndefined()
+    })
+
+    it('should not match native token with wrong symbol', () => {
+      const fakeAsset = { chain: 'BTC', symbol: 'FAKE', ticker: 'FAKE', type: 0 }
+      expect(findOneClickToken(fakeAsset, mockTokens)).toBeUndefined()
+    })
+  })
+})
+
+describe('OneClick protocol', () => {
+  let protocol: OneClickProtocol
+
+  beforeEach(() => {
+    mockFetch.mockReset()
+    // Mock getTokens for constructor's CachedValue
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/v0/tokens')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockTokens),
+        })
+      }
+      return Promise.resolve({ ok: false, status: 404 })
+    })
+
+    protocol = new OneClickProtocol()
+  })
+
+  describe('isAssetSupported', () => {
+    it('should support BTC', async () => {
+      expect(await protocol.isAssetSupported(AssetBTC)).toBe(true)
+    })
+
+    it('should support ETH', async () => {
+      expect(await protocol.isAssetSupported(AssetETH)).toBe(true)
+    })
+
+    it('should not support RUNE', async () => {
+      expect(await protocol.isAssetSupported(AssetRuneNative)).toBe(false)
+    })
+
+    it('should not support CACAO', async () => {
+      expect(await protocol.isAssetSupported(AssetCacao)).toBe(false)
+    })
+
+    it('should not support synth assets', async () => {
+      expect(await protocol.isAssetSupported(assetFromStringEx('BTC/BTC'))).toBe(false)
+    })
+
+    it('should not support trade assets', async () => {
+      expect(await protocol.isAssetSupported(assetFromStringEx('BTC~BTC'))).toBe(false)
+    })
+  })
+
+  describe('getSupportedChains', () => {
+    it('should return mapped chains from tokens', async () => {
+      const chains = await protocol.getSupportedChains()
+      expect(chains).toContain('BTC')
+      expect(chains).toContain('ETH')
+      expect(chains).toContain('SOL')
+      expect(chains).toContain('DOGE')
+      expect(chains).toContain('AVAX')
+      expect(chains).not.toContain('THOR')
+    })
+  })
+
+  describe('estimateSwap', () => {
+    it('should return quote on success', async () => {
+      mockFetch.mockImplementation((url: string, options?: RequestInit) => {
+        if (url.includes('/v0/tokens')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTokens) })
+        }
+        if (url.includes('/v0/quote')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                quote: {
+                  depositAddress: 'bc1qfakedeposit',
+                  amountOut: '99000',
+                  timeEstimate: 600,
+                },
+              }),
+          })
+        }
+        return Promise.resolve({ ok: false, status: 404 })
+      })
+
+      const quote = await protocol.estimateSwap({
+        fromAsset: AssetETH,
+        destinationAsset: AssetBTC,
+        amount: new CryptoAmount(assetToBase(assetAmount(1, 18)), AssetETH),
+        fromAddress: '0xSender',
+        destinationAddress: 'bc1qRecipient',
+      })
+
+      expect(quote.protocol).toBe('OneClick')
+      expect(quote.toAddress).toBe('bc1qfakedeposit')
+      expect(quote.canSwap).toBe(true)
+      expect(quote.errors).toHaveLength(0)
+      expect(quote.expectedAmount.baseAmount.amount().toString()).toBe('99000')
+      expect(assetToString(quote.expectedAmount.asset)).toBe('BTC.BTC')
+      expect(quote.totalSwapSeconds).toBe(600)
+    })
+
+    it('should return error quote for unsupported source asset', async () => {
+      const quote = await protocol.estimateSwap({
+        fromAsset: AssetRuneNative,
+        destinationAsset: AssetBTC,
+        amount: new CryptoAmount(assetToBase(assetAmount(1, 8)), AssetRuneNative),
+      })
+
+      expect(quote.canSwap).toBe(false)
+      expect(quote.errors).toContain('Source asset not supported')
+    })
+
+    it('should return error quote for unsupported destination asset', async () => {
+      const quote = await protocol.estimateSwap({
+        fromAsset: AssetBTC,
+        destinationAsset: AssetRuneNative,
+        amount: new CryptoAmount(assetToBase(assetAmount(1, 8)), AssetBTC),
+      })
+
+      expect(quote.canSwap).toBe(false)
+      expect(quote.errors).toContain('Destination asset not supported')
+    })
+
+    it('should return error quote when API returns error', async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/v0/tokens')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTokens) })
+        }
+        if (url.includes('/v0/quote')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ error: 'Insufficient liquidity', message: 'Insufficient liquidity' }),
+          })
+        }
+        return Promise.resolve({ ok: false, status: 404 })
+      })
+
+      const quote = await protocol.estimateSwap({
+        fromAsset: AssetETH,
+        destinationAsset: AssetBTC,
+        amount: new CryptoAmount(assetToBase(assetAmount(1, 18)), AssetETH),
+        fromAddress: '0xSender',
+        destinationAddress: 'bc1qRecipient',
+      })
+
+      expect(quote.canSwap).toBe(false)
+      expect(quote.errors).toContain('Insufficient liquidity')
+    })
+
+    it('should use dry=true when addresses not provided', async () => {
+      let capturedBody: string | undefined
+      mockFetch.mockImplementation((url: string, options?: RequestInit) => {
+        if (url.includes('/v0/tokens')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTokens) })
+        }
+        if (url.includes('/v0/quote')) {
+          capturedBody = options?.body as string
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ quote: { amountOut: '99000', timeEstimate: 600 } }),
+          })
+        }
+        return Promise.resolve({ ok: false, status: 404 })
+      })
+
+      await protocol.estimateSwap({
+        fromAsset: AssetETH,
+        destinationAsset: AssetBTC,
+        amount: new CryptoAmount(assetToBase(assetAmount(1, 18)), AssetETH),
+      })
+
+      const parsed = JSON.parse(capturedBody!)
+      expect(parsed.dry).toBe(true)
+    })
+  })
+
+  describe('doSwap', () => {
+    it('should throw if wallet not configured', async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/v0/tokens')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTokens) })
+        }
+        if (url.includes('/v0/quote')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                quote: {
+                  depositAddress: 'bc1qfakedeposit',
+                  amountOut: '99000',
+                  timeEstimate: 600,
+                },
+              }),
+          })
+        }
+        return Promise.resolve({ ok: false, status: 404 })
+      })
+
+      await expect(
+        protocol.doSwap({
+          fromAsset: AssetETH,
+          destinationAsset: AssetBTC,
+          amount: new CryptoAmount(assetToBase(assetAmount(1, 18)), AssetETH),
+          fromAddress: '0xSender',
+          destinationAddress: 'bc1qRecipient',
+        }),
+      ).rejects.toThrow('Wallet not configured')
+    })
+
+    it('should throw if swap cannot be done', async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/v0/tokens')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTokens) })
+        }
+        if (url.includes('/v0/quote')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ error: 'No route' }),
+          })
+        }
+        return Promise.resolve({ ok: false, status: 404 })
+      })
+
+      await expect(
+        protocol.doSwap({
+          fromAsset: AssetETH,
+          destinationAsset: AssetBTC,
+          amount: new CryptoAmount(assetToBase(assetAmount(1, 18)), AssetETH),
+          fromAddress: '0xSender',
+          destinationAddress: 'bc1qRecipient',
+        }),
+      ).rejects.toThrow('Can not make swap')
+    })
+  })
+
+  describe('getSwapHistory', () => {
+    it('should throw not implemented', async () => {
+      await expect(protocol.getSwapHistory({ chainAddresses: [] })).rejects.toThrow('Not implemented')
+    })
+  })
+
+  describe('shouldBeApproved', () => {
+    it('should return false', async () => {
+      const result = await protocol.shouldBeApproved({
+        asset: AssetETH as any,
+        amount: new CryptoAmount(assetToBase(assetAmount(1, 18)), AssetETH),
+        address: '0x123',
+      })
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('approveRouterToSpend', () => {
+    it('should throw not implemented', async () => {
+      expect(() => protocol.approveRouterToSpend({ asset: AssetETH as any })).toThrow('Not implemented')
+    })
+  })
+})

--- a/packages/xchain-aggregator/__tests__/oneclickProtocol.test.ts
+++ b/packages/xchain-aggregator/__tests__/oneclickProtocol.test.ts
@@ -261,7 +261,7 @@ describe('OneClick protocol', () => {
 
     it('should use dry=true when addresses not provided', async () => {
       let capturedBody: string | undefined
-      mockFetch.mockImplementation((url: string, _options?: RequestInit) => {
+      mockFetch.mockImplementation((url: string, options?: RequestInit) => {
         if (url.includes('/v0/tokens')) {
           return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTokens) })
         }

--- a/packages/xchain-aggregator/__tests__/oneclickProtocol.test.ts
+++ b/packages/xchain-aggregator/__tests__/oneclickProtocol.test.ts
@@ -2,10 +2,16 @@ import { AssetBTC } from '@xchainjs/xchain-bitcoin'
 import { AssetETH } from '@xchainjs/xchain-ethereum'
 import { AssetCacao } from '@xchainjs/xchain-mayachain'
 import { AssetRuneNative } from '@xchainjs/xchain-thorchain'
-import { CryptoAmount, assetAmount, assetFromStringEx, assetToBase, assetToString } from '@xchainjs/xchain-util'
+import {
+  CryptoAmount,
+  TokenAsset,
+  assetAmount,
+  assetFromStringEx,
+  assetToBase,
+  assetToString,
+} from '@xchainjs/xchain-util'
 
 import { OneClickProtocol } from '../src/protocols/oneclick'
-import { OneClickApi } from '../src/protocols/oneclick/api'
 import { OneClickToken } from '../src/protocols/oneclick/types'
 import {
   findOneClickToken,
@@ -168,7 +174,7 @@ describe('OneClick protocol', () => {
 
   describe('estimateSwap', () => {
     it('should return quote on success', async () => {
-      mockFetch.mockImplementation((url: string, options?: RequestInit) => {
+      mockFetch.mockImplementation((url: string, _options?: RequestInit) => {
         if (url.includes('/v0/tokens')) {
           return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTokens) })
         }
@@ -255,7 +261,7 @@ describe('OneClick protocol', () => {
 
     it('should use dry=true when addresses not provided', async () => {
       let capturedBody: string | undefined
-      mockFetch.mockImplementation((url: string, options?: RequestInit) => {
+      mockFetch.mockImplementation((url: string, _options?: RequestInit) => {
         if (url.includes('/v0/tokens')) {
           return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTokens) })
         }
@@ -340,16 +346,18 @@ describe('OneClick protocol', () => {
   })
 
   describe('getSwapHistory', () => {
-    it('should throw not implemented', async () => {
-      await expect(protocol.getSwapHistory({ chainAddresses: [] })).rejects.toThrow('Not implemented')
+    it('should return an empty history', async () => {
+      const result = await protocol.getSwapHistory({ chainAddresses: [] })
+      expect(result).toEqual({ count: 0, swaps: [] })
     })
   })
 
   describe('shouldBeApproved', () => {
-    it('should return false', async () => {
+    it('should return false for a token asset', async () => {
+      const usdt = assetFromStringEx('ETH.USDT-0xdAC17F958D2ee523a2206206994597C13D831ec7') as TokenAsset
       const result = await protocol.shouldBeApproved({
-        asset: AssetETH as any,
-        amount: new CryptoAmount(assetToBase(assetAmount(1, 18)), AssetETH),
+        asset: usdt,
+        amount: new CryptoAmount(assetToBase(assetAmount(100, 6)), usdt),
         address: '0x123',
       })
       expect(result).toBe(false)
@@ -357,8 +365,9 @@ describe('OneClick protocol', () => {
   })
 
   describe('approveRouterToSpend', () => {
-    it('should throw not implemented', async () => {
-      expect(() => protocol.approveRouterToSpend({ asset: AssetETH as any })).toThrow('Not implemented')
+    it('should reject as not implemented', async () => {
+      const usdt = assetFromStringEx('ETH.USDT-0xdAC17F958D2ee523a2206206994597C13D831ec7') as TokenAsset
+      await expect(protocol.approveRouterToSpend({ asset: usdt })).rejects.toThrow('Not implemented')
     })
   })
 })

--- a/packages/xchain-aggregator/src/const.ts
+++ b/packages/xchain-aggregator/src/const.ts
@@ -1,9 +1,9 @@
 import { Network } from '@xchainjs/xchain-client'
 import { Config, Protocol } from './types'
 
-export const SupportedProtocols: Protocol[] = ['Thorchain', 'Mayachain', 'Chainflip']
+export const SupportedProtocols: Protocol[] = ['Thorchain', 'Mayachain', 'Chainflip', 'OneClick']
 
-export const DEFAULT_CONFIG: Required<Omit<Config, 'wallet' | 'affiliate' | 'brokerUrl'>> = {
+export const DEFAULT_CONFIG: Required<Omit<Config, 'wallet' | 'affiliate' | 'brokerUrl' | 'oneClickApiKey'>> = {
   protocols: SupportedProtocols,
   network: Network.Mainnet,
   affiliateBrokers: [],

--- a/packages/xchain-aggregator/src/protocols/oneclick/api.ts
+++ b/packages/xchain-aggregator/src/protocols/oneclick/api.ts
@@ -1,0 +1,40 @@
+import { OneClickQuoteRequest, OneClickQuoteResponse, OneClickToken } from './types'
+
+const BASE_URL = 'https://1click.chaindefuser.com'
+
+export class OneClickApi {
+  private headers: Record<string, string>
+
+  constructor(apiKey?: string) {
+    this.headers = { 'Content-Type': 'application/json' }
+    if (apiKey) {
+      this.headers['Authorization'] = `Bearer ${apiKey}`
+    }
+  }
+
+  async getTokens(): Promise<OneClickToken[]> {
+    const resp = await fetch(`${BASE_URL}/v0/tokens`, { headers: this.headers })
+    if (!resp.ok) throw new Error(`1Click getTokens failed: ${resp.status}`)
+    return resp.json()
+  }
+
+  async getQuote(params: OneClickQuoteRequest): Promise<OneClickQuoteResponse> {
+    const resp = await fetch(`${BASE_URL}/v0/quote`, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify(params),
+    })
+    if (!resp.ok) throw new Error(`1Click getQuote failed: ${resp.status}`)
+    return resp.json()
+  }
+
+  async submitDeposit(txHash: string, depositAddress: string): Promise<void> {
+    await fetch(`${BASE_URL}/v0/deposit/submit`, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify({ txHash, depositAddress }),
+    }).catch(() => {
+      // Fire-and-forget
+    })
+  }
+}

--- a/packages/xchain-aggregator/src/protocols/oneclick/index.ts
+++ b/packages/xchain-aggregator/src/protocols/oneclick/index.ts
@@ -1,0 +1,1 @@
+export { OneClickProtocol } from './oneclickProtocol'

--- a/packages/xchain-aggregator/src/protocols/oneclick/oneclickProtocol.ts
+++ b/packages/xchain-aggregator/src/protocols/oneclick/oneclickProtocol.ts
@@ -1,0 +1,173 @@
+import {
+  AnyAsset,
+  CachedValue,
+  Chain,
+  CryptoAmount,
+  baseAmount,
+  isSecuredAsset,
+  isSynthAsset,
+  isTradeAsset,
+} from '@xchainjs/xchain-util'
+import { Wallet } from '@xchainjs/xchain-wallet'
+
+import { IProtocol, ProtocolConfig, QuoteSwap, QuoteSwapParams, SwapHistory, TxSubmitted } from '../../types'
+
+import { OneClickApi } from './api'
+import { CompatibleAsset, OneClickToken } from './types'
+import { findOneClickToken, oneClickBlockchainToXChain } from './utils'
+
+export class OneClickProtocol implements IProtocol {
+  public readonly name = 'OneClick' as const
+
+  private api: OneClickApi
+  private wallet?: Wallet
+  private affiliateAddress?: string
+  private affiliateBps?: number
+  private tokensCache: CachedValue<OneClickToken[]>
+
+  constructor(configuration?: ProtocolConfig) {
+    this.api = new OneClickApi(configuration?.oneClickApiKey)
+    this.wallet = configuration?.wallet
+    this.affiliateAddress = configuration?.affiliateAddress
+    this.affiliateBps = configuration?.affiliateBps
+    this.tokensCache = new CachedValue(() => this.api.getTokens(), 24 * 60 * 60 * 1000)
+  }
+
+  public approveRouterToSpend(): Promise<TxSubmitted> {
+    throw new Error('Not implemented')
+  }
+
+  public async shouldBeApproved(): Promise<boolean> {
+    return false
+  }
+
+  public async isAssetSupported(asset: AnyAsset): Promise<boolean> {
+    if (isSynthAsset(asset) || isTradeAsset(asset) || isSecuredAsset(asset)) return false
+    const tokens = await this.tokensCache.getValue()
+    return findOneClickToken(asset, tokens) !== undefined
+  }
+
+  public async getSupportedChains(): Promise<Chain[]> {
+    const tokens = await this.tokensCache.getValue()
+    const chains = new Set<Chain>()
+    for (const token of tokens) {
+      const chain = oneClickBlockchainToXChain(token.blockchain)
+      if (chain) chains.add(chain)
+    }
+    return Array.from(chains)
+  }
+
+  public async estimateSwap(params: QuoteSwapParams): Promise<QuoteSwap> {
+    const tokens = await this.tokensCache.getValue()
+
+    const srcToken = findOneClickToken(params.fromAsset, tokens)
+    const destToken = findOneClickToken(params.destinationAsset, tokens)
+
+    if (!srcToken || !destToken) {
+      return this.errorQuote(params, srcToken ? 'Destination asset not supported' : 'Source asset not supported')
+    }
+
+    try {
+      const isDry = !(params.fromAddress && params.destinationAddress)
+      const deadline = new Date(Date.now() + 10 * 60 * 1000).toISOString()
+
+      const appFees =
+        this.affiliateAddress && this.affiliateBps
+          ? [{ recipient: this.affiliateAddress, fee: this.affiliateBps }]
+          : undefined
+
+      const resp = await this.api.getQuote({
+        dry: isDry,
+        swapType: 'EXACT_INPUT',
+        depositType: 'ORIGIN_CHAIN',
+        recipientType: 'DESTINATION_CHAIN',
+        refundType: 'ORIGIN_CHAIN',
+        originAsset: srcToken.assetId,
+        destinationAsset: destToken.assetId,
+        amount: params.amount.baseAmount.amount().toString(),
+        refundTo: params.fromAddress || '',
+        recipient: params.destinationAddress || '',
+        slippageTolerance: params.toleranceBps ?? 100,
+        deadline,
+        appFees,
+      })
+
+      if (resp.error || resp.message) {
+        return this.errorQuote(params, resp.error || resp.message || 'Unknown error')
+      }
+
+      const quote = resp.quote
+      const toAddress = quote.depositAddress ?? ''
+
+      return {
+        protocol: this.name,
+        toAddress,
+        memo: '',
+        expectedAmount: new CryptoAmount(baseAmount(quote.amountOut, destToken.decimals), params.destinationAsset),
+        dustThreshold: new CryptoAmount(baseAmount(0), params.fromAsset),
+        totalSwapSeconds: quote.timeEstimate ?? 0,
+        maxStreamingQuantity: undefined,
+        canSwap: toAddress !== '',
+        warning: '',
+        errors: [],
+        slipBasisPoints: 0,
+        fees: {
+          asset: params.fromAsset,
+          affiliateFee: new CryptoAmount(baseAmount(0), params.fromAsset),
+          outboundFee: new CryptoAmount(baseAmount(0), params.destinationAsset),
+        },
+      }
+    } catch (e) {
+      return this.errorQuote(params, e instanceof Error ? e.message : 'Unknown error')
+    }
+  }
+
+  public async doSwap(params: QuoteSwapParams): Promise<TxSubmitted> {
+    const quoteSwap = await this.estimateSwap(params)
+    if (!quoteSwap.canSwap) {
+      throw new Error(`Can not make swap. ${quoteSwap.errors.join('\n')}`)
+    }
+
+    if (!this.wallet) throw new Error('Wallet not configured. Can not do swap')
+
+    const hash = await this.wallet.transfer({
+      recipient: quoteSwap.toAddress,
+      amount: params.amount.baseAmount,
+      asset: params.fromAsset as CompatibleAsset,
+      memo: quoteSwap.memo,
+    })
+
+    // Fire-and-forget: notify 1Click about the deposit
+    void this.api.submitDeposit(hash, quoteSwap.toAddress)
+
+    return {
+      hash,
+      url: await this.wallet.getExplorerTxUrl(params.fromAsset.chain, hash),
+    }
+  }
+
+  public async getSwapHistory(): Promise<SwapHistory> {
+    throw new Error('Not implemented')
+  }
+
+  private errorQuote(params: QuoteSwapParams, error: string): QuoteSwap {
+    return {
+      protocol: this.name,
+      toAddress: '',
+      memo: '',
+      expectedAmount: new CryptoAmount(baseAmount(0), params.destinationAsset),
+      dustThreshold: new CryptoAmount(baseAmount(0), params.fromAsset),
+      totalSwapSeconds: 0,
+      maxStreamingQuantity: undefined,
+      canSwap: false,
+      warning: '',
+      errors: [error],
+      slipBasisPoints: 0,
+      fees: {
+        asset: params.fromAsset,
+        affiliateFee: new CryptoAmount(baseAmount(0), params.fromAsset),
+        outboundFee: new CryptoAmount(baseAmount(0), params.destinationAsset),
+      },
+    }
+  }
+}

--- a/packages/xchain-aggregator/src/protocols/oneclick/oneclickProtocol.ts
+++ b/packages/xchain-aggregator/src/protocols/oneclick/oneclickProtocol.ts
@@ -18,6 +18,7 @@ import {
   QuoteSwap,
   QuoteSwapParams,
   SwapHistory,
+  SwapHistoryParams,
   TxSubmitted,
 } from '../../types'
 
@@ -170,7 +171,7 @@ export class OneClickProtocol implements IProtocol {
     return { hash, url }
   }
 
-  public async getSwapHistory(): Promise<SwapHistory> {
+  public async getSwapHistory(_params: SwapHistoryParams): Promise<SwapHistory> {
     return { count: 0, swaps: [] }
   }
 

--- a/packages/xchain-aggregator/src/protocols/oneclick/oneclickProtocol.ts
+++ b/packages/xchain-aggregator/src/protocols/oneclick/oneclickProtocol.ts
@@ -10,7 +10,16 @@ import {
 } from '@xchainjs/xchain-util'
 import { Wallet } from '@xchainjs/xchain-wallet'
 
-import { IProtocol, ProtocolConfig, QuoteSwap, QuoteSwapParams, SwapHistory, TxSubmitted } from '../../types'
+import {
+  ApproveParams,
+  IProtocol,
+  IsApprovedParams,
+  ProtocolConfig,
+  QuoteSwap,
+  QuoteSwapParams,
+  SwapHistory,
+  TxSubmitted,
+} from '../../types'
 
 import { OneClickApi } from './api'
 import { CompatibleAsset, OneClickToken } from './types'
@@ -33,11 +42,11 @@ export class OneClickProtocol implements IProtocol {
     this.tokensCache = new CachedValue(() => this.api.getTokens(), 24 * 60 * 60 * 1000)
   }
 
-  public approveRouterToSpend(): Promise<TxSubmitted> {
+  public async approveRouterToSpend(_params: ApproveParams): Promise<TxSubmitted> {
     throw new Error('Not implemented')
   }
 
-  public async shouldBeApproved(): Promise<boolean> {
+  public async shouldBeApproved(_params: IsApprovedParams): Promise<boolean> {
     return false
   }
 
@@ -137,17 +146,32 @@ export class OneClickProtocol implements IProtocol {
       memo: quoteSwap.memo,
     })
 
-    // Fire-and-forget: notify 1Click about the deposit
-    void this.api.submitDeposit(hash, quoteSwap.toAddress)
-
-    return {
-      hash,
-      url: await this.wallet.getExplorerTxUrl(params.fromAsset.chain, hash),
+    // Funds are already on the wire. Awaiting submitDeposit lets callers distinguish
+    // "deposit registered, swap will settle" from "registration silently failed, swap will
+    // never settle" — surface the failure with the broadcast hash so it can be retried.
+    try {
+      await this.api.submitDeposit(hash, quoteSwap.toAddress)
+    } catch (e) {
+      throw new Error(
+        `1Click deposit tx ${hash} was broadcast, but submitDeposit failed: ${
+          e instanceof Error ? e.message : 'unknown error'
+        }`,
+      )
     }
+
+    // Explorer URL is best-effort; the hash is what callers actually need for tracking.
+    let url = ''
+    try {
+      url = await this.wallet.getExplorerTxUrl(params.fromAsset.chain, hash)
+    } catch {
+      // swallow: explorer URL lookup must not reject a successful swap
+    }
+
+    return { hash, url }
   }
 
   public async getSwapHistory(): Promise<SwapHistory> {
-    throw new Error('Not implemented')
+    return { count: 0, swaps: [] }
   }
 
   private errorQuote(params: QuoteSwapParams, error: string): QuoteSwap {

--- a/packages/xchain-aggregator/src/protocols/oneclick/types.ts
+++ b/packages/xchain-aggregator/src/protocols/oneclick/types.ts
@@ -1,0 +1,43 @@
+import { Asset, TokenAsset } from '@xchainjs/xchain-util'
+
+export type CompatibleAsset = Asset | TokenAsset
+
+export type OneClickToken = {
+  assetId: string
+  blockchain: string
+  symbol: string
+  decimals: number
+  contractAddress?: string
+  price?: number
+  priceUpdatedAt?: string
+}
+
+export type OneClickQuoteRequest = {
+  dry?: boolean
+  swapType: 'EXACT_INPUT'
+  depositType: 'ORIGIN_CHAIN'
+  recipientType: 'DESTINATION_CHAIN'
+  refundType: 'ORIGIN_CHAIN'
+  originAsset: string
+  destinationAsset: string
+  amount: string
+  refundTo: string
+  recipient: string
+  slippageTolerance?: number
+  deadline?: string
+  appFees?: { recipient: string; fee: number }[]
+}
+
+export type OneClickQuoteInner = {
+  amountOut: string
+  amountOutFormatted?: string
+  timeEstimate?: number
+  depositAddress?: string
+}
+
+export type OneClickQuoteResponse = {
+  quote: OneClickQuoteInner
+  error?: string
+  message?: string
+  statusCode?: number
+}

--- a/packages/xchain-aggregator/src/protocols/oneclick/utils.ts
+++ b/packages/xchain-aggregator/src/protocols/oneclick/utils.ts
@@ -1,0 +1,73 @@
+import {
+  AnyAsset,
+  AssetType,
+  Chain,
+  isSecuredAsset,
+  isSynthAsset,
+  isTokenAsset,
+  isTradeAsset,
+} from '@xchainjs/xchain-util'
+
+import { OneClickToken } from './types'
+
+const X_TO_ONECLICK: Record<string, string> = {
+  BTC: 'btc',
+  ETH: 'eth',
+  ARB: 'arb',
+  AVAX: 'avax',
+  BSC: 'bsc',
+  SOL: 'sol',
+  DOGE: 'doge',
+  DASH: 'dash',
+  LTC: 'ltc',
+  BCH: 'bch',
+  XRP: 'xrp',
+  ADA: 'cardano',
+  SUI: 'sui',
+}
+
+const ONECLICK_TO_X: Record<string, string> = Object.fromEntries(Object.entries(X_TO_ONECLICK).map(([k, v]) => [v, k]))
+
+export const xChainToOneClickBlockchain = (chain: Chain): string | null => {
+  return X_TO_ONECLICK[chain] ?? null
+}
+
+export const oneClickBlockchainToXChain = (blockchain: string): Chain | null => {
+  return (ONECLICK_TO_X[blockchain] as Chain) ?? null
+}
+
+export const findOneClickToken = (asset: AnyAsset, tokens: OneClickToken[]): OneClickToken | undefined => {
+  if (isSynthAsset(asset) || isTradeAsset(asset) || isSecuredAsset(asset)) return undefined
+
+  const blockchain = xChainToOneClickBlockchain(asset.chain)
+  if (!blockchain) return undefined
+
+  return tokens.find((token) => {
+    if (token.blockchain !== blockchain) return false
+
+    if (isTokenAsset(asset)) {
+      // Match by contract address (case-insensitive)
+      const assetContract = asset.symbol.includes('-') ? asset.symbol.split('-')[1] : undefined
+      return assetContract && token.contractAddress
+        ? token.contractAddress.toLowerCase() === assetContract.toLowerCase()
+        : false
+    }
+
+    // Native asset: match by symbol, ensure no contract address on token
+    return token.symbol.toUpperCase() === asset.symbol.toUpperCase() && !token.contractAddress
+  })
+}
+
+export const oneClickTokenToXAsset = (
+  token: OneClickToken,
+): { chain: Chain; symbol: string; ticker: string; type: AssetType } | null => {
+  const chain = oneClickBlockchainToXChain(token.blockchain)
+  if (!chain) return null
+
+  if (token.contractAddress) {
+    const symbol = `${token.symbol}-${token.contractAddress}`
+    return { chain, symbol, ticker: symbol, type: AssetType.TOKEN }
+  }
+
+  return { chain, symbol: token.symbol, ticker: token.symbol, type: AssetType.NATIVE }
+}

--- a/packages/xchain-aggregator/src/protocols/oneclick/utils.ts
+++ b/packages/xchain-aggregator/src/protocols/oneclick/utils.ts
@@ -66,7 +66,7 @@ export const oneClickTokenToXAsset = (
 
   if (token.contractAddress) {
     const symbol = `${token.symbol}-${token.contractAddress}`
-    return { chain, symbol, ticker: symbol, type: AssetType.TOKEN }
+    return { chain, symbol, ticker: token.symbol, type: AssetType.TOKEN }
   }
 
   return { chain, symbol: token.symbol, ticker: token.symbol, type: AssetType.NATIVE }

--- a/packages/xchain-aggregator/src/protocols/protocolFactory.ts
+++ b/packages/xchain-aggregator/src/protocols/protocolFactory.ts
@@ -2,6 +2,7 @@ import { Config, IProtocol, Protocol, ProtocolConfig } from '../types'
 
 import { ChainflipProtocol } from './chainflip'
 import { MayachainProtocol } from './mayachain'
+import { OneClickProtocol } from './oneclick'
 import { ThorchainProtocol } from './thorchain'
 
 const getProtocolConfig = (name: Protocol, configuration: Config): ProtocolConfig => {
@@ -12,6 +13,7 @@ const getProtocolConfig = (name: Protocol, configuration: Config): ProtocolConfi
     network: configuration.network,
     affiliateBrokers: configuration.affiliateBrokers,
     brokerUrl: configuration.brokerUrl,
+    oneClickApiKey: configuration.oneClickApiKey,
   }
 }
 
@@ -25,6 +27,8 @@ export class ProtocolFactory {
         return new MayachainProtocol(protocolConfig)
       case 'Chainflip':
         return new ChainflipProtocol(protocolConfig)
+      case 'OneClick':
+        return new OneClickProtocol(protocolConfig)
     }
   }
 }

--- a/packages/xchain-aggregator/src/types.ts
+++ b/packages/xchain-aggregator/src/types.ts
@@ -33,7 +33,7 @@ type Fees = {
 /**
  * Protocols supported by the Aggregator
  */
-type Protocol = 'Thorchain' | 'Mayachain' | 'Chainflip'
+type Protocol = 'Thorchain' | 'Mayachain' | 'Chainflip' | 'OneClick'
 
 /**
  * Affiliate config for the aggregator
@@ -80,6 +80,10 @@ export type Config = Partial<{
    * Broker URL for Chainflip protocol
    */
   brokerUrl: string
+  /**
+   * API key for OneClick (NEAR Intents) protocol
+   */
+  oneClickApiKey: string
 }>
 
 /**
@@ -95,6 +99,7 @@ export type ProtocolConfig = Partial<{
     commissionBps: number
   }[]
   brokerUrl: string
+  oneClickApiKey: string
 }>
 
 /**

--- a/tools/xchain-suite/src/components/swap/SwapTrackingModal.tsx
+++ b/tools/xchain-suite/src/components/swap/SwapTrackingModal.tsx
@@ -64,20 +64,24 @@ function StageItem({ stage, stageKey, isActive }: { stage: TxStage; stageKey: st
   const label = STAGE_LABELS[stageKey]
 
   return (
-    <div className={`flex items-start gap-3 p-3 rounded-lg transition-colors ${
-      stage.completed
-        ? 'bg-green-50 dark:bg-green-900/20'
-        : isActive
-        ? 'bg-blue-50 dark:bg-blue-900/20'
-        : 'bg-gray-50 dark:bg-gray-800'
-    }`}>
-      <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${
+    <div
+      className={`flex items-start gap-3 p-3 rounded-lg transition-colors ${
         stage.completed
-          ? 'bg-green-500 text-white'
+          ? 'bg-green-50 dark:bg-green-900/20'
           : isActive
-          ? 'bg-blue-500 text-white'
-          : 'bg-gray-300 dark:bg-gray-600 text-gray-500 dark:text-gray-400'
-      }`}>
+          ? 'bg-blue-50 dark:bg-blue-900/20'
+          : 'bg-gray-50 dark:bg-gray-800'
+      }`}
+    >
+      <div
+        className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${
+          stage.completed
+            ? 'bg-green-500 text-white'
+            : isActive
+            ? 'bg-blue-500 text-white'
+            : 'bg-gray-300 dark:bg-gray-600 text-gray-500 dark:text-gray-400'
+        }`}
+      >
         {stage.completed ? (
           <Check className="w-4 h-4" />
         ) : isActive ? (
@@ -87,24 +91,29 @@ function StageItem({ stage, stageKey, isActive }: { stage: TxStage; stageKey: st
         )}
       </div>
       <div className="flex-1 min-w-0">
-        <p className={`font-medium ${
-          stage.completed
-            ? 'text-green-700 dark:text-green-300'
-            : isActive
-            ? 'text-blue-700 dark:text-blue-300'
-            : 'text-gray-500 dark:text-gray-400'
-        }`}>
+        <p
+          className={`font-medium ${
+            stage.completed
+              ? 'text-green-700 dark:text-green-300'
+              : isActive
+              ? 'text-blue-700 dark:text-blue-300'
+              : 'text-gray-500 dark:text-gray-400'
+          }`}
+        >
           {label.title}
         </p>
-        <p className="text-sm text-gray-500 dark:text-gray-400">
-          {label.description}
-        </p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">{label.description}</p>
       </div>
     </div>
   )
 }
 
-function ChainflipStageItem({ stageKey, completed, isActive, index }: {
+function ChainflipStageItem({
+  stageKey,
+  completed,
+  isActive,
+  index,
+}: {
   stageKey: string
   completed: boolean
   isActive: boolean
@@ -113,20 +122,24 @@ function ChainflipStageItem({ stageKey, completed, isActive, index }: {
   const label = CF_STAGE_LABELS[stageKey]
 
   return (
-    <div className={`flex items-start gap-3 p-3 rounded-lg transition-colors ${
-      completed
-        ? 'bg-green-50 dark:bg-green-900/20'
-        : isActive
-        ? 'bg-blue-50 dark:bg-blue-900/20'
-        : 'bg-gray-50 dark:bg-gray-800'
-    }`}>
-      <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${
+    <div
+      className={`flex items-start gap-3 p-3 rounded-lg transition-colors ${
         completed
-          ? 'bg-green-500 text-white'
+          ? 'bg-green-50 dark:bg-green-900/20'
           : isActive
-          ? 'bg-blue-500 text-white'
-          : 'bg-gray-300 dark:bg-gray-600 text-gray-500 dark:text-gray-400'
-      }`}>
+          ? 'bg-blue-50 dark:bg-blue-900/20'
+          : 'bg-gray-50 dark:bg-gray-800'
+      }`}
+    >
+      <div
+        className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${
+          completed
+            ? 'bg-green-500 text-white'
+            : isActive
+            ? 'bg-blue-500 text-white'
+            : 'bg-gray-300 dark:bg-gray-600 text-gray-500 dark:text-gray-400'
+        }`}
+      >
         {completed ? (
           <Check className="w-4 h-4" />
         ) : isActive ? (
@@ -136,18 +149,18 @@ function ChainflipStageItem({ stageKey, completed, isActive, index }: {
         )}
       </div>
       <div className="flex-1 min-w-0">
-        <p className={`font-medium ${
-          completed
-            ? 'text-green-700 dark:text-green-300'
-            : isActive
-            ? 'text-blue-700 dark:text-blue-300'
-            : 'text-gray-500 dark:text-gray-400'
-        }`}>
+        <p
+          className={`font-medium ${
+            completed
+              ? 'text-green-700 dark:text-green-300'
+              : isActive
+              ? 'text-blue-700 dark:text-blue-300'
+              : 'text-gray-500 dark:text-gray-400'
+          }`}
+        >
           {label.title}
         </p>
-        <p className="text-sm text-gray-500 dark:text-gray-400">
-          {label.description}
-        </p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">{label.description}</p>
       </div>
     </div>
   )
@@ -174,6 +187,9 @@ export function SwapTrackingModal({
 
   // THORChain / MAYAChain tracking
   useEffect(() => {
+    // Reset status whenever the modal target changes; otherwise a previous Thor/Maya
+    // status object can bleed into a subsequent Chainflip/OneClick render.
+    setStatus(null)
     if (!isOpen || !txHash || protocol === 'Chainflip' || protocol === 'OneClick') return
 
     transactionTracker.track(txHash, protocol as 'Thorchain' | 'Mayachain', setStatus)
@@ -214,12 +230,16 @@ export function SwapTrackingModal({
       } catch (e: any) {
         if (cancelled) return
         console.warn('[SwapTrackingModal] Chainflip poll error:', e.message)
-        setCfStatus(prev => prev ? { ...prev, error: e.message } : {
-          state: 'WAITING',
-          isComplete: false,
-          isFailed: false,
-          error: e.message,
-        })
+        setCfStatus((prev) =>
+          prev
+            ? { ...prev, error: e.message }
+            : {
+                state: 'WAITING',
+                isComplete: false,
+                isFailed: false,
+                error: e.message,
+              },
+        )
       }
     }
 
@@ -247,18 +267,17 @@ export function SwapTrackingModal({
   if (!isOpen) return null
 
   // Determine tracker URL
-  const trackerUrl = protocol === 'Chainflip'
-    ? `https://scan.chainflip.io/channels/${depositChannelId || ''}`
-    : protocol === 'Thorchain'
-    ? `https://track.thorchain.org/${txHash}`
-    : protocol === 'OneClick'
-    ? explorerUrl || ''
-    : `https://www.explorer.mayachain.info/tx/${txHash}`
+  const trackerUrl =
+    protocol === 'Chainflip'
+      ? `https://scan.chainflip.io/channels/${depositChannelId || ''}`
+      : protocol === 'Thorchain'
+      ? `https://track.thorchain.org/${txHash}`
+      : protocol === 'OneClick'
+      ? explorerUrl || ''
+      : `https://www.explorer.mayachain.info/tx/${txHash}`
 
   // THORChain/MAYAChain: find current active stage
-  const activeStageIndex = status
-    ? STAGE_ORDER.findIndex(key => !status.stages[key].completed)
-    : 0
+  const activeStageIndex = status ? STAGE_ORDER.findIndex((key) => !status.stages[key].completed) : 0
 
   // Chainflip: find current stage index
   const cfCurrentState = cfStatus?.state || 'WAITING'
@@ -273,9 +292,7 @@ export function SwapTrackingModal({
       <div className="relative z-[101] w-full max-w-md bg-white dark:bg-gray-800 rounded-xl shadow-2xl">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-            Transaction Progress
-          </h2>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Transaction Progress</h2>
           <button
             onClick={onClose}
             className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
@@ -292,9 +309,7 @@ export function SwapTrackingModal({
               <span className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                 {protocol === 'Chainflip' ? 'Deposit Channel' : 'Transaction Hash'}
               </span>
-              <span className="text-xs font-medium text-blue-600 dark:text-blue-400">
-                {protocol}
-              </span>
+              <span className="text-xs font-medium text-blue-600 dark:text-blue-400">{protocol}</span>
             </div>
             <div className="flex items-center gap-2">
               <code className="flex-1 text-sm font-mono text-gray-900 dark:text-gray-100 truncate">
@@ -305,56 +320,45 @@ export function SwapTrackingModal({
                 className="p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
                 title={protocol === 'Chainflip' && depositChannelId ? 'Copy deposit channel ID' : 'Copy tx hash'}
               >
-                {copied ? (
-                  <CheckCheck className="w-4 h-4 text-green-500" />
-                ) : (
-                  <Copy className="w-4 h-4" />
-                )}
+                {copied ? <CheckCheck className="w-4 h-4 text-green-500" /> : <Copy className="w-4 h-4" />}
               </button>
             </div>
           </div>
 
           {/* Error Display */}
-          {protocol === 'Chainflip' ? (
-            cfStatus?.error && (
-              <div className="flex items-start gap-2 p-3 bg-yellow-50 dark:bg-yellow-900/30 rounded-lg">
-                <AlertCircle className="w-5 h-5 text-yellow-600 dark:text-yellow-400 flex-shrink-0" />
-                <div>
-                  <p className="text-sm font-medium text-yellow-700 dark:text-yellow-300">
-                    {cfStatus.isFailed ? 'Swap Failed' : 'Waiting for status...'}
-                  </p>
-                  <p className="text-xs text-yellow-600 dark:text-yellow-400 mt-1">
-                    {cfStatus.error}
-                  </p>
+          {protocol === 'Chainflip'
+            ? cfStatus?.error && (
+                <div className="flex items-start gap-2 p-3 bg-yellow-50 dark:bg-yellow-900/30 rounded-lg">
+                  <AlertCircle className="w-5 h-5 text-yellow-600 dark:text-yellow-400 flex-shrink-0" />
+                  <div>
+                    <p className="text-sm font-medium text-yellow-700 dark:text-yellow-300">
+                      {cfStatus.isFailed ? 'Swap Failed' : 'Waiting for status...'}
+                    </p>
+                    <p className="text-xs text-yellow-600 dark:text-yellow-400 mt-1">{cfStatus.error}</p>
+                  </div>
                 </div>
-              </div>
-            )
-          ) : (
-            status?.error && (
-              <div className="flex items-start gap-2 p-3 bg-yellow-50 dark:bg-yellow-900/30 rounded-lg">
-                <AlertCircle className="w-5 h-5 text-yellow-600 dark:text-yellow-400 flex-shrink-0" />
-                <div>
-                  <p className="text-sm font-medium text-yellow-700 dark:text-yellow-300">
-                    Waiting for transaction...
-                  </p>
-                  <p className="text-xs text-yellow-600 dark:text-yellow-400 mt-1">
-                    {status.error}
-                  </p>
+              )
+            : status?.error && (
+                <div className="flex items-start gap-2 p-3 bg-yellow-50 dark:bg-yellow-900/30 rounded-lg">
+                  <AlertCircle className="w-5 h-5 text-yellow-600 dark:text-yellow-400 flex-shrink-0" />
+                  <div>
+                    <p className="text-sm font-medium text-yellow-700 dark:text-yellow-300">
+                      Waiting for transaction...
+                    </p>
+                    <p className="text-xs text-yellow-600 dark:text-yellow-400 mt-1">{status.error}</p>
+                  </div>
                 </div>
-              </div>
-            )
-          )}
+              )}
 
           {/* Stages */}
           <div className="space-y-2">
             {protocol === 'OneClick' ? (
               <div className="bg-green-50 dark:bg-green-900/30 rounded-lg p-4 text-center">
                 <Check className="w-8 h-8 text-green-500 mx-auto mb-2" />
-                <p className="font-medium text-green-700 dark:text-green-300">
-                  Deposit Submitted
-                </p>
+                <p className="font-medium text-green-700 dark:text-green-300">Deposit Submitted</p>
                 <p className="text-sm text-green-600 dark:text-green-400 mt-1">
-                  Your funds were sent to the 1Click deposit address. The swap will be processed automatically — check the explorer link below for status.
+                  Your funds were sent to the 1Click deposit address. The swap will be processed automatically — check
+                  the explorer link below for status.
                 </p>
               </div>
             ) : protocol === 'Chainflip' ? (
@@ -380,31 +384,26 @@ export function SwapTrackingModal({
           </div>
 
           {/* Completion Message */}
-          {protocol === 'Chainflip' ? (
-            cfStatus?.isComplete && (
-              <div className="bg-green-50 dark:bg-green-900/30 rounded-lg p-4 text-center">
-                <Check className="w-8 h-8 text-green-500 mx-auto mb-2" />
-                <p className="font-medium text-green-700 dark:text-green-300">
-                  Swap Complete!
-                </p>
-                <p className="text-sm text-green-600 dark:text-green-400 mt-1">
-                  Your funds have been sent to your destination address.
-                </p>
-              </div>
-            )
-          ) : protocol !== 'OneClick' && (
-            status?.isComplete && (
-              <div className="bg-green-50 dark:bg-green-900/30 rounded-lg p-4 text-center">
-                <Check className="w-8 h-8 text-green-500 mx-auto mb-2" />
-                <p className="font-medium text-green-700 dark:text-green-300">
-                  Swap Complete!
-                </p>
-                <p className="text-sm text-green-600 dark:text-green-400 mt-1">
-                  Your funds have been sent to your destination address.
-                </p>
-              </div>
-            )
-          )}
+          {protocol === 'Chainflip'
+            ? cfStatus?.isComplete && (
+                <div className="bg-green-50 dark:bg-green-900/30 rounded-lg p-4 text-center">
+                  <Check className="w-8 h-8 text-green-500 mx-auto mb-2" />
+                  <p className="font-medium text-green-700 dark:text-green-300">Swap Complete!</p>
+                  <p className="text-sm text-green-600 dark:text-green-400 mt-1">
+                    Your funds have been sent to your destination address.
+                  </p>
+                </div>
+              )
+            : protocol !== 'OneClick' &&
+              status?.isComplete && (
+                <div className="bg-green-50 dark:bg-green-900/30 rounded-lg p-4 text-center">
+                  <Check className="w-8 h-8 text-green-500 mx-auto mb-2" />
+                  <p className="font-medium text-green-700 dark:text-green-300">Swap Complete!</p>
+                  <p className="text-sm text-green-600 dark:text-green-400 mt-1">
+                    Your funds have been sent to your destination address.
+                  </p>
+                </div>
+              )}
 
           {/* Outbound Hash (THORChain/MAYAChain only) */}
           {protocol !== 'Chainflip' && status?.outboundHash && (
@@ -427,7 +426,8 @@ export function SwapTrackingModal({
             rel="noopener noreferrer"
             className="flex-1 px-4 py-2 text-sm font-medium text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors flex items-center justify-center gap-2"
           >
-            View on {protocol === 'Chainflip' ? 'Chainflip Scan' : protocol === 'OneClick' ? 'Explorer' : 'Tracker'} <ExternalLink className="w-4 h-4" />
+            View on {protocol === 'Chainflip' ? 'Chainflip Scan' : protocol === 'OneClick' ? 'Explorer' : 'Tracker'}{' '}
+            <ExternalLink className="w-4 h-4" />
           </a>
           {explorerUrl && protocol !== 'Chainflip' && (
             <a

--- a/tools/xchain-suite/src/components/swap/SwapTrackingModal.tsx
+++ b/tools/xchain-suite/src/components/swap/SwapTrackingModal.tsx
@@ -7,7 +7,7 @@ interface SwapTrackingModalProps {
   isOpen: boolean
   onClose: () => void
   txHash: string
-  protocol: 'Thorchain' | 'Mayachain' | 'Chainflip'
+  protocol: 'Thorchain' | 'Mayachain' | 'Chainflip' | 'OneClick'
   explorerUrl?: string
   depositChannelId?: string
 }
@@ -174,12 +174,12 @@ export function SwapTrackingModal({
 
   // THORChain / MAYAChain tracking
   useEffect(() => {
-    if (!isOpen || !txHash || protocol === 'Chainflip') return
+    if (!isOpen || !txHash || protocol === 'Chainflip' || protocol === 'OneClick') return
 
-    transactionTracker.track(txHash, protocol, setStatus)
+    transactionTracker.track(txHash, protocol as 'Thorchain' | 'Mayachain', setStatus)
 
     return () => {
-      transactionTracker.stop(txHash, protocol)
+      transactionTracker.stop(txHash, protocol as 'Thorchain' | 'Mayachain')
     }
   }, [isOpen, txHash, protocol])
 
@@ -251,6 +251,8 @@ export function SwapTrackingModal({
     ? `https://scan.chainflip.io/channels/${depositChannelId || ''}`
     : protocol === 'Thorchain'
     ? `https://track.thorchain.org/${txHash}`
+    : protocol === 'OneClick'
+    ? explorerUrl || ''
     : `https://www.explorer.mayachain.info/tx/${txHash}`
 
   // THORChain/MAYAChain: find current active stage
@@ -345,7 +347,17 @@ export function SwapTrackingModal({
 
           {/* Stages */}
           <div className="space-y-2">
-            {protocol === 'Chainflip' ? (
+            {protocol === 'OneClick' ? (
+              <div className="bg-green-50 dark:bg-green-900/30 rounded-lg p-4 text-center">
+                <Check className="w-8 h-8 text-green-500 mx-auto mb-2" />
+                <p className="font-medium text-green-700 dark:text-green-300">
+                  Deposit Submitted
+                </p>
+                <p className="text-sm text-green-600 dark:text-green-400 mt-1">
+                  Your funds were sent to the 1Click deposit address. The swap will be processed automatically — check the explorer link below for status.
+                </p>
+              </div>
+            ) : protocol === 'Chainflip' ? (
               CF_STAGE_ORDER.map((stageKey, index) => (
                 <ChainflipStageItem
                   key={stageKey}
@@ -380,7 +392,7 @@ export function SwapTrackingModal({
                 </p>
               </div>
             )
-          ) : (
+          ) : protocol !== 'OneClick' && (
             status?.isComplete && (
               <div className="bg-green-50 dark:bg-green-900/30 rounded-lg p-4 text-center">
                 <Check className="w-8 h-8 text-green-500 mx-auto mb-2" />
@@ -415,7 +427,7 @@ export function SwapTrackingModal({
             rel="noopener noreferrer"
             className="flex-1 px-4 py-2 text-sm font-medium text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors flex items-center justify-center gap-2"
           >
-            View on {protocol === 'Chainflip' ? 'Chainflip Scan' : 'Tracker'} <ExternalLink className="w-4 h-4" />
+            View on {protocol === 'Chainflip' ? 'Chainflip Scan' : protocol === 'OneClick' ? 'Explorer' : 'Tracker'} <ExternalLink className="w-4 h-4" />
           </a>
           {explorerUrl && protocol !== 'Chainflip' && (
             <a

--- a/tools/xchain-suite/src/hooks/useAggregator.ts
+++ b/tools/xchain-suite/src/hooks/useAggregator.ts
@@ -5,7 +5,7 @@ import type { XChainClient } from '@xchainjs/xchain-client'
 import type { Chain } from '@xchainjs/xchain-util'
 import { SwapService, type SwapQuote } from '../lib/swap/SwapService'
 
-// Chains supported by THORChain, MAYAChain, and Chainflip for swaps
+// Chains supported by THORChain, MAYAChain, Chainflip, and 1Click for swaps
 const SWAP_SUPPORTED_CHAINS: string[] = [
   'BTC',
   'BCH',
@@ -23,6 +23,8 @@ const SWAP_SUPPORTED_CHAINS: string[] = [
   'KUJI',
   'SOL',
   'SUI',
+  'XRP',
+  'ADA',
 ]
 
 interface UseSwapResult {

--- a/tools/xchain-suite/src/hooks/useRecurringSwaps.ts
+++ b/tools/xchain-suite/src/hooks/useRecurringSwaps.ts
@@ -15,7 +15,7 @@ export interface UseRecurringSwapsResult {
     fromAsset: ChainAsset
     toAsset: ChainAsset
     amount: string
-    protocol: 'Thorchain' | 'Mayachain' | 'Chainflip'
+    protocol: 'Thorchain' | 'Mayachain' | 'Chainflip' | 'OneClick'
     interval: RecurringInterval
     maxSlippageBps: number
     streaming?: boolean

--- a/tools/xchain-suite/src/lib/swap/RecurringSwapScheduler.ts
+++ b/tools/xchain-suite/src/lib/swap/RecurringSwapScheduler.ts
@@ -12,7 +12,7 @@ export interface RecurringSchedule {
   fromAsset: ChainAsset
   toAsset: ChainAsset
   amount: string
-  protocol: 'Thorchain' | 'Mayachain' | 'Chainflip'
+  protocol: 'Thorchain' | 'Mayachain' | 'Chainflip' | 'OneClick'
   interval: RecurringInterval
   maxSlippageBps: number
   streaming: boolean
@@ -95,7 +95,7 @@ export class RecurringSwapScheduler {
     fromAsset: ChainAsset
     toAsset: ChainAsset
     amount: string
-    protocol: 'Thorchain' | 'Mayachain' | 'Chainflip'
+    protocol: 'Thorchain' | 'Mayachain' | 'Chainflip' | 'OneClick'
     interval: RecurringInterval
     maxSlippageBps: number
     streaming?: boolean

--- a/tools/xchain-suite/src/lib/swap/SwapHistory.ts
+++ b/tools/xchain-suite/src/lib/swap/SwapHistory.ts
@@ -8,7 +8,7 @@ export interface SwapHistoryEntry {
   toAsset: string // e.g. "ETH.ETH"
   inputAmount: string
   expectedOutput: string
-  protocol: 'Thorchain' | 'Mayachain' | 'Chainflip'
+  protocol: 'Thorchain' | 'Mayachain' | 'Chainflip' | 'OneClick'
   slippageBps: number
   txHash: string
   explorerUrl: string

--- a/tools/xchain-suite/src/lib/swap/SwapService.ts
+++ b/tools/xchain-suite/src/lib/swap/SwapService.ts
@@ -9,7 +9,7 @@ import { type AnyAsset, type CryptoAmount, type Chain, CryptoAmount as CryptoAmo
 
 // Types for swap quotes
 export interface SwapQuote {
-  protocol: 'Thorchain' | 'Mayachain' | 'Chainflip'
+  protocol: 'Thorchain' | 'Mayachain' | 'Chainflip' | 'OneClick'
   toAddress: string
   memo: string
   expectedAmount: CryptoAmount
@@ -41,6 +41,66 @@ export interface SwapResult {
   hash: string
   url: string
   depositChannelId?: string
+}
+
+// 1Click (NEAR Intents) chain mapping
+const ONECLICK_CHAINS: Record<string, string> = {
+  BTC: 'btc', ETH: 'eth', ARB: 'arb', AVAX: 'avax', BSC: 'bsc',
+  SOL: 'sol', DOGE: 'doge', DASH: 'dash', LTC: 'ltc', BCH: 'bch',
+  XRP: 'xrp', ADA: 'cardano', SUI: 'sui',
+}
+
+const ONECLICK_BASE_URL = 'https://1click.chaindefuser.com'
+
+interface OneClickToken {
+  assetId: string
+  blockchain: string
+  symbol: string
+  decimals: number
+  contractAddress?: string
+}
+
+// Cached token list (24h TTL)
+let oneClickTokensCache: { tokens: OneClickToken[]; fetchedAt: number } | null = null
+
+async function getOneClickTokens(): Promise<OneClickToken[]> {
+  const now = Date.now()
+  if (oneClickTokensCache && now - oneClickTokensCache.fetchedAt < 24 * 60 * 60 * 1000) {
+    return oneClickTokensCache.tokens
+  }
+  const apiKey = import.meta.env.VITE_ONECLICK_API_KEY
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`
+
+  const resp = await fetch(`${ONECLICK_BASE_URL}/v0/tokens`, { headers })
+  if (!resp.ok) throw new Error(`1Click getTokens failed: ${resp.status}`)
+  const tokens: OneClickToken[] = await resp.json()
+  oneClickTokensCache = { tokens, fetchedAt: now }
+  return tokens
+}
+
+function findOneClickToken(asset: AnyAsset, tokens: OneClickToken[]): OneClickToken | undefined {
+  const blockchain = ONECLICK_CHAINS[asset.chain]
+  if (!blockchain) return undefined
+
+  // Token asset: match by contract address
+  if (asset.symbol.includes('-')) {
+    const contractAddress = asset.symbol.split('-')[1]
+    return tokens.find(
+      (t) => t.blockchain === blockchain && t.contractAddress &&
+        t.contractAddress.toLowerCase() === contractAddress.toLowerCase(),
+    )
+  }
+
+  // Native asset: match by symbol, no contract address
+  return tokens.find(
+    (t) => t.blockchain === blockchain && !t.contractAddress &&
+      t.symbol.toUpperCase() === asset.symbol.toUpperCase(),
+  )
+}
+
+function isOneClickCompatible(chain: string): boolean {
+  return chain in ONECLICK_CHAINS
 }
 
 // Chainflip chain mapping
@@ -287,11 +347,75 @@ export class SwapService {
       }
     }
 
+    // Try 1Click / NEAR Intents (only if both chains are supported)
+    if (isOneClickCompatible(params.fromAsset.chain) && isOneClickCompatible(params.destinationAsset.chain)) {
+      try {
+        console.log('[SwapService] Getting 1Click quote...')
+        const tokens = await getOneClickTokens()
+        const srcToken = findOneClickToken(params.fromAsset, tokens)
+        const destToken = findOneClickToken(params.destinationAsset, tokens)
+
+        if (srcToken && destToken) {
+          const apiKey = import.meta.env.VITE_ONECLICK_API_KEY
+          const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+          if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`
+
+          const quoteResp = await fetch(`${ONECLICK_BASE_URL}/v0/quote`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({
+              dry: false,
+              swapType: 'EXACT_INPUT',
+              depositType: 'ORIGIN_CHAIN',
+              recipientType: 'DESTINATION_CHAIN',
+              refundType: 'ORIGIN_CHAIN',
+              originAsset: srcToken.assetId,
+              destinationAsset: destToken.assetId,
+              amount: params.amount.baseAmount.amount().toFixed(0),
+              refundTo: params.fromAddress,
+              recipient: params.destinationAddress,
+              slippageTolerance: params.slippageToleranceBps ?? 100,
+              deadline: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+            }),
+          })
+
+          if (!quoteResp.ok) throw new Error(`1Click quote failed: ${quoteResp.status}`)
+          const resp = await quoteResp.json()
+
+          if (!resp.error && !resp.message && resp.quote) {
+            const depositAddress = resp.quote.depositAddress || ''
+            const zeroFee = new CryptoAmountClass(baseAmountFn(0), params.destinationAsset)
+
+            quotes.push({
+              protocol: 'OneClick',
+              toAddress: depositAddress,
+              memo: '',
+              expectedAmount: new CryptoAmountClass(
+                baseAmountFn(resp.quote.amountOut, destToken.decimals),
+                params.destinationAsset,
+              ),
+              totalSwapSeconds: resp.quote.timeEstimate || 0,
+              slipBasisPoints: 0,
+              canSwap: depositAddress !== '',
+              errors: [],
+              warning: '',
+              fees: {
+                affiliateFee: zeroFee,
+                outboundFee: zeroFee,
+              },
+            })
+          }
+        }
+      } catch (e) {
+        console.error('[SwapService] 1Click estimate failed:', e)
+      }
+    }
+
     console.log('[SwapService] Returning quotes:', quotes.length)
     return quotes
   }
 
-  async doSwap(params: SwapParams & { protocol: 'Thorchain' | 'Mayachain' | 'Chainflip' }): Promise<SwapResult> {
+  async doSwap(params: SwapParams & { protocol: 'Thorchain' | 'Mayachain' | 'Chainflip' | 'OneClick' }): Promise<SwapResult> {
     console.log('[SwapService] doSwap called with:', {
       protocol: params.protocol,
       fromAsset: params.fromAsset,
@@ -337,6 +461,57 @@ export class SwapService {
           url: `https://scan.chainflip.io/channels/${depositResponse.depositChannelId}`,
           depositChannelId: depositResponse.depositChannelId,
         }
+      } else if (params.protocol === 'OneClick') {
+        console.log('[SwapService] Executing 1Click swap...')
+        // Re-estimate to get deposit address
+        const tokens = await getOneClickTokens()
+        const srcToken = findOneClickToken(params.fromAsset, tokens)
+        const destToken = findOneClickToken(params.destinationAsset, tokens)
+        if (!srcToken || !destToken) throw new Error('1Click: asset not supported')
+
+        const apiKey = import.meta.env.VITE_ONECLICK_API_KEY
+        const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+        if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`
+
+        const quoteResp = await fetch(`${ONECLICK_BASE_URL}/v0/quote`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            dry: false,
+            swapType: 'EXACT_INPUT',
+            depositType: 'ORIGIN_CHAIN',
+            recipientType: 'DESTINATION_CHAIN',
+            refundType: 'ORIGIN_CHAIN',
+            originAsset: srcToken.assetId,
+            destinationAsset: destToken.assetId,
+            amount: params.amount.baseAmount.amount().toFixed(0),
+            refundTo: params.fromAddress,
+            recipient: params.destinationAddress,
+            slippageTolerance: params.slippageToleranceBps ?? 100,
+            deadline: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+          }),
+        })
+        if (!quoteResp.ok) throw new Error(`1Click quote failed: ${quoteResp.status}`)
+        const resp = await quoteResp.json()
+        if (resp.error || resp.message) throw new Error(`1Click: ${resp.error || resp.message}`)
+        if (!resp.quote?.depositAddress) throw new Error('1Click: no deposit address returned')
+
+        const hash = await this.wallet.transfer({
+          asset: params.fromAsset,
+          amount: params.amount.baseAmount,
+          recipient: resp.quote.depositAddress,
+        })
+        console.log('[SwapService] 1Click transfer result:', hash)
+
+        // Fire-and-forget: notify 1Click about the deposit
+        fetch(`${ONECLICK_BASE_URL}/v0/deposit/submit`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ txHash: hash, depositAddress: resp.quote.depositAddress }),
+        }).catch(() => {})
+
+        const explorerUrl = await this.wallet.getExplorerTxUrl(params.fromAsset.chain, hash)
+        return { hash, url: explorerUrl }
       } else if (params.protocol === 'Thorchain') {
         console.log('[SwapService] Executing THORChain swap...')
         const thorchainAmm = await getThorchainAmm(this.wallet)

--- a/tools/xchain-suite/src/lib/swap/SwapService.ts
+++ b/tools/xchain-suite/src/lib/swap/SwapService.ts
@@ -4,8 +4,14 @@
  * Uses THORChain AMM, MAYAChain AMM, and Chainflip SDK directly.
  */
 
-import type { Network } from '@xchainjs/xchain-client'
-import { type AnyAsset, type CryptoAmount, type Chain, CryptoAmount as CryptoAmountClass, baseAmount as baseAmountFn } from '@xchainjs/xchain-util'
+import { Network } from '@xchainjs/xchain-client'
+import {
+  type AnyAsset,
+  type CryptoAmount,
+  type Chain,
+  CryptoAmount as CryptoAmountClass,
+  baseAmount as baseAmountFn,
+} from '@xchainjs/xchain-util'
 
 // Types for swap quotes
 export interface SwapQuote {
@@ -45,9 +51,19 @@ export interface SwapResult {
 
 // 1Click (NEAR Intents) chain mapping
 const ONECLICK_CHAINS: Record<string, string> = {
-  BTC: 'btc', ETH: 'eth', ARB: 'arb', AVAX: 'avax', BSC: 'bsc',
-  SOL: 'sol', DOGE: 'doge', DASH: 'dash', LTC: 'ltc', BCH: 'bch',
-  XRP: 'xrp', ADA: 'cardano', SUI: 'sui',
+  BTC: 'btc',
+  ETH: 'eth',
+  ARB: 'arb',
+  AVAX: 'avax',
+  BSC: 'bsc',
+  SOL: 'sol',
+  DOGE: 'doge',
+  DASH: 'dash',
+  LTC: 'ltc',
+  BCH: 'bch',
+  XRP: 'xrp',
+  ADA: 'cardano',
+  SUI: 'sui',
 }
 
 const ONECLICK_BASE_URL = 'https://1click.chaindefuser.com'
@@ -87,15 +103,16 @@ function findOneClickToken(asset: AnyAsset, tokens: OneClickToken[]): OneClickTo
   if (asset.symbol.includes('-')) {
     const contractAddress = asset.symbol.split('-')[1]
     return tokens.find(
-      (t) => t.blockchain === blockchain && t.contractAddress &&
+      (t) =>
+        t.blockchain === blockchain &&
+        t.contractAddress &&
         t.contractAddress.toLowerCase() === contractAddress.toLowerCase(),
     )
   }
 
   // Native asset: match by symbol, no contract address
   return tokens.find(
-    (t) => t.blockchain === blockchain && !t.contractAddress &&
-      t.symbol.toUpperCase() === asset.symbol.toUpperCase(),
+    (t) => t.blockchain === blockchain && !t.contractAddress && t.symbol.toUpperCase() === asset.symbol.toUpperCase(),
   )
 }
 
@@ -249,7 +266,8 @@ export class SwapService {
         toAddress: estimate.toAddress,
         memo: estimate.memo,
         expectedAmount: estimate.txEstimate.netOutput,
-        totalSwapSeconds: (estimate.txEstimate.inboundConfirmationSeconds || 0) + estimate.txEstimate.outboundDelaySeconds,
+        totalSwapSeconds:
+          (estimate.txEstimate.inboundConfirmationSeconds || 0) + estimate.txEstimate.outboundDelaySeconds,
         slipBasisPoints: estimate.txEstimate.slipBasisPoints,
         canSwap: estimate.txEstimate.canSwap,
         errors: estimate.txEstimate.errors,
@@ -288,7 +306,8 @@ export class SwapService {
         toAddress: estimate.toAddress,
         memo: estimate.memo,
         expectedAmount: estimate.expectedAmount,
-        totalSwapSeconds: estimate.totalSwapSeconds || ((estimate.inboundConfirmationSeconds || 0) + estimate.outboundDelaySeconds),
+        totalSwapSeconds:
+          estimate.totalSwapSeconds || (estimate.inboundConfirmationSeconds || 0) + estimate.outboundDelaySeconds,
         slipBasisPoints: estimate.slipBasisPoints,
         canSwap: estimate.canSwap,
         errors: estimate.errors,
@@ -318,10 +337,7 @@ export class SwapService {
           )
 
           // Zero-value amount for fee placeholders (Chainflip fees are included in the quote)
-          const zeroFee = new CryptoAmountClass(
-            baseAmountFn(0, destDecimals),
-            params.destinationAsset,
-          )
+          const zeroFee = new CryptoAmountClass(baseAmountFn(0, destDecimals), params.destinationAsset)
 
           // Use recommended slippage tolerance as the price impact estimate
           const slipBps = Math.round((bestQuote.recommendedSlippageTolerancePercent || 0) * 100)
@@ -347,8 +363,13 @@ export class SwapService {
       }
     }
 
-    // Try 1Click / NEAR Intents (only if both chains are supported)
-    if (isOneClickCompatible(params.fromAsset.chain) && isOneClickCompatible(params.destinationAsset.chain)) {
+    // Try 1Click / NEAR Intents (only on Mainnet — the 1click.chaindefuser.com API
+    // is mainnet-only; testnet/stagenet wallets must not receive quotes)
+    if (
+      this.wallet.getNetwork() === Network.Mainnet &&
+      isOneClickCompatible(params.fromAsset.chain) &&
+      isOneClickCompatible(params.destinationAsset.chain)
+    ) {
       try {
         console.log('[SwapService] Getting 1Click quote...')
         const tokens = await getOneClickTokens()
@@ -415,7 +436,9 @@ export class SwapService {
     return quotes
   }
 
-  async doSwap(params: SwapParams & { protocol: 'Thorchain' | 'Mayachain' | 'Chainflip' | 'OneClick' }): Promise<SwapResult> {
+  async doSwap(
+    params: SwapParams & { protocol: 'Thorchain' | 'Mayachain' | 'Chainflip' | 'OneClick' },
+  ): Promise<SwapResult> {
     console.log('[SwapService] doSwap called with:', {
       protocol: params.protocol,
       fromAsset: params.fromAsset,
@@ -432,9 +455,10 @@ export class SwapService {
         if (!bestQuote) throw new Error('No Chainflip quote available')
 
         // Use user-provided slippage tolerance, fall back to quote recommendation or 2%
-        const slippagePercent = params.slippageToleranceBps !== undefined
-          ? params.slippageToleranceBps / 100
-          : bestQuote.recommendedSlippageTolerancePercent || 2
+        const slippagePercent =
+          params.slippageToleranceBps !== undefined
+            ? params.slippageToleranceBps / 100
+            : bestQuote.recommendedSlippageTolerancePercent || 2
 
         const depositResponse = await sdk.requestDepositAddressV2({
           quote: bestQuote,
@@ -462,6 +486,9 @@ export class SwapService {
           depositChannelId: depositResponse.depositChannelId,
         }
       } else if (params.protocol === 'OneClick') {
+        if (this.wallet.getNetwork() !== Network.Mainnet) {
+          throw new Error('1Click swaps are only supported on Mainnet')
+        }
         console.log('[SwapService] Executing 1Click swap...')
         // Re-estimate to get deposit address
         const tokens = await getOneClickTokens()
@@ -503,14 +530,27 @@ export class SwapService {
         })
         console.log('[SwapService] 1Click transfer result:', hash)
 
-        // Fire-and-forget: notify 1Click about the deposit
-        fetch(`${ONECLICK_BASE_URL}/v0/deposit/submit`, {
+        // Funds are already on the wire. Awaiting the submit lets us surface registration
+        // failures with the broadcast hash so the user can recover, instead of silently
+        // dropping them with .catch(() => {}) and leaving the swap to never settle.
+        const submitResp = await fetch(`${ONECLICK_BASE_URL}/v0/deposit/submit`, {
           method: 'POST',
           headers,
           body: JSON.stringify({ txHash: hash, depositAddress: resp.quote.depositAddress }),
-        }).catch(() => {})
+        })
+        if (!submitResp.ok) {
+          throw new Error(
+            `1Click deposit tx ${hash} was broadcast, but submitDeposit failed: HTTP ${submitResp.status}`,
+          )
+        }
 
-        const explorerUrl = await this.wallet.getExplorerTxUrl(params.fromAsset.chain, hash)
+        // Explorer URL is best-effort; the hash is what matters for tracking.
+        let explorerUrl = ''
+        try {
+          explorerUrl = await this.wallet.getExplorerTxUrl(params.fromAsset.chain, hash)
+        } catch (e) {
+          console.warn('[SwapService] 1Click explorer URL lookup failed:', e)
+        }
         return { hash, url: explorerUrl }
       } else if (params.protocol === 'Thorchain') {
         console.log('[SwapService] Executing THORChain swap...')

--- a/tools/xchain-suite/src/pages/SwapPage.tsx
+++ b/tools/xchain-suite/src/pages/SwapPage.tsx
@@ -73,7 +73,9 @@ export default function SwapPage() {
   // Tracking state
   const [isTrackingOpen, setIsTrackingOpen] = useState(false)
   const [trackingTxHash, setTrackingTxHash] = useState<string | null>(null)
-  const [trackingProtocol, setTrackingProtocol] = useState<'Thorchain' | 'Mayachain' | 'Chainflip' | 'OneClick'>('Thorchain')
+  const [trackingProtocol, setTrackingProtocol] = useState<'Thorchain' | 'Mayachain' | 'Chainflip' | 'OneClick'>(
+    'Thorchain',
+  )
   const [trackingExplorerUrl, setTrackingExplorerUrl] = useState<string | undefined>()
   const [trackingDepositChannelId, setTrackingDepositChannelId] = useState<string | undefined>()
 
@@ -119,9 +121,7 @@ export default function SwapPage() {
         if (cancelled) return
 
         const match = balances.find(
-          (b: any) =>
-            b.asset.chain === asset.chain &&
-            b.asset.symbol.toLowerCase() === asset.symbol.toLowerCase(),
+          (b: any) => b.asset.chain === asset.chain && b.asset.symbol.toLowerCase() === asset.symbol.toLowerCase(),
         )
         if (match) {
           const assetAmt = baseToAsset(match.amount)
@@ -140,7 +140,9 @@ export default function SwapPage() {
     }
 
     fetchBalance()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+    }
   }, [wallet, fromAsset])
 
   // Clear destination override when toAsset changes
@@ -245,7 +247,7 @@ export default function SwapPage() {
 
     // Get addresses
     const fromAddress = await wallet.getAddress(fromAsset.chainId)
-    const destinationAddress = destinationOverride.trim() || await wallet.getAddress(toAsset.chainId)
+    const destinationAddress = destinationOverride.trim() || (await wallet.getAddress(toAsset.chainId))
 
     console.log('[SwapPage] Addresses:', { fromAddress, destinationAddress })
 
@@ -295,7 +297,7 @@ export default function SwapPage() {
     const cryptoAmount = new CryptoAmount(assetToBase(assetAmount(amountNum, decimals)), fromAssetObj)
 
     const fromAddress = await wallet.getAddress(fromAsset.chainId)
-    const destinationAddress = destinationOverride.trim() || await wallet.getAddress(toAsset.chainId)
+    const destinationAddress = destinationOverride.trim() || (await wallet.getAddress(toAsset.chainId))
 
     setIsConfirmOpen(false)
 
@@ -311,7 +313,8 @@ export default function SwapPage() {
           slippageToleranceBps: slippageBps,
           // Streaming swap parameters (only for THORChain/MAYAChain)
           ...(isStreaming &&
-            selectedQuote.protocol !== 'Chainflip' && selectedQuote.protocol !== 'OneClick' && {
+            selectedQuote.protocol !== 'Chainflip' &&
+            selectedQuote.protocol !== 'OneClick' && {
               streamingInterval: parseInt(streamingInterval) || 1,
               streamingQuantity: parseInt(streamingQuantity) || 0,
             }),
@@ -611,7 +614,10 @@ export default function SwapPage() {
                   <button
                     key={bps}
                     type="button"
-                    onClick={() => { setSlippageBps(bps); setCustomSlippage('') }}
+                    onClick={() => {
+                      setSlippageBps(bps)
+                      setCustomSlippage('')
+                    }}
                     className={`px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
                       slippageBps === bps && !customSlippage
                         ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
@@ -763,29 +769,32 @@ export default function SwapPage() {
         )}
 
         {/* Code Examples */}
-        {fromAsset && toAsset && amount && selectedQuote?.protocol !== 'Chainflip' && (
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6 space-y-4">
-            <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">Code Examples</h3>
-            <CodePreview
-              code={generateSwapEstimateCode(
-                fromAsset.chainId,
-                toAsset.chainId,
-                amount,
-                selectedQuote?.protocol === 'Mayachain' ? 'MAYAChain' : 'THORChain',
-              )}
-              title="Get Swap Quote"
-            />
-            <CodePreview
-              code={generateSwapExecuteCode(
-                fromAsset.chainId,
-                toAsset.chainId,
-                amount,
-                selectedQuote?.protocol === 'Mayachain' ? 'MAYAChain' : 'THORChain',
-              )}
-              title="Execute Swap"
-            />
-          </div>
-        )}
+        {fromAsset &&
+          toAsset &&
+          amount &&
+          (selectedQuote?.protocol === 'Thorchain' || selectedQuote?.protocol === 'Mayachain') && (
+            <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6 space-y-4">
+              <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">Code Examples</h3>
+              <CodePreview
+                code={generateSwapEstimateCode(
+                  fromAsset.chainId,
+                  toAsset.chainId,
+                  amount,
+                  selectedQuote?.protocol === 'Mayachain' ? 'MAYAChain' : 'THORChain',
+                )}
+                title="Get Swap Quote"
+              />
+              <CodePreview
+                code={generateSwapExecuteCode(
+                  fromAsset.chainId,
+                  toAsset.chainId,
+                  amount,
+                  selectedQuote?.protocol === 'Mayachain' ? 'MAYAChain' : 'THORChain',
+                )}
+                title="Execute Swap"
+              />
+            </div>
+          )}
         {/* DCA Callout */}
         <Link
           to="/recurring"
@@ -795,7 +804,9 @@ export default function SwapPage() {
             <CalendarClock className="w-5 h-5 text-blue-500 shrink-0" />
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium text-gray-900 dark:text-gray-100">Dollar-Cost Average</p>
-              <p className="text-xs text-gray-500 dark:text-gray-400">Set up recurring swaps to DCA into any asset automatically</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                Set up recurring swaps to DCA into any asset automatically
+              </p>
             </div>
             <ChevronDown className="w-4 h-4 text-gray-400 -rotate-90 group-hover:translate-x-0.5 transition-transform" />
           </div>
@@ -827,20 +838,24 @@ export default function SwapPage() {
                   >
                     <div className="min-w-0">
                       <div className="font-medium text-gray-900 dark:text-gray-100">
-                        {entry.inputAmount} {entry.fromAsset.split('.')[1]} → {entry.expectedOutput} {entry.toAsset.split('.')[1]}
+                        {entry.inputAmount} {entry.fromAsset.split('.')[1]} → {entry.expectedOutput}{' '}
+                        {entry.toAsset.split('.')[1]}
                       </div>
                       <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                        {entry.protocol} · {formatTimeAgo(entry.timestamp)} · Slip: {(entry.slippageBps / 100).toFixed(2)}%
+                        {entry.protocol} · {formatTimeAgo(entry.timestamp)} · Slip:{' '}
+                        {(entry.slippageBps / 100).toFixed(2)}%
                       </div>
                     </div>
                     <div className="flex items-center gap-2 shrink-0">
-                      <span className={`px-2 py-0.5 text-xs rounded-full font-medium ${
-                        entry.status === 'completed'
-                          ? 'bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-400'
-                          : entry.status === 'failed'
-                          ? 'bg-red-100 dark:bg-red-900/50 text-red-700 dark:text-red-400'
-                          : 'bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-400'
-                      }`}>
+                      <span
+                        className={`px-2 py-0.5 text-xs rounded-full font-medium ${
+                          entry.status === 'completed'
+                            ? 'bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-400'
+                            : entry.status === 'failed'
+                            ? 'bg-red-100 dark:bg-red-900/50 text-red-700 dark:text-red-400'
+                            : 'bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-400'
+                        }`}
+                      >
                         {entry.status}
                       </span>
                       <a
@@ -856,7 +871,10 @@ export default function SwapPage() {
                 ))}
                 <button
                   type="button"
-                  onClick={() => { clearHistory(); setSwapHistory([]) }}
+                  onClick={() => {
+                    clearHistory()
+                    setSwapHistory([])
+                  }}
                   className="flex items-center gap-1 text-xs text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors"
                 >
                   <Trash2 className="w-3 h-3" />

--- a/tools/xchain-suite/src/pages/SwapPage.tsx
+++ b/tools/xchain-suite/src/pages/SwapPage.tsx
@@ -73,7 +73,7 @@ export default function SwapPage() {
   // Tracking state
   const [isTrackingOpen, setIsTrackingOpen] = useState(false)
   const [trackingTxHash, setTrackingTxHash] = useState<string | null>(null)
-  const [trackingProtocol, setTrackingProtocol] = useState<'Thorchain' | 'Mayachain' | 'Chainflip'>('Thorchain')
+  const [trackingProtocol, setTrackingProtocol] = useState<'Thorchain' | 'Mayachain' | 'Chainflip' | 'OneClick'>('Thorchain')
   const [trackingExplorerUrl, setTrackingExplorerUrl] = useState<string | undefined>()
   const [trackingDepositChannelId, setTrackingDepositChannelId] = useState<string | undefined>()
 
@@ -309,9 +309,9 @@ export default function SwapPage() {
           destinationAddress,
           protocol: selectedQuote.protocol,
           slippageToleranceBps: slippageBps,
-          // Streaming swap parameters (not applicable for Chainflip)
+          // Streaming swap parameters (only for THORChain/MAYAChain)
           ...(isStreaming &&
-            selectedQuote.protocol !== 'Chainflip' && {
+            selectedQuote.protocol !== 'Chainflip' && selectedQuote.protocol !== 'OneClick' && {
               streamingInterval: parseInt(streamingInterval) || 1,
               streamingQuantity: parseInt(streamingQuantity) || 0,
             }),


### PR DESCRIPTION
…n swaps

Add 1Click as a fourth protocol in xchain-aggregator alongside THORChain, MAYAChain, and Chainflip. Uses deposit-address flow via the 1Click REST API to enable swaps across 13 chains (BTC, ETH, ARB, AVAX, BSC, SOL, DOGE, DASH, LTC, BCH, XRP, ADA, SUI).

Also integrates OneClick into tools/xchain-suite testing GUI with quote comparison, swap execution, and tracking modal support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OneClick added as a new swap protocol with API-backed quoting, deposit submission, and UI integration.
  * XRP and ADA added to supported chains.
  * OneClick enabled for recurring swap scheduling.

* **Improvements**
  * Swap tracking UI adds OneClick deposit stage and uses an Explorer CTA.
  * Swap service and history now surface OneClick quotes and executions.

* **Tests**
  * Added comprehensive OneClick protocol tests covering token resolution, quoting, swap flows, and error handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xchainjs/xchainjs-lib/pull/1664)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->