### PR TITLE
migrate Nine Realms endpoints to Liquify and updated providers

### DIFF
--- a/.changeset/migrate-ninerealms-to-liquify.md
+++ b/.changeset/migrate-ninerealms-to-liquify.md
@@ -1,0 +1,21 @@
+---
+"@xchainjs/xchain-client": patch
+"@xchainjs/xchain-thorchain": patch
+"@xchainjs/xchain-thornode": patch
+"@xchainjs/xchain-midgard": patch
+"@xchainjs/xchain-midgard-query": patch
+"@xchainjs/xchain-thorchain-query": patch
+"@xchainjs/xchain-thorchain-amm": patch
+"@xchainjs/xchain-bitcoincash": patch
+"@xchainjs/xchain-util": patch
+---
+
+Migrate Nine Realms endpoints to Liquify and updated providers
+
+- Mainnet thornode/midgard/rpc endpoints now use gateway.liquify.com
+- Haskoin endpoint updated to api.haskoin.com
+- Tracker URL updated to track.thorchain.org
+- New THORNODE_API_URL and MIDGARD_API_URL exports (old 9R names deprecated)
+- x-client-id header middleware expanded to match liquify.com
+- Stagenet defaults cleared (no Liquify stagenet yet)
+- Testnet entries marked as deprecated

--- a/packages/xchain-aggregator/NETWORK_CONFIG.md
+++ b/packages/xchain-aggregator/NETWORK_CONFIG.md
@@ -91,9 +91,8 @@ console.log('Active protocols:', config.protocols)
 
 The aggregator automatically uses the correct endpoints for each network:
 
-- **Mainnet**: `https://thornode.ninerealms.com`
-- **Stagenet**: `https://stagenet-thornode.ninerealms.com`
-- **Testnet**: `https://testnet.thornode.thorchain.info`
+- **Mainnet**: `https://gateway.liquify.com/chain/thorchain_api`
+- **Stagenet**: TBD — stagenet URL migration pending
 
 ## Supported Networks by Protocol
 

--- a/packages/xchain-bitcoin/README.md
+++ b/packages/xchain-bitcoin/README.md
@@ -40,13 +40,13 @@ Sochain API rate limits: https://sochain.com/api#rate-limits (300 requests/minut
 
 Bitgo API rate limits: https://app.bitgo.com/docs/#section/Rate-Limiting (10 requests/second)
 
-### Setting Headers for Nine Realms endpoints
+### Setting Headers for Liquify endpoints
 
-If you plan on using the publically accessible endpoints provided by Nine Realms(listed below), ensure that you add a valid 'x-client-id' to all requests
+If you plan on using the publically accessible endpoints provided by Liquify (listed below), ensure that you add a valid 'x-client-id' to all requests
 
-- https://midgard.ninerealms.com
-- https://haskoin.ninerealms.com (BTC/BCH/LTC)
-- https://thornode.ninerealms.com
+- https://gateway.liquify.com/chain/thorchain_midgard
+- https://api.haskoin.com (BTC/BCH/LTC)
+- https://gateway.liquify.com/chain/thorchain_api
 
 Example
 

--- a/packages/xchain-bitcoin/README.md
+++ b/packages/xchain-bitcoin/README.md
@@ -40,9 +40,9 @@ Sochain API rate limits: https://sochain.com/api#rate-limits (300 requests/minut
 
 Bitgo API rate limits: https://app.bitgo.com/docs/#section/Rate-Limiting (10 requests/second)
 
-### Setting Headers for Liquify endpoints
+### Setting Headers for public endpoints
 
-If you plan on using the publically accessible endpoints provided by Liquify (listed below), ensure that you add a valid 'x-client-id' to all requests
+If you plan on using the publicly accessible endpoints listed below, ensure that you add a valid 'x-client-id' to all requests
 
 - https://gateway.liquify.com/chain/thorchain_midgard
 - https://api.haskoin.com (BTC/BCH/LTC)

--- a/packages/xchain-bitcoincash/README.md
+++ b/packages/xchain-bitcoincash/README.md
@@ -40,13 +40,13 @@ Haskoin API rate limits: No
 
 Bitgo API rate limits: https://app.bitgo.com/docs/#section/Rate-Limiting (10 requests/second)
 
-### Setting Headers for Nine Realms endpoints
+### Setting Headers for Liquify endpoints
 
-If you plan on using the publically accessible endpoints provided by Nine Realms(listed below), ensure that you add a valid 'x-client-id' to all requests
+If you plan on using the publically accessible endpoints provided by Liquify (listed below), ensure that you add a valid 'x-client-id' to all requests
 
-- https://midgard.ninerealms.com
-- https://haskoin.ninerealms.com (BTC/BCH/LTC)
-- https://thornode.ninerealms.com
+- https://gateway.liquify.com/chain/thorchain_midgard
+- https://api.haskoin.com (BTC/BCH/LTC)
+- https://gateway.liquify.com/chain/thorchain_api
 
 Example
 

--- a/packages/xchain-bitcoincash/README.md
+++ b/packages/xchain-bitcoincash/README.md
@@ -40,9 +40,9 @@ Haskoin API rate limits: No
 
 Bitgo API rate limits: https://app.bitgo.com/docs/#section/Rate-Limiting (10 requests/second)
 
-### Setting Headers for Liquify endpoints
+### Setting Headers for public endpoints
 
-If you plan on using the publically accessible endpoints provided by Liquify (listed below), ensure that you add a valid 'x-client-id' to all requests
+If you plan on using the publicly accessible endpoints listed below, ensure that you add a valid 'x-client-id' to all requests
 
 - https://gateway.liquify.com/chain/thorchain_midgard
 - https://api.haskoin.com (BTC/BCH/LTC)

--- a/packages/xchain-bitcoincash/src/const.ts
+++ b/packages/xchain-bitcoincash/src/const.ts
@@ -63,13 +63,7 @@ const testnetHaskoinProvider = new HaskoinProvider(
   8,
   HaskoinNetwork.BCHTEST,
 )
-const mainnetHaskoinProvider = new HaskoinProvider(
-  'https://haskoin.ninerealms.com',
-  BCHChain,
-  AssetBCH,
-  8,
-  HaskoinNetwork.BCH,
-)
+const mainnetHaskoinProvider = new HaskoinProvider('https://api.haskoin.com', BCHChain, AssetBCH, 8, HaskoinNetwork.BCH)
 export const HaskoinDataProviders: UtxoOnlineDataProviders = {
   [Network.Testnet]: testnetHaskoinProvider,
   [Network.Stagenet]: mainnetHaskoinProvider,

--- a/packages/xchain-client/src/BaseXChainClient.ts
+++ b/packages/xchain-client/src/BaseXChainClient.ts
@@ -23,8 +23,8 @@ import {
   XChainClientParams,
 } from './types'
 
-const MAINNET_THORNODE_API_BASE = 'https://thornode.ninerealms.com/thorchain'
-const STAGENET_THORNODE_API_BASE = 'https://stagenet-thornode.ninerealms.com/thorchain'
+const MAINNET_THORNODE_API_BASE = 'https://gateway.liquify.com/chain/thorchain_api/thorchain'
+const STAGENET_THORNODE_API_BASE = 'TBD'
 const TESTNET_THORNODE_API_BASE = 'https://testnet.thornode.thorchain.info/thorchain'
 
 const MAINNET_MAYANODE_API_BASE = 'https://mayanode.mayachain.info/mayachain'

--- a/packages/xchain-client/src/BaseXChainClient.ts
+++ b/packages/xchain-client/src/BaseXChainClient.ts
@@ -24,7 +24,7 @@ import {
 } from './types'
 
 const MAINNET_THORNODE_API_BASE = 'https://gateway.liquify.com/chain/thorchain_api/thorchain'
-const STAGENET_THORNODE_API_BASE = 'TBD'
+const STAGENET_THORNODE_API_BASE = ''
 const TESTNET_THORNODE_API_BASE = 'https://testnet.thornode.thorchain.info/thorchain'
 
 const MAINNET_MAYANODE_API_BASE = 'https://mayanode.mayachain.info/mayachain'

--- a/packages/xchain-litecoin/README.md
+++ b/packages/xchain-litecoin/README.md
@@ -44,7 +44,7 @@ Bitaps API rate limits: Standard limit 15 requests within 5 seconds for a single
 
 ### Setting Headers for Nine Realms endpoints
 
-If you plan on using the publically accessible endpoints provided by Nine Realms(listed below), ensure that you add a valid 'x-client-id' to all requests
+If you plan on using the publicly accessible endpoints provided by Nine Realms(listed below), ensure that you add a valid 'x-client-id' to all requests
 
 - https://midgard.ninerealms.com
 - https://haskoin.ninerealms.com (LTC/BCH/LTC)

--- a/packages/xchain-mayachain-query/README.md
+++ b/packages/xchain-mayachain-query/README.md
@@ -160,13 +160,12 @@ Estimate AddSaver() & WithdrawSaver() & getSaverPosition() https://replit.com/@t
 
 Check transaction Stage 
 
-### Setting Headers for Nine Realms endpoints
+### Setting Headers for MAYAChain endpoints
 
-If you plan on using the publically accessible endpoints provided by Nine Realms(listed below), ensure that you add a valid 'x-client-id' to all requests
+If you plan on using the publicly accessible endpoints provided by MAYAChain (listed below), ensure that you add a valid 'x-client-id' to all requests
 
-- https://midgard.ninerealms.com
-- https://haskoin.ninerealms.com (BTC/BCH/LTC)
-- https://thornode.ninerealms.com
+- https://midgard.mayachain.info
+- https://mayanode.mayachain.info
 
 ## Example
 

--- a/packages/xchain-midgard-query/src/midgard-query.ts
+++ b/packages/xchain-midgard-query/src/midgard-query.ts
@@ -68,7 +68,7 @@ export class MidgardQuery {
     const assetString = assetToString(asset)
 
     // Map of assets to their actual decimal places from THORChain pools
-    // Data sourced from https://thornode-v2.ninerealms.com/thorchain/pools
+    // Data sourced from https://gateway.liquify.com/chain/thorchain_api/thorchain/pools
     const fallbackDecimalMap: Record<string, number> = {
       // Bitcoin and forks
       'BTC.BTC': 8,

--- a/packages/xchain-midgard-query/src/utils/midgard.ts
+++ b/packages/xchain-midgard-query/src/utils/midgard.ts
@@ -20,7 +20,7 @@ const defaultMidgardConfig: Record<Network, MidgardConfig> = {
   },
   stagenet: {
     apiRetries: 3,
-    midgardBaseUrls: ['TBD'],
+    midgardBaseUrls: [],
   },
   testnet: {
     apiRetries: 3,

--- a/packages/xchain-midgard-query/src/utils/midgard.ts
+++ b/packages/xchain-midgard-query/src/utils/midgard.ts
@@ -16,15 +16,15 @@ import { GetActionsParams, MidgardConfig } from '../types'
 const defaultMidgardConfig: Record<Network, MidgardConfig> = {
   mainnet: {
     apiRetries: 3,
-    midgardBaseUrls: ['https://midgard.ninerealms.com'],
+    midgardBaseUrls: ['https://gateway.liquify.com/chain/thorchain_midgard'],
   },
   stagenet: {
     apiRetries: 3,
-    midgardBaseUrls: ['https://stagenet-midgard.ninerealms.com'],
+    midgardBaseUrls: ['TBD'],
   },
   testnet: {
     apiRetries: 3,
-    midgardBaseUrls: ['https://testnet.midgard.thorchain.info'],
+    midgardBaseUrls: ['deprecated'],
   },
 }
 

--- a/packages/xchain-midgard/README.md
+++ b/packages/xchain-midgard/README.md
@@ -28,9 +28,9 @@ const data = midgardApi.getPool('BTC.BTC')
 
 [`Midgard Liquify endpoint`](https://gateway.liquify.com/chain/thorchain_midgard/v2/doc)
 
-### Setting Headers for Liquify endpoints
+### Setting Headers for public endpoints
 
-If you plan on using the publically accessible endpoints provided by Liquify (listed below), ensure that you add a valid 'x-client-id' to all requests
+If you plan on using the publicly accessible endpoints listed below, ensure that you add a valid 'x-client-id' to all requests
 
 - https://gateway.liquify.com/chain/thorchain_midgard
 - https://api.haskoin.com (BTC/BCH/LTC)

--- a/packages/xchain-midgard/README.md
+++ b/packages/xchain-midgard/README.md
@@ -26,16 +26,15 @@ const data = midgardApi.getPool('BTC.BTC')
 
 ## Documentation
 
-[`Midgard Thorchain endpoint`](https://midgard.thorchain.info/v2/doc)
-[`Midgard NineRelms endpoint`](https://midgard.ninerealms.com/v2/doc)
+[`Midgard Liquify endpoint`](https://gateway.liquify.com/chain/thorchain_midgard/v2/doc)
 
-### Setting Headers for Nine Realms endpoints
+### Setting Headers for Liquify endpoints
 
-If you plan on using the publically accessible endpoints provided by Nine Realms(listed below), ensure that you add a valid 'x-client-id' to all requests
+If you plan on using the publically accessible endpoints provided by Liquify (listed below), ensure that you add a valid 'x-client-id' to all requests
 
-- https://midgard.ninerealms.com
-- https://haskoin.ninerealms.com (BTC/BCH/LTC)
-- https://thornode.ninerealms.com
+- https://gateway.liquify.com/chain/thorchain_midgard
+- https://api.haskoin.com (BTC/BCH/LTC)
+- https://gateway.liquify.com/chain/thorchain_api
 
 Example
 

--- a/packages/xchain-midgard/package.json
+++ b/packages/xchain-midgard/package.json
@@ -30,7 +30,7 @@
     "lint": "eslint --config ../../eslint.config.mjs \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "test": "jest --passWithNoTests",
     "generate:types": "yarn clean:types:midgard && yarn generate:types:midgard",
-    "generate:types:midgard": "TS_POST_PROCESS_FILE=./node_modules/.bin/prettier openapi-generator-cli generate -i https://midgard.ninerealms.com/v2/swagger.json -g typescript-axios -o ./src/generated/midgardApi --generate-alias-as-model --reserved-words-mappings in=in",
+    "generate:types:midgard": "TS_POST_PROCESS_FILE=./node_modules/.bin/prettier openapi-generator-cli generate -i https://gateway.liquify.com/chain/thorchain_midgard/v2/swagger.json -g typescript-axios -o ./src/generated/midgardApi --generate-alias-as-model --reserved-words-mappings in=in",
     "clean:types:midgard": "rimraf ./src/generated/midgardApi"
   },
   "dependencies": {

--- a/packages/xchain-midgard/src/config.ts
+++ b/packages/xchain-midgard/src/config.ts
@@ -1,4 +1,6 @@
 /**
- * The base URL for the Midgard API provided by Nine Realms.
+ * The base URL for the Midgard API endpoint.
  */
-export const MIDGARD_API_9R_URL = 'https://midgard.ninerealms.com/'
+export const MIDGARD_API_URL = 'https://gateway.liquify.com/chain/thorchain_midgard/'
+/** @deprecated Use MIDGARD_API_URL instead */
+export const MIDGARD_API_9R_URL = MIDGARD_API_URL

--- a/packages/xchain-midgard/src/config.ts
+++ b/packages/xchain-midgard/src/config.ts
@@ -2,5 +2,5 @@
  * The base URL for the Midgard API endpoint.
  */
 export const MIDGARD_API_URL = 'https://gateway.liquify.com/chain/thorchain_midgard/'
-/** @deprecated Use MIDGARD_API_URL instead */
+/** @deprecated Use MIDGARD_API_URL instead. Will be removed in next major version. */
 export const MIDGARD_API_9R_URL = MIDGARD_API_URL

--- a/packages/xchain-midgard/src/index.ts
+++ b/packages/xchain-midgard/src/index.ts
@@ -1,10 +1,10 @@
-import { MIDGARD_API_9R_URL } from './config'
+import { MIDGARD_API_URL } from './config'
 import { Configuration, DefaultApi } from './generated/midgardApi'
 
 /**
  * The base URL for the Midgard API.
  */
-const baseUrl = MIDGARD_API_9R_URL
+const baseUrl = MIDGARD_API_URL
 
 /**
  * Default configuration for the Midgard API client.

--- a/packages/xchain-thorchain-amm/README.md
+++ b/packages/xchain-thorchain-amm/README.md
@@ -105,13 +105,13 @@ You can find examples using the THORChain AMM package in the [thorchain-amm](htt
 
 More information about how to use the Thorchain AMM package can be found on [documentation](https://xchainjs.gitbook.io/xchainjs/protocols/thorchain/xchain-thorchain-amm)
 
-### Setting Headers for Nine Realms endpoints
+### Setting Headers for Liquify endpoints
 
-If you plan on using the publically accessible endpoints provided by Nine Realms(listed below), ensure that you add a valid 'x-client-id' to all requests
+If you plan on using the publically accessible endpoints provided by Liquify (listed below), ensure that you add a valid 'x-client-id' to all requests
 
-- https://midgard.ninerealms.com
-- https://haskoin.ninerealms.com (BTC/BCH/LTC)
-- https://thornode.ninerealms.com
+- https://gateway.liquify.com/chain/thorchain_midgard
+- https://api.haskoin.com (BTC/BCH/LTC)
+- https://gateway.liquify.com/chain/thorchain_api
 
 Example
 

--- a/packages/xchain-thorchain-amm/README.md
+++ b/packages/xchain-thorchain-amm/README.md
@@ -105,9 +105,9 @@ You can find examples using the THORChain AMM package in the [thorchain-amm](htt
 
 More information about how to use the Thorchain AMM package can be found on [documentation](https://xchainjs.gitbook.io/xchainjs/protocols/thorchain/xchain-thorchain-amm)
 
-### Setting Headers for Liquify endpoints
+### Setting Headers for public endpoints
 
-If you plan on using the publically accessible endpoints provided by Liquify (listed below), ensure that you add a valid 'x-client-id' to all requests
+If you plan on using the publicly accessible endpoints listed below, ensure that you add a valid 'x-client-id' to all requests
 
 - https://gateway.liquify.com/chain/thorchain_midgard
 - https://api.haskoin.com (BTC/BCH/LTC)

--- a/packages/xchain-thorchain-amm/spec.md
+++ b/packages/xchain-thorchain-amm/spec.md
@@ -26,10 +26,10 @@ Basic validation of a request before running the
 if sourceAsset <= 0
  return "source asset is 0"
 
-if source asset != RUNE && source asset not in active pool list (https://midgard.ninerealms.com/v2/pools where status = "available")
+if source asset != RUNE && source asset not in active pool list (https://gateway.liquify.com/chain/thorchain_midgard/v2/pools where status = "available")
   return "source asset not on pool list"
 
-if destinationAsset != RUNE && destinationAsset not in active pool list (https://midgard.ninerealms.com/v2/pools where status = "available")
+if destinationAsset != RUNE && destinationAsset not in active pool list (https://gateway.liquify.com/chain/thorchain_midgard/v2/pools where status = "available")
   return "destination asset not on pool list"
 
 If valueofRUNE(inbound fee + outbound fee) > valueOfRUNE(inboundAsset)
@@ -99,7 +99,7 @@ This will be the Min Outbound delay time. Could be more depending on network act
 ### Midgard Requirements
 
 1. Mimir values
-1. Outbound Queue (https://midgard.ninerealms.com/v2/thorchain/queue)
+1. Outbound Queue (https://gateway.liquify.com/chain/thorchain_midgard/v2/thorchain/queue)
 
 ### Logic
 
@@ -120,7 +120,7 @@ runeValue = runeValueOf(outputAmount)
 if runeValue < minTxOutVolumeThreshold
     Return 6 // likely next block.
 
-sumValue = runeValue + scheduled_outbound_value (https://midgard.ninerealms.com/v2/thorchain/queue)
+sumValue = runeValue + scheduled_outbound_value (https://gateway.liquify.com/chain/thorchain_midgard/v2/thorchain/queue)
 
 // reduce delay rate relative to the total scheduled value. In high volume
 // scenarios, this causes the network to send outbound transactions slower,
@@ -356,8 +356,8 @@ Removes liquidity for a user
 
 ### Midgard Requirements
 
-1. `LP Details https://midgard.ninerealms.com/v2/member/{address}`
-1. `Pool List https://midgard.ninerealms.com/v2/pools `
+1. `LP Details https://gateway.liquify.com/chain/thorchain_midgard/v2/member/{address}`
+1. `Pool List https://gateway.liquify.com/chain/thorchain_midgard/v2/pools `
 
 See if the pool is valid
 See if their wallet is a member of the pool.

--- a/packages/xchain-thorchain-amm/spec.md
+++ b/packages/xchain-thorchain-amm/spec.md
@@ -357,7 +357,7 @@ Removes liquidity for a user
 ### Midgard Requirements
 
 1. `LP Details https://gateway.liquify.com/chain/thorchain_midgard/v2/member/{address}`
-1. `Pool List https://gateway.liquify.com/chain/thorchain_midgard/v2/pools `
+1. `Pool List https://gateway.liquify.com/chain/thorchain_midgard/v2/pools`
 
 See if the pool is valid
 See if their wallet is a member of the pool.

--- a/packages/xchain-thorchain-query/README.md
+++ b/packages/xchain-thorchain-query/README.md
@@ -130,13 +130,13 @@ Estimate AddSaver() & WithdrawSaver() & getSaverPosition() https://replit.com/@t
 
 Check transaction Stage
 
-### Setting Headers for Nine Realms endpoints
+### Setting Headers for Liquify endpoints
 
-If you plan on using the publically accessible endpoints provided by Nine Realms(listed below), ensure that you add a valid 'x-client-id' to all requests
+If you plan on using the publically accessible endpoints provided by Liquify (listed below), ensure that you add a valid 'x-client-id' to all requests
 
-- https://midgard.ninerealms.com
-- https://haskoin.ninerealms.com (BTC/BCH/LTC)
-- https://thornode.ninerealms.com
+- https://gateway.liquify.com/chain/thorchain_midgard
+- https://api.haskoin.com (BTC/BCH/LTC)
+- https://gateway.liquify.com/chain/thorchain_api
 
 ## Example
 

--- a/packages/xchain-thorchain-query/README.md
+++ b/packages/xchain-thorchain-query/README.md
@@ -130,9 +130,9 @@ Estimate AddSaver() & WithdrawSaver() & getSaverPosition() https://replit.com/@t
 
 Check transaction Stage
 
-### Setting Headers for Liquify endpoints
+### Setting Headers for public endpoints
 
-If you plan on using the publically accessible endpoints provided by Liquify (listed below), ensure that you add a valid 'x-client-id' to all requests
+If you plan on using the publicly accessible endpoints listed below, ensure that you add a valid 'x-client-id' to all requests
 
 - https://gateway.liquify.com/chain/thorchain_midgard
 - https://api.haskoin.com (BTC/BCH/LTC)

--- a/packages/xchain-thorchain-query/src/utils/thornode.ts
+++ b/packages/xchain-thorchain-query/src/utils/thornode.ts
@@ -51,7 +51,7 @@ const defaultThornodeConfig: Record<Network, ThornodeConfig> = {
   },
   stagenet: {
     apiRetries: 3,
-    thornodeBaseUrls: ['TBD'],
+    thornodeBaseUrls: [],
   },
   testnet: {
     apiRetries: 3,

--- a/packages/xchain-thorchain-query/src/utils/thornode.ts
+++ b/packages/xchain-thorchain-query/src/utils/thornode.ts
@@ -39,7 +39,6 @@ import { Address } from '@xchainjs/xchain-util'
 import axios from 'axios'
 import axiosRetry from 'axios-retry'
 
-
 export type ThornodeConfig = {
   apiRetries: number
   thornodeBaseUrls: string[]
@@ -48,15 +47,15 @@ export type ThornodeConfig = {
 const defaultThornodeConfig: Record<Network, ThornodeConfig> = {
   mainnet: {
     apiRetries: 3,
-    thornodeBaseUrls: [`https://thornode.ninerealms.com`],
+    thornodeBaseUrls: [`https://gateway.liquify.com/chain/thorchain_api`],
   },
   stagenet: {
     apiRetries: 3,
-    thornodeBaseUrls: ['https://stagenet-thornode.ninerealms.com'],
+    thornodeBaseUrls: ['TBD'],
   },
   testnet: {
     apiRetries: 3,
-    thornodeBaseUrls: ['https://testnet.thornode.thorchain.info'],
+    thornodeBaseUrls: ['deprecated'],
   },
 }
 

--- a/packages/xchain-thorchain/README.md
+++ b/packages/xchain-thorchain/README.md
@@ -63,9 +63,9 @@ In order for this library to de/serialize proto3 structures, you can use the fol
 
 Alternatively, you can run the convenience script: `genMsgs.sh`, which will overwrite the proto/js files in types/proto. This should only be done and checked in if changes were made to the upstream Msg in the THORNode repo.
 
-### Setting Headers for Liquify endpoints
+### Setting Headers for public endpoints
 
-If you plan on using the publically accessible endpoints provided by Liquify (listed below), ensure that you add a valid 'x-client-id' to all requests
+If you plan on using the publicly accessible endpoints listed below, ensure that you add a valid 'x-client-id' to all requests
 
 - https://gateway.liquify.com/chain/thorchain_midgard
 - https://api.haskoin.com (BTC/BCH/LTC)

--- a/packages/xchain-thorchain/README.md
+++ b/packages/xchain-thorchain/README.md
@@ -63,13 +63,13 @@ In order for this library to de/serialize proto3 structures, you can use the fol
 
 Alternatively, you can run the convenience script: `genMsgs.sh`, which will overwrite the proto/js files in types/proto. This should only be done and checked in if changes were made to the upstream Msg in the THORNode repo.
 
-### Setting Headers for Nine Realms endpoints
+### Setting Headers for Liquify endpoints
 
-If you plan on using the publically accessible endpoints provided by Nine Realms(listed below), ensure that you add a valid 'x-client-id' to all requests
+If you plan on using the publically accessible endpoints provided by Liquify (listed below), ensure that you add a valid 'x-client-id' to all requests
 
-- https://midgard.ninerealms.com
-- https://haskoin.ninerealms.com (BTC/BCH/LTC)
-- https://thornode.ninerealms.com
+- https://gateway.liquify.com/chain/thorchain_midgard
+- https://api.haskoin.com (BTC/BCH/LTC)
+- https://gateway.liquify.com/chain/thorchain_api
 
 Example
 

--- a/packages/xchain-thorchain/src/utils.ts
+++ b/packages/xchain-thorchain/src/utils.ts
@@ -23,8 +23,8 @@ import { CompatibleAsset } from './types'
 export const getDefaultClientUrls = (): Record<Network, string[]> => {
   return {
     [Network.Testnet]: ['deprecated'],
-    [Network.Stagenet]: ['https://stagenet-rpc.ninerealms.com'],
-    [Network.Mainnet]: ['https://rpc.ninerealms.com'],
+    [Network.Stagenet]: ['TBD'],
+    [Network.Mainnet]: ['https://gateway.liquify.com/chain/thorchain_rpc'],
   }
 }
 /**

--- a/packages/xchain-thorchain/src/utils.ts
+++ b/packages/xchain-thorchain/src/utils.ts
@@ -23,7 +23,7 @@ import { CompatibleAsset } from './types'
 export const getDefaultClientUrls = (): Record<Network, string[]> => {
   return {
     [Network.Testnet]: ['deprecated'],
-    [Network.Stagenet]: ['TBD'],
+    [Network.Stagenet]: [],
     [Network.Mainnet]: ['https://gateway.liquify.com/chain/thorchain_rpc'],
   }
 }

--- a/packages/xchain-thornode/README.md
+++ b/packages/xchain-thornode/README.md
@@ -51,9 +51,9 @@ Request data from MimirApi
 
 [`Thornode Liquify endpoint`](https://gateway.liquify.com/chain/thorchain_api/)
 
-### Setting Headers for Liquify endpoints
+### Setting Headers for public endpoints
 
-If you plan on using the publically accessible endpoints provided by Liquify (listed below), ensure that you add a valid 'x-client-id' to all requests
+If you plan on using the publicly accessible endpoints listed below, ensure that you add a valid 'x-client-id' to all requests
 
 - https://gateway.liquify.com/chain/thorchain_midgard
 - https://api.haskoin.com (BTC/BCH/LTC)

--- a/packages/xchain-thornode/README.md
+++ b/packages/xchain-thornode/README.md
@@ -5,7 +5,7 @@ Thornode Module for XChainJS Clients
 ## Modules
 
 Thornode module has been created using openapi-generator-cli to auto-generate rest api reading from "https://gitlab.com/thorchain/thornode/-/raw/release-{version}/openapi/openapi.yaml"
-This library exposes all the Api's outlined in the swagger doc "https://thornode.ninerealms.com/thorchain/doc"
+This library exposes all the Api's outlined in the swagger doc "https://gateway.liquify.com/chain/thorchain_api/thorchain/doc"
 
 ## Installation
 
@@ -18,10 +18,10 @@ yarn add @xchainjs/xchain-thornode
 Request data from MimirApi
 
 ```
-// THORNODE_API_9R_URL - default exported URL
-// import { MimirApi, THORNODE_API_9R_URL, Configuration } from '@xchainjs/xchain-thornode'
+// THORNODE_API_URL - default exported URL
+// import { MimirApi, THORNODE_API_URL, Configuration } from '@xchainjs/xchain-thornode'
 
-  const baseUrl = THORNODE_API_9R_URL
+  const baseUrl = THORNODE_API_URL
   const apiconfig = new Configuration({ basePath: baseUrl })
   const mimirApi = new MimirApi(apiconfig)
   const mimirResponse = await mimirApi.mimir()
@@ -34,10 +34,10 @@ Request data from MimirApi
 Request data from MimirApi
 
 ```
-// THORNODE_API_9R_URL - default exported URL
-// import { MimirApi, THORNODE_API_9R_URL, Configuration } from '@xchainjs/xchain-thornode'
+// THORNODE_API_URL - default exported URL
+// import { MimirApi, THORNODE_API_URL, Configuration } from '@xchainjs/xchain-thornode'
 
-  const baseUrl = THORNODE_API_9R_URL
+  const baseUrl = THORNODE_API_URL
   const headers = {"x-client-id": "my-custom-val"}
   const baseOptions = { headers }
   const apiconfig = new Configuration({ basePath: baseUrl , baseOptions })
@@ -49,15 +49,15 @@ Request data from MimirApi
 
 ## Documentation
 
-[`Thornode NineRelms endpoint`](https://thornode.ninerealms.com/)
+[`Thornode Liquify endpoint`](https://gateway.liquify.com/chain/thorchain_api/)
 
-### Setting Headers for Nine Realms endpoints
+### Setting Headers for Liquify endpoints
 
-If you plan on using the publically accessible endpoints provided by Nine Realms(listed below), ensure that you add a valid 'x-client-id' to all requests
+If you plan on using the publically accessible endpoints provided by Liquify (listed below), ensure that you add a valid 'x-client-id' to all requests
 
-- https://midgard.ninerealms.com
-- https://haskoin.ninerealms.com (BTC/BCH/LTC)
-- https://thornode.ninerealms.com
+- https://gateway.liquify.com/chain/thorchain_midgard
+- https://api.haskoin.com (BTC/BCH/LTC)
+- https://gateway.liquify.com/chain/thorchain_api
 
 Example
 

--- a/packages/xchain-thornode/package.json
+++ b/packages/xchain-thornode/package.json
@@ -30,7 +30,7 @@
     "lint": "eslint --config ../../eslint.config.mjs \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0",
     "test": "jest --passWithNoTests",
     "generate:types": "yarn clean:types:thornode && yarn generate:types:thornode",
-    "generate:types:thornode": "TS_POST_PROCESS_FILE=./node_modules/.bin/prettier openapi-generator-cli generate -i https://thornode.ninerealms.com/thorchain/doc/openapi.yaml -g typescript-axios -o ./src/generated/thornodeApi --skip-validate-spec --generate-alias-as-model",
+    "generate:types:thornode": "TS_POST_PROCESS_FILE=./node_modules/.bin/prettier openapi-generator-cli generate -i https://gateway.liquify.com/chain/thorchain_api/thorchain/doc/openapi.yaml -g typescript-axios -o ./src/generated/thornodeApi --skip-validate-spec --generate-alias-as-model",
     "clean:types:thornode": "rimraf ./src/generated/thornodeApi"
   },
   "dependencies": {

--- a/packages/xchain-thornode/src/config.ts
+++ b/packages/xchain-thornode/src/config.ts
@@ -2,5 +2,5 @@
  * The base URL for the THORNode API endpoint.
  */
 export const THORNODE_API_URL = 'https://gateway.liquify.com/chain/thorchain_api/'
-/** @deprecated Use THORNODE_API_URL instead */
+/** @deprecated Use THORNODE_API_URL instead. Will be removed in next major version. */
 export const THORNODE_API_9R_URL = THORNODE_API_URL

--- a/packages/xchain-thornode/src/config.ts
+++ b/packages/xchain-thornode/src/config.ts
@@ -1,4 +1,6 @@
 /**
  * The base URL for the THORNode API endpoint.
  */
-export const THORNODE_API_9R_URL = 'https://thornode.ninerealms.com/'
+export const THORNODE_API_URL = 'https://gateway.liquify.com/chain/thorchain_api/'
+/** @deprecated Use THORNODE_API_URL instead */
+export const THORNODE_API_9R_URL = THORNODE_API_URL

--- a/packages/xchain-util/src/ninerealms.ts
+++ b/packages/xchain-util/src/ninerealms.ts
@@ -13,7 +13,7 @@ export const add9Rheader = <T extends { url?: string; headers?: Record<string, s
     // [TypeError: Invalid URL] input: 'unknown-url', code: 'ERR_INVALID_URL' }
     const url = new URL(request?.url ?? 'unknown-url')
     const headerAlreadyExists = request.headers && 'x-client-id' in request.headers
-    if (url.host.includes('ninerealms') && !headerAlreadyExists) {
+    if ((url.host.includes('ninerealms') || url.host.includes('liquify.com')) && !headerAlreadyExists) {
       const headers = request?.headers ?? {}
       // Add custom header to request before returning it
       const newRequest = {

--- a/tools/xchain-suite/src/components/swap/SwapTrackingModal.tsx
+++ b/tools/xchain-suite/src/components/swap/SwapTrackingModal.tsx
@@ -250,7 +250,7 @@ export function SwapTrackingModal({
   const trackerUrl = protocol === 'Chainflip'
     ? `https://scan.chainflip.io/channels/${depositChannelId || ''}`
     : protocol === 'Thorchain'
-    ? `https://track.ninerealms.com/${txHash}`
+    ? `https://track.thorchain.org/${txHash}`
     : `https://www.mayascan.org/tx/${txHash}`
 
   // THORChain/MAYAChain: find current active stage

--- a/tools/xchain-suite/src/components/thornode/NodeDetails.tsx
+++ b/tools/xchain-suite/src/components/thornode/NodeDetails.tsx
@@ -66,10 +66,10 @@ export function NodeDetails({ nodesApi }: NodeDetailsProps) {
     }, { operation: 'node', params: { nodeAddress } })
   }
 
-  const codeExample = `import { NodesApi, Configuration, THORNODE_API_9R_URL } from '@xchainjs/xchain-thornode'
+  const codeExample = `import { NodesApi, Configuration, THORNODE_API_URL } from '@xchainjs/xchain-thornode'
 
 // Initialize API
-const config = new Configuration({ basePath: THORNODE_API_9R_URL })
+const config = new Configuration({ basePath: THORNODE_API_URL })
 const nodesApi = new NodesApi(config)
 
 // Fetch specific node by address

--- a/tools/xchain-suite/src/components/thornode/NodeList.tsx
+++ b/tools/xchain-suite/src/components/thornode/NodeList.tsx
@@ -46,10 +46,10 @@ export function NodeList({ nodesApi }: NodeListProps) {
     }, { operation: 'nodes', params: { statusFilter } })
   }
 
-  const codeExample = `import { NodesApi, Configuration, THORNODE_API_9R_URL } from '@xchainjs/xchain-thornode'
+  const codeExample = `import { NodesApi, Configuration, THORNODE_API_URL } from '@xchainjs/xchain-thornode'
 
 // Initialize API
-const config = new Configuration({ basePath: THORNODE_API_9R_URL })
+const config = new Configuration({ basePath: THORNODE_API_URL })
 const nodesApi = new NodesApi(config)
 
 // Fetch all nodes

--- a/tools/xchain-suite/src/hooks/useTHORNode.ts
+++ b/tools/xchain-suite/src/hooks/useTHORNode.ts
@@ -41,7 +41,7 @@ export function useTHORNode(): THORNodeConfig {
         // Use appropriate endpoint based on network (testnet is not supported)
         let baseUrl = THORNODE_API_URL
         if (network === Network.Stagenet) {
-          baseUrl = 'TBD'
+          baseUrl = ''
         }
 
         const config = new Configuration({ basePath: baseUrl })

--- a/tools/xchain-suite/src/hooks/useTHORNode.ts
+++ b/tools/xchain-suite/src/hooks/useTHORNode.ts
@@ -34,16 +34,14 @@ export function useTHORNode(): THORNodeConfig {
 
       try {
         // Dynamically import thornode to avoid SSR issues
-        const { NodesApi, NetworkApi, MimirApi, Configuration, THORNODE_API_9R_URL } = await import(
+        const { NodesApi, NetworkApi, MimirApi, Configuration, THORNODE_API_URL } = await import(
           '@xchainjs/xchain-thornode'
         )
 
-        // Use appropriate endpoint based on network
-        let baseUrl = THORNODE_API_9R_URL
+        // Use appropriate endpoint based on network (testnet is not supported)
+        let baseUrl = THORNODE_API_URL
         if (network === Network.Stagenet) {
-          baseUrl = 'https://stagenet-thornode.ninerealms.com/'
-        } else if (network === Network.Testnet) {
-          baseUrl = 'https://testnet-thornode.ninerealms.com/'
+          baseUrl = 'TBD'
         }
 
         const config = new Configuration({ basePath: baseUrl })

--- a/tools/xchain-suite/src/lib/pricing/PriceService.ts
+++ b/tools/xchain-suite/src/lib/pricing/PriceService.ts
@@ -16,7 +16,7 @@ export interface PriceData {
 // Midgard endpoints
 const MIDGARD_URLS: Record<Network, string> = {
   [Network.Mainnet]: 'https://gateway.liquify.com/chain/thorchain_midgard/v2',
-  [Network.Stagenet]: 'TBD',
+  [Network.Stagenet]: '',
   [Network.Testnet]: 'deprecated',
 }
 

--- a/tools/xchain-suite/src/lib/pricing/PriceService.ts
+++ b/tools/xchain-suite/src/lib/pricing/PriceService.ts
@@ -15,9 +15,9 @@ export interface PriceData {
 
 // Midgard endpoints
 const MIDGARD_URLS: Record<Network, string> = {
-  [Network.Mainnet]: 'https://midgard.ninerealms.com/v2',
-  [Network.Stagenet]: 'https://stagenet-midgard.ninerealms.com/v2',
-  [Network.Testnet]: 'https://testnet.midgard.thorchain.info/v2',
+  [Network.Mainnet]: 'https://gateway.liquify.com/chain/thorchain_midgard/v2',
+  [Network.Stagenet]: 'TBD',
+  [Network.Testnet]: 'deprecated',
 }
 
 const MAYA_MIDGARD_URLS: Record<Network, string> = {
@@ -74,9 +74,7 @@ async function fetchThorchainPrices(network: Network): Promise<Map<string, numbe
     const usdcPrice = prices.get('AVAX.USDC') ?? prices.get('ETH.USDC')
     if (usdcPrice) {
       // Find a stablecoin pool to get RUNE price
-      const stablecoinPool = pools.find(p =>
-        p.asset.includes('USDC') || p.asset.includes('USDT')
-      )
+      const stablecoinPool = pools.find((p) => p.asset.includes('USDC') || p.asset.includes('USDT'))
       if (stablecoinPool) {
         // assetPrice is in RUNE terms, so RUNE price = 1 / assetPrice * assetPriceUSD
         // But actually, assetPriceUSD already accounts for this, so we can derive:
@@ -256,10 +254,7 @@ export class PriceService {
   async refreshPrices(): Promise<void> {
     thorchainCache = null
     mayachainCache = null
-    await Promise.all([
-      fetchThorchainPrices(this.network),
-      fetchMayachainPrices(this.network),
-    ])
+    await Promise.all([fetchThorchainPrices(this.network), fetchMayachainPrices(this.network)])
   }
 }
 

--- a/tools/xchain-suite/src/lib/swap/TransactionTracker.ts
+++ b/tools/xchain-suite/src/lib/swap/TransactionTracker.ts
@@ -51,7 +51,7 @@ async function getThornodeApi() {
   if (!thornodeApiPromise) {
     thornodeApiPromise = (async () => {
       const { TransactionsApi, Configuration } = await import('@xchainjs/xchain-thornode')
-      const config = new Configuration({ basePath: 'https://thornode.ninerealms.com' })
+      const config = new Configuration({ basePath: 'https://gateway.liquify.com/chain/thorchain_api' })
       return new TransactionsApi(config)
     })()
   }
@@ -77,11 +77,7 @@ export class TransactionTracker {
   /**
    * Start tracking a transaction
    */
-  async track(
-    hash: string,
-    protocol: 'Thorchain' | 'Mayachain',
-    onUpdate: StatusListener
-  ): Promise<void> {
+  async track(hash: string, protocol: 'Thorchain' | 'Mayachain', onUpdate: StatusListener): Promise<void> {
     const key = `${protocol}:${hash}`
 
     // Initialize status
@@ -142,9 +138,7 @@ export class TransactionTracker {
 
     const poll = async () => {
       try {
-        const api = protocol === 'Thorchain'
-          ? await getThornodeApi()
-          : await getMayanodeApi()
+        const api = protocol === 'Thorchain' ? await getThornodeApi() : await getMayanodeApi()
 
         // Normalize hash for API (remove 0x prefix, uppercase)
         const normalizedHash = normalizeHash(hash)
@@ -193,7 +187,7 @@ export class TransactionTracker {
 
         // Notify listeners
         const listeners = this.listeners.get(key) || []
-        listeners.forEach(listener => listener(newStatus))
+        listeners.forEach((listener) => listener(newStatus))
 
         // Stop polling if complete
         if (newStatus.isComplete) {
@@ -212,7 +206,7 @@ export class TransactionTracker {
           this.statuses.set(key, errorStatus)
 
           const listeners = this.listeners.get(key) || []
-          listeners.forEach(listener => listener(errorStatus))
+          listeners.forEach((listener) => listener(errorStatus))
         }
       }
     }

--- a/tools/xchain-suite/src/lib/trading/MidgardOHLCVService.ts
+++ b/tools/xchain-suite/src/lib/trading/MidgardOHLCVService.ts
@@ -1,6 +1,6 @@
 import { OHLCVCandle, TickerStats, TimeInterval, MIDGARD_INTERVALS } from './chartUtils'
 
-const THORCHAIN_MIDGARD = 'https://midgard.ninerealms.com/v2'
+const THORCHAIN_MIDGARD = 'https://gateway.liquify.com/chain/thorchain_midgard/v2'
 const MAYA_MIDGARD = 'https://midgard.mayachain.info/v2'
 
 interface DepthHistoryItem {
@@ -41,11 +41,7 @@ function isNativeAsset(pool: string): boolean {
   return pool in NATIVE_POOL_PROXY
 }
 
-export async function fetchDepthHistory(
-  pool: string,
-  interval: TimeInterval,
-  count = 500
-): Promise<OHLCVCandle[]> {
+export async function fetchDepthHistory(pool: string, interval: TimeInterval, count = 500): Promise<OHLCVCandle[]> {
   const midgardUrl = getMidgardUrl(pool)
   const midgardInterval = MIDGARD_INTERVALS[interval]
   const poolId = getPoolId(pool)

--- a/tools/xchain-suite/src/pages/PoolsPage.tsx
+++ b/tools/xchain-suite/src/pages/PoolsPage.tsx
@@ -51,13 +51,13 @@ interface ChainflipBoost {
 
 // THORNode/MAYANode endpoints for pool status
 const NODE_ENDPOINTS = {
-  thorchain: 'https://thornode.ninerealms.com/thorchain/pools',
+  thorchain: 'https://gateway.liquify.com/chain/thorchain_api/thorchain/pools',
   mayachain: 'https://mayanode.mayachain.info/mayachain/pools',
 }
 
 // Midgard endpoints for price/volume data
 const MIDGARD_ENDPOINTS = {
-  thorchain: 'https://midgard.ninerealms.com/v2/pools',
+  thorchain: 'https://gateway.liquify.com/chain/thorchain_midgard/v2/pools',
   mayachain: 'https://midgard.mayachain.info/v2/pools',
 }
 

--- a/tools/xchain-suite/src/pages/THORNamePage.tsx
+++ b/tools/xchain-suite/src/pages/THORNamePage.tsx
@@ -93,7 +93,7 @@ export default function THORNamePage() {
         // Fetch THORName details and current block height in parallel
         const [details, lastBlock] = await Promise.all([
           thorchainQuery.getThornameDetails(thorName),
-          fetch('https://thornode.ninerealms.com/thorchain/lastblock').then((r) => r.json()),
+          fetch('https://gateway.liquify.com/chain/thorchain_api/thorchain/lastblock').then((r) => r.json()),
         ])
 
         if (!details || !details.name) {


### PR DESCRIPTION
Nine Realms infrastructure (*.ninerealms.com) is being retired. This
migrates all hardcoded endpoints across the monorepo to the new Liquify
gateway and updated providers.

Changes:
- Mainnet thornode/midgard/rpc → gateway.liquify.com/chain/thorchain_*
- Haskoin → api.haskoin.com
- Tracker → track.thorchain.org
- Stagenet URLs set to 'TBD' (no Liquify stagenet yet)
- Testnet entries set to 'deprecated' (no THORChain testnet)
- New THORNODE_API_URL and MIDGARD_API_URL exports with deprecated
  aliases for THORNODE_API_9R_URL and MIDGARD_API_9R_URL (non-breaking)
- x-client-id header utility expanded to match liquify.com
- OpenAPI generator scripts updated to Liquify spec URLs
- All documentation updated

Excludes LTC node URL removal (see PR #1667).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated READMEs and docs to reference new public gateway endpoints, renamed “Nine Realms” guidance to “public endpoints”, clarified x-client-id header usage, and marked some testnet entries as deprecated/migration pending.
* **Chores**
  * Migrated mainnet endpoints to Liquify gateway URLs, added new exported endpoint constants with deprecation notes for legacy names, and cleared/flagged Stagenet defaults as TBD.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->