### PR TITLE
Fix/zcash zip317 nu6.1 fees

### DIFF
--- a/.changeset/fix-zcash-memo-fees.md
+++ b/.changeset/fix-zcash-memo-fees.md
@@ -1,0 +1,6 @@
+---
+'@xchainjs/zcash-js': patch
+'@xchainjs/xchain-zcash': patch
+---
+
+Fix memo fee double-counting in buildTx/prepareMaxTx and bypass in buildMaxTx by standardizing all codepaths to use getFee as the single source of truth for memo output slot calculation

--- a/packages/xchain-zcash/__tests__/client.test.ts
+++ b/packages/xchain-zcash/__tests__/client.test.ts
@@ -150,9 +150,9 @@ describe('Zcash client', () => {
     const fees = await client.getFees({ memo: 'test' })
     const expected = {
       type: FeeType.FlatFee,
-      average: baseAmount(25000, ZEC_DECIMAL),
-      fast: baseAmount(25000, ZEC_DECIMAL),
-      fastest: baseAmount(25000, ZEC_DECIMAL),
+      average: baseAmount(30000, ZEC_DECIMAL),
+      fast: baseAmount(30000, ZEC_DECIMAL),
+      fastest: baseAmount(30000, ZEC_DECIMAL),
     }
     expect(deepSerialize(fees)).toEqual(deepSerialize(expected))
   })
@@ -161,9 +161,9 @@ describe('Zcash client', () => {
     const fees = await client.getFees({ sender: 't1eiZYPXWurGMxFwoTu62531s8fAiExFh88' })
     const expected = {
       type: FeeType.FlatFee,
-      average: baseAmount(30000, ZEC_DECIMAL),
-      fast: baseAmount(30000, ZEC_DECIMAL),
-      fastest: baseAmount(30000, ZEC_DECIMAL),
+      average: baseAmount(40000, ZEC_DECIMAL),
+      fast: baseAmount(40000, ZEC_DECIMAL),
+      fastest: baseAmount(40000, ZEC_DECIMAL),
     }
     expect(deepSerialize(fees)).toEqual(deepSerialize(expected))
   })

--- a/packages/xchain-zcash/src/client.ts
+++ b/packages/xchain-zcash/src/client.ts
@@ -251,8 +251,8 @@ abstract class Client extends UTXOClient {
       // Calculate total value of all UTXOs
       const totalValue = utxos.reduce((sum, utxo) => sum + utxo.value, 0)
 
-      // Calculate flat fee for this transaction (2 outputs: recipient + potential memo)
-      const fee = getFee(utxos.length, memo ? 2 : 1, memo)
+      // Calculate flat fee for this transaction (1 = recipient only; getFee adds memo slots)
+      const fee = getFee(utxos.length, 1, memo)
 
       // Calculate max sendable amount
       const maxAmount = totalValue - fee

--- a/packages/zcash-js/src/builder.ts
+++ b/packages/zcash-js/src/builder.ts
@@ -18,12 +18,11 @@ const TX_VERSION_GROUP_ID = 0x26a7270a
 const TX_VERSION = 0x80000005
 
 const PKH_OUTPUT_SIZE = 34
-const MARGINAL_FEE = 5000
-const GRACE_ACTIONS = 2
+const MARGINAL_FEE = 10000
 
 function calculateFee(inCount: number, outCount: number): number {
-  const logicalActions = inCount + outCount
-  return MARGINAL_FEE * Math.max(GRACE_ACTIONS, logicalActions)
+  const logicalActions = Math.max(inCount, outCount)
+  return MARGINAL_FEE * Math.max(1, logicalActions)
 }
 
 /**

--- a/packages/zcash-js/src/builder.ts
+++ b/packages/zcash-js/src/builder.ts
@@ -103,8 +103,7 @@ export async function buildMaxTx(
   if (utxos.length === 0) throw new Error('No UTXOs provided')
 
   // For max tx: NO change output, just recipient + optional memo
-  const outputCount = memo ? 2 : 1
-  const fee = calculateFee(utxos.length, outputCount)
+  const fee = getFee(utxos.length, 1, memo) // 1 = recipient only; getFee adds memo slots
 
   // Calculate total value and max sendable amount
   const totalValue = sumBy(utxos, (u: UTXO) => u.satoshis)
@@ -151,8 +150,7 @@ export async function buildTx(
   if (memo && memo.length > 80) throw new Error('Memo too long')
 
   const inputs = selectUTXOS(utxos, amount, memo)
-  const outputCount = memo ? 3 : 2 // change + to + memo (if exists)
-  const fee = getFee(inputs.length, outputCount, memo)
+  const fee = getFee(inputs.length, 2, memo) // 2 = change + recipient; getFee adds memo slots
   const change = sumBy(inputs, (u: UTXO) => u.satoshis) - amount - fee
   if (change < 0) throw new Error('Not enough funds')
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved memo fee double-counting issue in Zcash transactions, eliminating unexpected fee inflation when transaction memos are included
  * Unified fee calculation methodology across all transaction creation pathways to provide consistent, accurate, and predictable transaction fees

<!-- end of auto-generated comment: release notes by coderabbit.ai -->