### PR TITLE
fix(mayachain-amm): use protocol fee rates for swap transfers

### DIFF
--- a/.changeset/fresh-teeth-decide.md
+++ b/.changeset/fresh-teeth-decide.md
@@ -1,0 +1,5 @@
+---
+'@xchainjs/xchain-mayachain-amm': patch
+---
+
+Use getFeeRates from the protocol for a AMM swap

--- a/packages/xchain-mayachain-amm/src/mayachain-action.ts
+++ b/packages/xchain-mayachain-amm/src/mayachain-action.ts
@@ -1,3 +1,4 @@
+import { Protocol } from '@xchainjs/xchain-client'
 import { abi } from '@xchainjs/xchain-evm'
 import { MAYAChain } from '@xchainjs/xchain-mayachain'
 import { CompatibleAsset, MayachainQuery } from '@xchainjs/xchain-mayachain-query'
@@ -75,12 +76,7 @@ export class MayachainAction {
           url: await wallet.getExplorerTxUrl(assetAmount.asset.chain, hash),
         }
       }
-      const feeRates = await wallet.estimateTransferFees({
-        asset: assetAmount.asset,
-        amount: assetAmount.baseAmount,
-        recipient,
-        memo,
-      })
+      const feeRates = await wallet.getFeeRates(assetAmount.asset.chain, Protocol.MAYACHAIN)
       const hash = await wallet.transfer({
         asset: assetAmount.asset,
         amount: assetAmount.baseAmount,


### PR DESCRIPTION
## Summary
- Replaces `wallet.estimateTransferFees(...)` with `wallet.getFeeRates(chain, Protocol.MAYACHAIN)` in `MayachainAction.makeAction` so AMM swap transfers use Mayachain's protocol-published fee rates instead of the chain's local estimator.
- Avoids stale/incorrect fee rates on UTXO chains, where the local estimator can disagree with what the protocol expects.

## Test plan
- [ ] `yarn build --filter=@xchainjs/xchain-mayachain-amm`
- [ ] `yarn test --filter=@xchainjs/xchain-mayachain-amm`
- [ ] Manual: execute an AMM swap from a UTXO chain (BTC/LTC/DOGE/DASH/BCH) and confirm the broadcast tx uses the protocol-quoted fee rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AMM swap transfer fee calculation to use protocol-based fee rates for improved accuracy and consistency

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xchainjs/xchainjs-lib/pull/1685)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->