### PR TITLE
fix: resolve high/critical audit vulnerabilities

### DIFF
--- a/.changeset/fix-audit-vulnerabilities.md
+++ b/.changeset/fix-audit-vulnerabilities.md
@@ -1,0 +1,28 @@
+---
+'@xchainjs/xchain-aggregator': patch
+'@xchainjs/xchain-bitcoin': patch
+'@xchainjs/xchain-bitcoincash': patch
+'@xchainjs/xchain-client': patch
+'@xchainjs/xchain-cosmos': patch
+'@xchainjs/xchain-dash': patch
+'@xchainjs/xchain-doge': patch
+'@xchainjs/xchain-evm-providers': patch
+'@xchainjs/xchain-evm': patch
+'@xchainjs/xchain-litecoin': patch
+'@xchainjs/xchain-mayachain-amm': patch
+'@xchainjs/xchain-mayachain-query': patch
+'@xchainjs/xchain-mayachain': patch
+'@xchainjs/xchain-mayamidgard-query': patch
+'@xchainjs/xchain-mayamidgard': patch
+'@xchainjs/xchain-mayanode': patch
+'@xchainjs/xchain-midgard-query': patch
+'@xchainjs/xchain-midgard': patch
+'@xchainjs/xchain-thorchain-amm': patch
+'@xchainjs/xchain-thorchain-query': patch
+'@xchainjs/xchain-thorchain': patch
+'@xchainjs/xchain-thornode': patch
+'@xchainjs/xchain-utxo-providers': patch
+'@xchainjs/zcash-js': patch
+---
+
+Update axios 1.13.5 → 1.15.0 to fix critical SSRF and header injection vulnerabilities. Update lodash to ^4.18.0 in zcash-js to fix code injection via _.template.

--- a/.changeset/fix-audit-vulnerabilities.md
+++ b/.changeset/fix-audit-vulnerabilities.md
@@ -22,7 +22,14 @@
 '@xchainjs/xchain-thorchain': patch
 '@xchainjs/xchain-thornode': patch
 '@xchainjs/xchain-utxo-providers': patch
+'@xchainjs/xchain-wallet': patch
+'@xchainjs/xchain-arbitrum': patch
+'@xchainjs/xchain-avax': patch
+'@xchainjs/xchain-base': patch
+'@xchainjs/xchain-bsc': patch
+'@xchainjs/xchain-ethereum': patch
+'@xchainjs/xchain-util': patch
 '@xchainjs/zcash-js': patch
 ---
 
-Update axios 1.13.5 → 1.15.0 to fix critical SSRF and header injection vulnerabilities. Update lodash to ^4.18.0 in zcash-js to fix code injection via _.template.
+Update axios 1.13.5 → 1.15.0 to fix critical SSRF and header injection vulnerabilities. Update lodash to ^4.18.0 in zcash-js to fix code injection via _.template. Update bignumber.js ^10.0.1 → ^11.0.0.

--- a/packages/xchain-aggregator/package.json
+++ b/packages/xchain-aggregator/package.json
@@ -47,7 +47,7 @@
     "@xchainjs/xchain-bsc": "workspace:*",
     "@xchainjs/xchain-ethereum": "workspace:*",
     "@xchainjs/xchain-kujira": "workspace:*",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "axios-mock-adapter": "^2.1.0"
   }
 }

--- a/packages/xchain-arbitrum/package.json
+++ b/packages/xchain-arbitrum/package.json
@@ -41,7 +41,7 @@
     "@xchainjs/xchain-evm": "workspace:*",
     "@xchainjs/xchain-evm-providers": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "bignumber.js": "^10.0.1",
+    "bignumber.js": "^11.0.0",
     "ethers": "^6.14.3"
   }
 }

--- a/packages/xchain-avax/package.json
+++ b/packages/xchain-avax/package.json
@@ -41,7 +41,7 @@
     "@xchainjs/xchain-evm": "workspace:*",
     "@xchainjs/xchain-evm-providers": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "bignumber.js": "^10.0.1",
+    "bignumber.js": "^11.0.0",
     "ethers": "^6.14.3"
   },
   "devDependencies": {

--- a/packages/xchain-base/package.json
+++ b/packages/xchain-base/package.json
@@ -40,7 +40,7 @@
     "@xchainjs/xchain-evm": "workspace:*",
     "@xchainjs/xchain-evm-providers": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "bignumber.js": "^10.0.1",
+    "bignumber.js": "^11.0.0",
     "ethers": "^6.14.3"
   },
   "devDependencies": {

--- a/packages/xchain-bitcoin/package.json
+++ b/packages/xchain-bitcoin/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "axios-mock-adapter": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/xchain-bitcoincash/package.json
+++ b/packages/xchain-bitcoincash/package.json
@@ -50,7 +50,7 @@
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
     "@types/bitcore-lib-cash": "^8.23.8",
     "@types/cashaddrjs": "^0",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "axios-mock-adapter": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/xchain-bsc/package.json
+++ b/packages/xchain-bsc/package.json
@@ -41,7 +41,7 @@
     "@xchainjs/xchain-evm": "workspace:*",
     "@xchainjs/xchain-evm-providers": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "bignumber.js": "^10.0.1",
+    "bignumber.js": "^11.0.0",
     "ethers": "^6.14.3"
   }
 }

--- a/packages/xchain-client/package.json
+++ b/packages/xchain-client/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@xchainjs/xchain-crypto": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.13.5"
+    "axios": "1.15.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/xchain-cosmos/package.json
+++ b/packages/xchain-cosmos/package.json
@@ -47,7 +47,7 @@
     "@xchainjs/xchain-crypto": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
     "axios": "1.15.0",
-    "bignumber.js": "^10.0.1",
+    "bignumber.js": "^11.0.0",
     "cosmjs-types": "0.9.0",
     "protobufjs": "6.11.4"
   },

--- a/packages/xchain-cosmos/package.json
+++ b/packages/xchain-cosmos/package.json
@@ -46,7 +46,7 @@
     "@xchainjs/xchain-cosmos-sdk": "workspace:*",
     "@xchainjs/xchain-crypto": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "bignumber.js": "^10.0.1",
     "cosmjs-types": "0.9.0",
     "protobufjs": "6.11.4"

--- a/packages/xchain-dash/package.json
+++ b/packages/xchain-dash/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "axios-mock-adapter": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/xchain-doge/package.json
+++ b/packages/xchain-doge/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "axios-mock-adapter": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/xchain-ethereum/package.json
+++ b/packages/xchain-ethereum/package.json
@@ -41,7 +41,7 @@
     "@xchainjs/xchain-evm": "workspace:*",
     "@xchainjs/xchain-evm-providers": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "bignumber.js": "^10.0.1",
+    "bignumber.js": "^11.0.0",
     "ethers": "^6.14.3"
   }
 }

--- a/packages/xchain-evm-providers/package.json
+++ b/packages/xchain-evm-providers/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@xchainjs/xchain-client": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "ethers": "^6.14.3"
   }
 }

--- a/packages/xchain-evm/package.json
+++ b/packages/xchain-evm/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@ledgerhq/hw-transport": "^6.31.6",
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "axios-mock-adapter": "^2.1.0"
   }
 }

--- a/packages/xchain-evm/package.json
+++ b/packages/xchain-evm/package.json
@@ -41,7 +41,7 @@
     "@xchainjs/xchain-crypto": "workspace:*",
     "@xchainjs/xchain-evm-providers": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "bignumber.js": "^10.0.1",
+    "bignumber.js": "^11.0.0",
     "ethers": "^6.14.3"
   },
   "devDependencies": {

--- a/packages/xchain-litecoin/package.json
+++ b/packages/xchain-litecoin/package.json
@@ -41,7 +41,7 @@
     "@xchainjs/xchain-util": "workspace:*",
     "@xchainjs/xchain-utxo": "workspace:*",
     "@xchainjs/xchain-utxo-providers": "workspace:*",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "bitcoinjs-lib": "^6.1.7",
     "coinselect": "3.1.12",
     "ecpair": "2.1.0"

--- a/packages/xchain-mayachain-amm/package.json
+++ b/packages/xchain-mayachain-amm/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "axios-mock-adapter": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/xchain-mayachain-query/package.json
+++ b/packages/xchain-mayachain-query/package.json
@@ -40,7 +40,7 @@
     "@xchainjs/xchain-util": "workspace:*",
     "axios": "1.15.0",
     "axios-retry": "3.2.5",
-    "bignumber.js": "^10.0.1"
+    "bignumber.js": "^11.0.0"
   },
   "devDependencies": {
     "axios-mock-adapter": "2.1.0"

--- a/packages/xchain-mayachain-query/package.json
+++ b/packages/xchain-mayachain-query/package.json
@@ -38,7 +38,7 @@
     "@xchainjs/xchain-mayamidgard-query": "workspace:*",
     "@xchainjs/xchain-mayanode": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "axios-retry": "3.2.5",
     "bignumber.js": "^10.0.1"
   },

--- a/packages/xchain-mayachain/package.json
+++ b/packages/xchain-mayachain/package.json
@@ -47,7 +47,7 @@
     "@xchainjs/xchain-cosmos-sdk": "workspace:*",
     "@xchainjs/xchain-crypto": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "bignumber.js": "^10.0.1",
     "cosmjs-types": "0.9.0",
     "protobufjs": "6.11.4"

--- a/packages/xchain-mayachain/package.json
+++ b/packages/xchain-mayachain/package.json
@@ -48,7 +48,7 @@
     "@xchainjs/xchain-crypto": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
     "axios": "1.15.0",
-    "bignumber.js": "^10.0.1",
+    "bignumber.js": "^11.0.0",
     "cosmjs-types": "0.9.0",
     "protobufjs": "6.11.4"
   },

--- a/packages/xchain-mayamidgard-query/package.json
+++ b/packages/xchain-mayamidgard-query/package.json
@@ -35,7 +35,7 @@
     "@xchainjs/xchain-client": "workspace:*",
     "@xchainjs/xchain-mayamidgard": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "axios-retry": "^3.9.1"
   },
   "devDependencies": {

--- a/packages/xchain-mayamidgard/package.json
+++ b/packages/xchain-mayamidgard/package.json
@@ -34,7 +34,7 @@
     "clean:types:midgard": "rimraf ./src/generated/midgardApi"
   },
   "dependencies": {
-    "axios": "1.13.5"
+    "axios": "1.15.0"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.20.2",

--- a/packages/xchain-mayanode/package.json
+++ b/packages/xchain-mayanode/package.json
@@ -34,7 +34,7 @@
     "clean:types:mayanode": "rimraf ./src/generated/mayanodeApi"
   },
   "dependencies": {
-    "axios": "1.13.5"
+    "axios": "1.15.0"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.20.2",

--- a/packages/xchain-midgard-query/package.json
+++ b/packages/xchain-midgard-query/package.json
@@ -35,7 +35,7 @@
     "@xchainjs/xchain-client": "workspace:*",
     "@xchainjs/xchain-midgard": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "axios-retry": "^3.9.1"
   },
   "devDependencies": {

--- a/packages/xchain-midgard/package.json
+++ b/packages/xchain-midgard/package.json
@@ -34,7 +34,7 @@
     "clean:types:midgard": "rimraf ./src/generated/midgardApi"
   },
   "dependencies": {
-    "axios": "1.13.5"
+    "axios": "1.15.0"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.20.2",

--- a/packages/xchain-thorchain-amm/package.json
+++ b/packages/xchain-thorchain-amm/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "axios-mock-adapter": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/xchain-thorchain-query/package.json
+++ b/packages/xchain-thorchain-query/package.json
@@ -37,7 +37,7 @@
     "@xchainjs/xchain-midgard-query": "workspace:*",
     "@xchainjs/xchain-thornode": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "axios-retry": "3.2.5",
     "bignumber.js": "^10.0.1"
   },

--- a/packages/xchain-thorchain-query/package.json
+++ b/packages/xchain-thorchain-query/package.json
@@ -39,7 +39,7 @@
     "@xchainjs/xchain-util": "workspace:*",
     "axios": "1.15.0",
     "axios-retry": "3.2.5",
-    "bignumber.js": "^10.0.1"
+    "bignumber.js": "^11.0.0"
   },
   "devDependencies": {
     "axios-mock-adapter": "2.1.0"

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -49,7 +49,7 @@
     "@xchainjs/xchain-cosmos-sdk": "workspace:*",
     "@xchainjs/xchain-crypto": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "bignumber.js": "^10.0.1",
     "cosmjs-types": "0.9.0",
     "protobufjs": "6.11.4"

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -50,7 +50,7 @@
     "@xchainjs/xchain-crypto": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
     "axios": "1.15.0",
-    "bignumber.js": "^10.0.1",
+    "bignumber.js": "^11.0.0",
     "cosmjs-types": "0.9.0",
     "protobufjs": "6.11.4"
   },

--- a/packages/xchain-thornode/package.json
+++ b/packages/xchain-thornode/package.json
@@ -34,7 +34,7 @@
     "clean:types:thornode": "rimraf ./src/generated/thornodeApi"
   },
   "dependencies": {
-    "axios": "1.13.5"
+    "axios": "1.15.0"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.20.2",

--- a/packages/xchain-util/package.json
+++ b/packages/xchain-util/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint --config ../../eslint.config.mjs \"{src,__tests__}/**/*.ts\" --fix --max-warnings 0"
   },
   "dependencies": {
-    "bignumber.js": "^10.0.1"
+    "bignumber.js": "^11.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/xchain-utxo-providers/package.json
+++ b/packages/xchain-utxo-providers/package.json
@@ -31,7 +31,7 @@
     "@supercharge/promise-pool": "2.4.0",
     "@xchainjs/xchain-client": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.13.5"
+    "axios": "1.15.0"
   },
   "devDependencies": {
     "axios-mock-adapter": "^2.1.0"

--- a/packages/xchain-wallet/package.json
+++ b/packages/xchain-wallet/package.json
@@ -36,7 +36,7 @@
     "@xchainjs/xchain-thorchain": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
     "@xchainjs/xchain-utxo": "workspace:*",
-    "bignumber.js": "^10.0.1",
+    "bignumber.js": "^11.0.0",
     "ethers": "^6.14.3"
   },
   "devDependencies": {

--- a/packages/zcash-js/package.json
+++ b/packages/zcash-js/package.json
@@ -32,11 +32,11 @@
   "dependencies": {
     "@noble/curves": "^1.7.0",
     "@noble/hashes": "^1.6.1",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "bs58check": "^4.0.0",
     "buffer": "^6.0.3",
     "json-rpc-2.0": "^1.7.0",
-    "lodash": "^4.17.21"
+    "lodash": "^4.18.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.17.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5119,7 +5119,7 @@ __metadata:
     "@xchainjs/xchain-thorchain-query": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-wallet": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     axios-mock-adapter: "npm:^2.1.0"
   languageName: unknown
   linkType: soft
@@ -5180,7 +5180,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-utxo": "workspace:*"
     "@xchainjs/xchain-utxo-providers": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     axios-mock-adapter: "npm:^2.1.0"
     bitcoinjs-lib: "npm:^6.1.7"
     coinselect: "npm:3.1.12"
@@ -5202,7 +5202,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-utxo": "workspace:*"
     "@xchainjs/xchain-utxo-providers": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     axios-mock-adapter: "npm:^2.1.0"
     bitcore-lib-cash: "npm:11.0.0"
     bs58check: "npm:^4.0.0"
@@ -5244,7 +5244,7 @@ __metadata:
   dependencies:
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
   languageName: unknown
   linkType: soft
 
@@ -5285,7 +5285,7 @@ __metadata:
     "@xchainjs/xchain-cosmos-sdk": "workspace:*"
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     bignumber.js: "npm:^10.0.1"
     cosmjs-types: "npm:0.9.0"
     protobufjs: "npm:6.11.4"
@@ -5318,7 +5318,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-utxo": "workspace:*"
     "@xchainjs/xchain-utxo-providers": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     axios-mock-adapter: "npm:^2.1.0"
     bitcoinjs-lib: "npm:^6.1.7"
     coinselect: "npm:3.1.12"
@@ -5339,7 +5339,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-utxo": "workspace:*"
     "@xchainjs/xchain-utxo-providers": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     axios-mock-adapter: "npm:^2.1.0"
     bitcoinjs-lib: "npm:^6.1.7"
     coinselect: "npm:3.1.12"
@@ -5367,7 +5367,7 @@ __metadata:
   dependencies:
     "@xchainjs/xchain-client": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     ethers: "npm:^6.14.3"
   languageName: unknown
   linkType: soft
@@ -5383,7 +5383,7 @@ __metadata:
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-evm-providers": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     axios-mock-adapter: "npm:^2.1.0"
     bignumber.js: "npm:^10.0.1"
     ethers: "npm:^6.14.3"
@@ -5423,7 +5423,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-utxo": "workspace:*"
     "@xchainjs/xchain-utxo-providers": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     axios-mock-adapter: "npm:^2.1.0"
     bitcoinjs-lib: "npm:^6.1.7"
     coinselect: "npm:3.1.12"
@@ -5451,7 +5451,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-wallet": "workspace:*"
     "@xchainjs/xchain-zcash": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     axios-mock-adapter: "npm:^2.1.0"
     ethers: "npm:^6.14.3"
   languageName: unknown
@@ -5466,7 +5466,7 @@ __metadata:
     "@xchainjs/xchain-mayamidgard-query": "workspace:*"
     "@xchainjs/xchain-mayanode": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     axios-mock-adapter: "npm:2.1.0"
     axios-retry: "npm:3.2.5"
     bignumber.js: "npm:^10.0.1"
@@ -5490,7 +5490,7 @@ __metadata:
     "@xchainjs/xchain-cosmos-sdk": "workspace:*"
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     bignumber.js: "npm:^10.0.1"
     cosmjs-types: "npm:0.9.0"
     protobufjs: "npm:6.11.4"
@@ -5504,7 +5504,7 @@ __metadata:
     "@xchainjs/xchain-client": "workspace:*"
     "@xchainjs/xchain-mayamidgard": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     axios-mock-adapter: "npm:^2.1.0"
     axios-retry: "npm:^3.9.1"
   languageName: unknown
@@ -5515,7 +5515,7 @@ __metadata:
   resolution: "@xchainjs/xchain-mayamidgard@workspace:packages/xchain-mayamidgard"
   dependencies:
     "@openapitools/openapi-generator-cli": "npm:^2.20.2"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     rimraf: "npm:5.0.0"
   languageName: unknown
   linkType: soft
@@ -5525,7 +5525,7 @@ __metadata:
   resolution: "@xchainjs/xchain-mayanode@workspace:packages/xchain-mayanode"
   dependencies:
     "@openapitools/openapi-generator-cli": "npm:^2.20.2"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     rimraf: "npm:5.0.0"
   languageName: unknown
   linkType: soft
@@ -5537,7 +5537,7 @@ __metadata:
     "@xchainjs/xchain-client": "workspace:*"
     "@xchainjs/xchain-midgard": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     axios-mock-adapter: "npm:^2.1.0"
     axios-retry: "npm:^3.9.1"
     dotenv: "npm:16.0.0"
@@ -5549,7 +5549,7 @@ __metadata:
   resolution: "@xchainjs/xchain-midgard@workspace:packages/xchain-midgard"
   dependencies:
     "@openapitools/openapi-generator-cli": "npm:^2.20.2"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     rimraf: "npm:5.0.0"
   languageName: unknown
   linkType: soft
@@ -5650,7 +5650,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-wallet": "workspace:*"
     "@xchainjs/xchain-zcash": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     axios-mock-adapter: "npm:^2.1.0"
     ethers: "npm:^6.14.3"
   languageName: unknown
@@ -5664,7 +5664,7 @@ __metadata:
     "@xchainjs/xchain-midgard-query": "workspace:*"
     "@xchainjs/xchain-thornode": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     axios-mock-adapter: "npm:2.1.0"
     axios-retry: "npm:3.2.5"
     bignumber.js: "npm:^10.0.1"
@@ -5690,7 +5690,7 @@ __metadata:
     "@xchainjs/xchain-cosmos-sdk": "workspace:*"
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     bignumber.js: "npm:^10.0.1"
     cosmjs-types: "npm:0.9.0"
     protobufjs: "npm:6.11.4"
@@ -5702,7 +5702,7 @@ __metadata:
   resolution: "@xchainjs/xchain-thornode@workspace:packages/xchain-thornode"
   dependencies:
     "@openapitools/openapi-generator-cli": "npm:^2.20.2"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     rimraf: "npm:5.0.0"
   languageName: unknown
   linkType: soft
@@ -5736,7 +5736,7 @@ __metadata:
     "@supercharge/promise-pool": "npm:2.4.0"
     "@xchainjs/xchain-client": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     axios-mock-adapter: "npm:^2.1.0"
   languageName: unknown
   linkType: soft
@@ -5796,11 +5796,11 @@ __metadata:
     "@noble/curves": "npm:^1.7.0"
     "@noble/hashes": "npm:^1.6.1"
     "@types/lodash": "npm:^4.17.13"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     bs58check: "npm:^4.0.0"
     buffer: "npm:^6.0.3"
     json-rpc-2.0: "npm:^1.7.0"
-    lodash: "npm:^4.17.21"
+    lodash: "npm:^4.18.0"
   languageName: unknown
   linkType: soft
 
@@ -6309,14 +6309,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.13.5":
-  version: 1.13.5
-  resolution: "axios@npm:1.13.5"
+"axios@npm:1.15.0":
+  version: 1.15.0
+  resolution: "axios@npm:1.15.0"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/abf468c34f2d145f3dc7dbc0f1be67e520630624307bda69a41bbe8d386bd672d87b4405c4ee77f9ff54b235ab02f96a9968fb00e75b13ce64706e352a3068fd
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
   languageName: node
   linkType: hard
 
@@ -11752,6 +11752,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash@npm:^4.18.0":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
+  languageName: node
+  linkType: hard
+
 "log-symbols@npm:^4.0.0, log-symbols@npm:^4.1.0":
   version: 4.1.0
   resolution: "log-symbols@npm:4.1.0"
@@ -13479,6 +13486,13 @@ __metadata:
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
   checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "proxy-from-env@npm:2.1.0"
+  checksum: 10c0/ed01729fd4d094eab619cd7e17ce3698b3413b31eb102c4904f9875e677cd207392795d5b4adee9cec359dfd31c44d5ad7595a3a3ad51c40250e141512281c58
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5133,7 +5133,7 @@ __metadata:
     "@xchainjs/xchain-evm": "workspace:*"
     "@xchainjs/xchain-evm-providers": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    bignumber.js: "npm:^10.0.1"
+    bignumber.js: "npm:^11.0.0"
     ethers: "npm:^6.14.3"
   languageName: unknown
   linkType: soft
@@ -5148,7 +5148,7 @@ __metadata:
     "@xchainjs/xchain-evm": "workspace:*"
     "@xchainjs/xchain-evm-providers": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    bignumber.js: "npm:^10.0.1"
+    bignumber.js: "npm:^11.0.0"
     ethers: "npm:^6.14.3"
   languageName: unknown
   linkType: soft
@@ -5162,7 +5162,7 @@ __metadata:
     "@xchainjs/xchain-evm": "workspace:*"
     "@xchainjs/xchain-evm-providers": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    bignumber.js: "npm:^10.0.1"
+    bignumber.js: "npm:^11.0.0"
     ethers: "npm:^6.14.3"
   languageName: unknown
   linkType: soft
@@ -5220,7 +5220,7 @@ __metadata:
     "@xchainjs/xchain-evm": "workspace:*"
     "@xchainjs/xchain-evm-providers": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    bignumber.js: "npm:^10.0.1"
+    bignumber.js: "npm:^11.0.0"
     ethers: "npm:^6.14.3"
   languageName: unknown
   linkType: soft
@@ -5286,7 +5286,7 @@ __metadata:
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
     axios: "npm:1.15.0"
-    bignumber.js: "npm:^10.0.1"
+    bignumber.js: "npm:^11.0.0"
     cosmjs-types: "npm:0.9.0"
     protobufjs: "npm:6.11.4"
   languageName: unknown
@@ -5356,7 +5356,7 @@ __metadata:
     "@xchainjs/xchain-evm": "workspace:*"
     "@xchainjs/xchain-evm-providers": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    bignumber.js: "npm:^10.0.1"
+    bignumber.js: "npm:^11.0.0"
     ethers: "npm:^6.14.3"
   languageName: unknown
   linkType: soft
@@ -5385,7 +5385,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     axios: "npm:1.15.0"
     axios-mock-adapter: "npm:^2.1.0"
-    bignumber.js: "npm:^10.0.1"
+    bignumber.js: "npm:^11.0.0"
     ethers: "npm:^6.14.3"
   languageName: unknown
   linkType: soft
@@ -5469,7 +5469,7 @@ __metadata:
     axios: "npm:1.15.0"
     axios-mock-adapter: "npm:2.1.0"
     axios-retry: "npm:3.2.5"
-    bignumber.js: "npm:^10.0.1"
+    bignumber.js: "npm:^11.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5491,7 +5491,7 @@ __metadata:
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
     axios: "npm:1.15.0"
-    bignumber.js: "npm:^10.0.1"
+    bignumber.js: "npm:^11.0.0"
     cosmjs-types: "npm:0.9.0"
     protobufjs: "npm:6.11.4"
   languageName: unknown
@@ -5667,7 +5667,7 @@ __metadata:
     axios: "npm:1.15.0"
     axios-mock-adapter: "npm:2.1.0"
     axios-retry: "npm:3.2.5"
-    bignumber.js: "npm:^10.0.1"
+    bignumber.js: "npm:^11.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5691,7 +5691,7 @@ __metadata:
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
     axios: "npm:1.15.0"
-    bignumber.js: "npm:^10.0.1"
+    bignumber.js: "npm:^11.0.0"
     cosmjs-types: "npm:0.9.0"
     protobufjs: "npm:6.11.4"
   languageName: unknown
@@ -5725,7 +5725,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@xchainjs/xchain-util@workspace:packages/xchain-util"
   dependencies:
-    bignumber.js: "npm:^10.0.1"
+    bignumber.js: "npm:^11.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5765,7 +5765,7 @@ __metadata:
     "@xchainjs/xchain-thorchain": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-utxo": "workspace:*"
-    bignumber.js: "npm:^10.0.1"
+    bignumber.js: "npm:^11.0.0"
     ethers: "npm:^6.14.3"
   languageName: unknown
   linkType: soft
@@ -6531,10 +6531,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bignumber.js@npm:^10.0.1":
-  version: 10.0.2
-  resolution: "bignumber.js@npm:10.0.2"
-  checksum: 10c0/471a17d851d275e458156d090c028b8851c84389dc41db79b08dd584b4df1e4d24f70b1684705a5974aec6c59dc8511337007e01bd78d8ed8d93e1a541356a7f
+"bignumber.js@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "bignumber.js@npm:11.0.0"
+  checksum: 10c0/a3675125b7bff72a618981d05e938e5318b1b9994fed6802a6d1330ea00ef2f3f8a0b90fa44872d43f34331aa4f5977276c775c170748ace516e4eecf6f216a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update axios 1.13.5 → 1.15.0 across all 24 packages to fix SSRF (GHSA-3p68-rc4w-qgx5) and header injection (GHSA-fvcv-3m26-pcqx). Update lodash ^4.17.21 → ^4.18.0 in zcash-js to fix code injection via _.template (GHSA-r5fr-rjxr-66jc).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated axios from version 1.13.5 to 1.15.0 across all packages.
  * Updated lodash from ^4.17.21 to ^4.18.0 in the zcash-js package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->