### PR TITLE
Refactor/remove ninerealms ltc defaults

### DIFF
--- a/.changeset/brave-groups-see.md
+++ b/.changeset/brave-groups-see.md
@@ -1,0 +1,5 @@
+---
+'@xchainjs/xchain-litecoin': minor
+---
+
+Cleaned up the LTC client by removing Ninerealms default parameters (nodeUrls and nodeAuth).

--- a/packages/xchain-litecoin/README.md
+++ b/packages/xchain-litecoin/README.md
@@ -70,10 +70,7 @@ For a complete example please see this [test](https://github.com/xchainjs/xchain
 Creating a no-arg LTC Client will default to the following settings:
 
 ```typescript
-const defaultLTCParams: UtxoClientParams & {
-  nodeUrls: NodeUrls
-  nodeAuth?: NodeAuth
-} = {
+const defaultLTCParams: UtxoClientParams = {
   network: Network.Mainnet,
   phrase: '',
   explorerProviders: explorerProviders,
@@ -87,15 +84,10 @@ const defaultLTCParams: UtxoClientParams & {
     lower: LOWER_FEE_BOUND,
     upper: UPPER_FEE_BOUND,
   },
-  nodeUrls: {
-    [Network.Mainnet]: 'https://litecoin.ninerealms.com',
-    [Network.Stagenet]: 'https://litecoin.ninerealms.com',
-    [Network.Testnet]: 'https://testnet.ltc.thorchain.info',
-  },
 }
 ```
 
-Note: BlockCypher is the default online data provider (to fetch realtime utxos, balances, etc)
+Note: Default online data providers is Blockcypher for UTXOs, balances, and broadcast.
 
 ## Overriding providers
 

--- a/packages/xchain-litecoin/__tests__/client.test.ts
+++ b/packages/xchain-litecoin/__tests__/client.test.ts
@@ -5,7 +5,6 @@ import { UtxoClientParams } from '@xchainjs/xchain-utxo'
 import mockSochainApi from '../__mocks__/sochain'
 import mockThornodeApi from '../__mocks__/thornode-api'
 import { ClientKeystore as Client } from '../src'
-import { NodeUrls } from '../src/client'
 import {
   AssetLTC,
   LOWER_FEE_BOUND,
@@ -14,12 +13,8 @@ import {
   explorerProviders,
   sochainDataProviders,
 } from '../src/const'
-import { NodeAuth } from '../src/types'
 
-export const defaultLTCParams: UtxoClientParams & {
-  nodeUrls: NodeUrls
-  nodeAuth?: NodeAuth
-} = {
+export const defaultLTCParams: UtxoClientParams = {
   network: Network.Mainnet,
   phrase: '',
   explorerProviders: explorerProviders,
@@ -32,11 +27,6 @@ export const defaultLTCParams: UtxoClientParams & {
   feeBounds: {
     lower: LOWER_FEE_BOUND,
     upper: UPPER_FEE_BOUND,
-  },
-  nodeUrls: {
-    [Network.Mainnet]: 'https://litecoin.ninerealms.com',
-    [Network.Stagenet]: 'https://litecoin.ninerealms.com',
-    [Network.Testnet]: 'https://testnet.ltc.thorchain.info',
   },
 }
 

--- a/packages/xchain-litecoin/src/ClientKeystore.ts
+++ b/packages/xchain-litecoin/src/ClientKeystore.ts
@@ -98,11 +98,7 @@ export class ClientKeystore extends Client {
     psbt.finalizeAllInputs()
     const txHex = psbt.extractTransaction().toHex()
 
-    return await Utils.broadcastTx({
-      txHex,
-      nodeUrl: this.nodeUrls[this.network],
-      auth: this.nodeAuth,
-    })
+    return await this.broadcastTx(txHex)
   }
 
   /**
@@ -145,11 +141,7 @@ export class ClientKeystore extends Client {
     psbt.finalizeAllInputs()
 
     const txHex = psbt.extractTransaction().toHex()
-    const hash = await Utils.broadcastTx({
-      txHex,
-      nodeUrl: this.nodeUrls[this.network],
-      auth: this.nodeAuth,
-    })
+    const hash = await this.broadcastTx(txHex)
 
     return { hash, maxAmount, fee }
   }

--- a/packages/xchain-litecoin/src/ClientLedger.ts
+++ b/packages/xchain-litecoin/src/ClientLedger.ts
@@ -5,8 +5,7 @@ import { Address } from '@xchainjs/xchain-util'
 import { TxParams, UTXO, UtxoClientParams, UtxoSelectionPreferences } from '@xchainjs/xchain-utxo'
 import * as Litecoin from 'bitcoinjs-lib'
 
-import { Client, NodeUrls } from './client'
-import { NodeAuth } from './types'
+import { Client } from './client'
 
 /**
  * Custom Ledger Litecoin client
@@ -19,7 +18,7 @@ class ClientLedger extends Client {
 
   // Constructor
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor(params: UtxoClientParams & { transport: any; nodeUrls: NodeUrls; nodeAuth?: NodeAuth }) {
+  constructor(params: UtxoClientParams & { transport: any }) {
     super(params)
     this.transport = params.transport
   }

--- a/packages/xchain-litecoin/src/client.ts
+++ b/packages/xchain-litecoin/src/client.ts
@@ -24,19 +24,11 @@ import {
   UPPER_FEE_BOUND,
   explorerProviders,
 } from './const'
-import { NodeAuth } from './types'
 import * as Utils from './utils'
-/**
- * Defines a mapping of node URLs for different networks.
- */
-export type NodeUrls = Record<Network, string>
 /**
  * Default parameters for the Litecoin client.
  */
-export const defaultLtcParams: UtxoClientParams & {
-  nodeUrls: NodeUrls
-  nodeAuth?: NodeAuth
-} = {
+export const defaultLtcParams: UtxoClientParams = {
   network: Network.Mainnet,
   phrase: '',
   explorerProviders: explorerProviders,
@@ -50,19 +42,12 @@ export const defaultLtcParams: UtxoClientParams & {
     lower: LOWER_FEE_BOUND,
     upper: UPPER_FEE_BOUND,
   },
-  nodeUrls: {
-    [Network.Mainnet]: 'https://litecoin.ninerealms.com',
-    [Network.Stagenet]: 'https://litecoin.ninerealms.com',
-    [Network.Testnet]: 'https://testnet.ltc.thorchain.info',
-  },
 }
 
 /**
  * Custom Litecoin client.
  */
 abstract class Client extends UTXOClient {
-  protected nodeUrls: NodeUrls
-  protected nodeAuth?: NodeAuth
   /**
    * Constructs a new `Client` with the provided parameters.
    *
@@ -77,8 +62,6 @@ abstract class Client extends UTXOClient {
       explorerProviders: params.explorerProviders,
       dataProviders: params.dataProviders,
     })
-    this.nodeUrls = params.nodeUrls
-    this.nodeAuth = params.nodeAuth
   }
 
   /**

--- a/packages/xchain-litecoin/src/index.ts
+++ b/packages/xchain-litecoin/src/index.ts
@@ -6,7 +6,7 @@ export * from './types'
 /**
  * Export the 'Client' class from the 'client' module.
  */
-export { type NodeUrls, defaultLtcParams } from './client'
+export { defaultLtcParams } from './client'
 export { ClientKeystore, ClientKeystore as Client } from './ClientKeystore'
 export { ClientLedger } from './ClientLedger'
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed pre-configured node URL and authentication defaults from Litecoin client initialization; custom node configuration is now required.

* **Documentation**
  * Updated README examples and documentation to reflect simplified client defaults and clarify that BlockCypher serves as the default online data provider for UTXO and balance operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->