### PR TITLE
fix(dash): bypass Cloudflare-blocked insight.dash.org

### DIFF
--- a/.changeset/dash-blockcypher-primary.md
+++ b/.changeset/dash-blockcypher-primary.md
@@ -1,0 +1,5 @@
+---
+'@xchainjs/xchain-dash': patch
+---
+
+Route Dash balance, transaction list, single-transaction lookups, and broadcast through the configured `dataProviders` instead of calling `insight.dash.org/insight-api` directly. Insight has been placed behind a Cloudflare bot challenge that returns HTTP 403 to programmatic clients. Blockcypher is now ordered ahead of Bitgo in `defaultDashParams.dataProviders` so reads and broadcasts hit a working provider by default; Bitgo remains as a fallback. `transfer` and `transferMax` in `ClientKeystore` and `ClientLedger` now call the inherited `broadcastTx` from `UTXOClient` rather than posting to `nodeUrls`. The mainnet/stagenet explorer URLs (`getExplorerUrl`, `getExplorerAddressUrl`, `getExplorerTxUrl`) have moved from `insight.dash.org/insight` to `blockchair.com/dash`, which is more reliable and aligns with what consumers already use elsewhere. The transfer flow's UTXO fetch path is unchanged.

--- a/packages/xchain-dash/__tests__/client.test.ts
+++ b/packages/xchain-dash/__tests__/client.test.ts
@@ -1,5 +1,4 @@
 import { Network } from '@xchainjs/xchain-client'
-import { baseAmount } from '@xchainjs/xchain-util'
 
 import dashMocks from '../__mocks__/dash-mocks'
 import { Client } from '../src'
@@ -67,7 +66,7 @@ describe('DashClient Test', () => {
 
   it('should return valid explorer url', () => {
     dashClient.setNetwork(Network.Mainnet)
-    expect(dashClient.getExplorerUrl()).toEqual('https://insight.dash.org/insight')
+    expect(dashClient.getExplorerUrl()).toEqual('https://blockchair.com/dash')
 
     dashClient.setNetwork(Network.Testnet)
     expect(dashClient.getExplorerUrl()).toEqual('https://blockexplorer.one/dash/testnet/')
@@ -76,7 +75,7 @@ describe('DashClient Test', () => {
   it('should return valid explorer address url', () => {
     dashClient.setNetwork(Network.Mainnet)
     expect(dashClient.getExplorerAddressUrl('testAddressHere')).toEqual(
-      'https://insight.dash.org/insight/address/testAddressHere',
+      'https://blockchair.com/dash/address/testAddressHere',
     )
     dashClient.setNetwork(Network.Testnet)
     expect(dashClient.getExplorerAddressUrl('anotherTestAddressHere')).toEqual(
@@ -86,48 +85,17 @@ describe('DashClient Test', () => {
 
   it('should return valid explorer tx url', () => {
     dashClient.setNetwork(Network.Mainnet)
-    expect(dashClient.getExplorerTxUrl('testTxHere')).toEqual('https://insight.dash.org/insight/tx/testTxHere')
+    expect(dashClient.getExplorerTxUrl('testTxHere')).toEqual('https://blockchair.com/dash/transaction/testTxHere')
     dashClient.setNetwork(Network.Testnet)
     expect(dashClient.getExplorerTxUrl('anotherTestTxHere')).toEqual(
       'https://blockexplorer.one/dash/testnet/tx/anotherTestTxHere',
     )
   })
 
-  it('should get the right balance', async () => {
-    const balance = await dashClient.getBalance(dashClient.getAddress())
-    expect(balance.length).toEqual(1)
-    expect(balance[0].amount.amount().toString()).toEqual('100831726070')
-  })
-
-  it('should get transaction data', async () => {
-    const txid = '7176e32e34e83b28c8491fdadd06270bfd21635c8f75004e1792ab7cc68aa4d2'
-    const txData = await dashClient.getTransactionData(txid)
-
-    expect(txData.hash).toEqual(txid)
-    expect(txData.from.length).toEqual(1)
-    expect(txData.from[0].from).toEqual('yQonuFGw7Yd781ScM7JPMmQJxWeiFyMx57')
-    expect(txData.from[0].amount.amount().isEqualTo(baseAmount(659692410624).amount())).toBeTruthy()
-    expect(txData.to.length).toEqual(2)
-    expect(txData.to[0].to).toEqual('yMypNRrzi3otv866sFDDuDc3JD3pAge5kd')
-    expect(txData.to[0].amount.amount().isEqualTo(baseAmount(10925300000).amount())).toBeTruthy()
-    expect(txData.to[1].to).toEqual('yWcytKfuGwZ3hkGEmfuCH2VkGAuLdFp1PU')
-    expect(txData.to[1].amount.amount().isEqualTo(baseAmount(648767110380).amount())).toBeTruthy()
-  })
-
-  it('should get transactions', async () => {
-    const txs = await dashClient.getTransactions({
-      address: 'yLhzaEXappHzG1C7fkEhEWQTzMQhjn18Rb',
-      limit: 1,
-    })
-    expect(txs.total).toEqual(2)
-    expect(txs.txs[0].hash).toEqual('52f0be2139c95ee67696b91b523f2c6cbf2ccf813916b728aa3d46a62b0ab021')
-    expect(txs.txs[0].from.length).toEqual(1)
-    expect(txs.txs[0].from[0].from).toEqual('yLhzaEXappHzG1C7fkEhEWQTzMQhjn18Rb')
-    expect(txs.txs[0].from[0].amount.amount().isEqualTo(baseAmount(40000).amount())).toBeTruthy()
-    expect(txs.txs[0].to.length).toEqual(2)
-    expect(txs.txs[0].to[1].to).toEqual('yN6hx8QEiwiDcMfPKFEgaLWBK9trBX1vVX')
-    expect(txs.txs[0].to[1].amount.amount().isEqualTo(baseAmount(38997).amount())).toBeTruthy()
-  })
+  // Balance, getTransactionData, and getTransactions tests previously relied on
+  // insight.dash.org responses. Those calls are now delegated to the configured
+  // dataProviders (Blockcypher → Bitgo) via the UTXOClient base class, whose
+  // round-robin transport is covered in xchain-utxo-providers.
 
   // it('should transfer dash', async () => {
   //   const txId = await dashClient.transfer({

--- a/packages/xchain-dash/src/client.ts
+++ b/packages/xchain-dash/src/client.ts
@@ -1,13 +1,10 @@
 import dashcore from '@dashevo/dashcore-lib'
-import { AssetInfo, FeeRate, Network, TxHistoryParams, TxType } from '@xchainjs/xchain-client'
-import { Address, assetAmount, assetToBase, baseAmount } from '@xchainjs/xchain-util'
+import { AssetInfo, FeeRate, Network } from '@xchainjs/xchain-client'
+import { Address } from '@xchainjs/xchain-util'
 import {
-  Balance,
   Client as UTXOClient,
   PreparedTx,
-  Tx,
   TxParams,
-  TxsPage,
   UTXO,
   UtxoClientParams,
   UtxoError,
@@ -25,8 +22,6 @@ import {
   UPPER_FEE_BOUND,
   explorerProviders,
 } from './const'
-import * as insight from './insight-api'
-import { InsightTxResponse } from './insight-api'
 import { DashPreparedTx, NodeAuth, NodeUrls } from './types'
 import * as Utils from './utils'
 
@@ -40,7 +35,7 @@ export const defaultDashParams: UtxoClientParams & {
   network: Network.Mainnet,
   phrase: '',
   explorerProviders: explorerProviders,
-  dataProviders: [BitgoProviders, BlockcypherDataProviders],
+  dataProviders: [BlockcypherDataProviders, BitgoProviders],
   rootDerivationPaths: {
     [Network.Mainnet]: `m/44'/5'/0'/0/`,
     [Network.Stagenet]: `m/44'/5'/0'/0/`,
@@ -95,117 +90,6 @@ abstract class Client extends UTXOClient {
    */
   validateAddress(address: string): boolean {
     return Utils.validateAddress(address, this.network)
-  }
-  /**
-   * Asynchronously get the balance for a DASH address.
-   * @param {string} address The DASH address.
-   * @returns {Promise<Balance[]>} A promise resolving to an array of balances.
-   */
-  async getBalance(address: string): Promise<Balance[]> {
-    const addressResponse = await insight.getAddress({ network: this.network, address })
-    const confirmed = baseAmount(addressResponse.balanceSat)
-    const unconfirmed = baseAmount(addressResponse.unconfirmedBalanceSat)
-    return [
-      {
-        asset: AssetDASH,
-        amount: confirmed.plus(unconfirmed),
-      },
-    ]
-  }
-  /**
-   * Asynchronously retrieves transactions for a given address.
-   * @param {TxHistoryParams} params - Parameters for transaction retrieval.
-   * @returns {Promise<TxsPage>} A promise resolving to a page of transactions.
-   */
-  async getTransactions(params?: TxHistoryParams): Promise<TxsPage> {
-    // Extract offset and limit from parameters or set default values
-    const offset = params?.offset ?? 0
-    const limit = params?.limit || 10
-
-    // Insight uses pages rather than offset/limit indexes, so we have to
-    // iterate through each page within the offset/limit range.
-    const perPage = 10
-    const startPage = Math.floor(offset / perPage)
-    const endPage = Math.floor((offset + limit - 1) / perPage)
-    const firstPageOffset = offset % perPage
-    const lastPageLimit = (firstPageOffset + (limit - 1)) % perPage
-
-    let totalPages = -1
-    let lastPageTotal = -1
-
-    let insightTxs: InsightTxResponse[] = []
-    // Iterate through each page within the offset/limit range
-    for (let pageNum = startPage; pageNum <= endPage; pageNum++) {
-      const response = await insight.getAddressTxs({
-        network: this.network,
-        address: `${params?.address}`,
-        pageNum,
-      })
-      let startIndex = 0
-      let endIndex = perPage - 1
-      if (pageNum == startPage) {
-        startIndex = firstPageOffset
-      }
-      if (pageNum === endPage) {
-        endIndex = lastPageLimit
-      }
-      insightTxs = [...insightTxs, ...response.txs.slice(startIndex, endIndex + 1)]
-
-      // Insight only returns the number of pages not the total number of
-      // transactions. If the last page is within the offset/limit range then we
-      // can set the lastPageTotal here and avoid having to send another request,
-      // otherwise we can fetch the last page later to determine the total
-      // transaction count
-      totalPages = response.pagesTotal
-      if (pageNum === totalPages - 1) {
-        lastPageTotal = response.txs.length
-      }
-    }
-    // Map insight transactions to XChain transactions
-    const txs: Tx[] = insightTxs.map(this.insightTxToXChainTx)
-    // Fetch transactions count for last page if not obtained
-    if (lastPageTotal < 0) {
-      const lastPageResponse = await insight.getAddressTxs({
-        network: this.network,
-        address: `${params?.address}`,
-        pageNum: totalPages - 1,
-      })
-      lastPageTotal = lastPageResponse.txs.length
-    }
-    // Calculate total transactions count and return the page of transactions
-    return {
-      total: (totalPages - 1) * perPage + lastPageTotal,
-      txs,
-    }
-  }
-  /**
-   * Asynchronously retrieves transaction data for a given transaction ID.
-   * @param {string} txid - The transaction ID.
-   * @returns {Promise<Tx>} A promise resolving to the transaction data.
-   */
-  async getTransactionData(txid: string): Promise<Tx> {
-    const tx = await insight.getTx({ network: this.network, txid })
-    return this.insightTxToXChainTx(tx)
-  }
-  /**
-   * Converts an Insight transaction response to XChain transaction.
-   * @param {InsightTxResponse} tx - The Insight transaction response.
-   * @returns {Tx} The XChain transaction.
-   */
-  private insightTxToXChainTx(tx: InsightTxResponse): Tx {
-    return {
-      asset: AssetDASH,
-      from: tx.vin.map((i) => ({
-        from: i.addr,
-        amount: assetToBase(assetAmount(i.value)),
-      })),
-      to: tx.vout
-        .filter((i) => i.scriptPubKey.type !== 'nulldata')
-        .map((i) => ({ to: i.scriptPubKey.addresses?.[0], amount: assetToBase(assetAmount(i.value)) })),
-      date: new Date(tx.time * 1000),
-      type: TxType.Transfer,
-      hash: tx.txid,
-    }
   }
 
   /**

--- a/packages/xchain-dash/src/clientKeystore.ts
+++ b/packages/xchain-dash/src/clientKeystore.ts
@@ -10,7 +10,6 @@ import * as Dash from 'bitcoinjs-lib'
 import { ECPairFactory, ECPairInterface } from 'ecpair'
 
 import { Client } from './client'
-import * as nodeApi from './node-api'
 import * as Utils from './utils'
 
 const ECPair = ECPairFactory(ecc)
@@ -141,11 +140,7 @@ export class ClientKeystore extends Client {
     tx.sign(`${dashKeys.privateKey?.toString('hex')}`)
 
     const txHex = tx.checkedSerialize({})
-    return await nodeApi.broadcastTx({
-      txHex,
-      nodeUrl: this.nodeUrls[this.network],
-      auth: this.nodeAuth,
-    })
+    return await this.broadcastTx(txHex)
   }
 
   /**
@@ -212,11 +207,7 @@ export class ClientKeystore extends Client {
     tx.sign(`${dashKeys.privateKey?.toString('hex')}`)
 
     const txHex = tx.checkedSerialize({})
-    const hash = await nodeApi.broadcastTx({
-      txHex,
-      nodeUrl: this.nodeUrls[this.network],
-      auth: this.nodeAuth,
-    })
+    const hash = await this.broadcastTx(txHex)
 
     return { hash, maxAmount, fee }
   }

--- a/packages/xchain-dash/src/clientLedger.ts
+++ b/packages/xchain-dash/src/clientLedger.ts
@@ -7,7 +7,6 @@ import { TxParams, UTXO, UtxoClientParams, UtxoSelectionPreferences } from '@xch
 
 import { Client } from './client'
 import { getRawTx } from './insight-api'
-import * as nodeApi from './node-api'
 import { NodeAuth, NodeUrls } from './types'
 
 /**
@@ -96,13 +95,8 @@ class ClientLedger extends Client {
       additionals: [],
     })
 
-    // Broadcast transaction
-    const txHash = await nodeApi.broadcastTx({
-      txHex,
-      nodeUrl: this.nodeUrls[this.network],
-      auth: this.nodeAuth,
-    })
-    // Throw error if no transaction hash is received
+    // Broadcast transaction via the configured data providers
+    const txHash = await this.broadcastTx(txHex)
     if (!txHash) {
       throw Error('No Tx hash')
     }
@@ -163,11 +157,7 @@ class ClientLedger extends Client {
       additionals: [],
     })
 
-    const hash = await nodeApi.broadcastTx({
-      txHex,
-      nodeUrl: this.nodeUrls[this.network],
-      auth: this.nodeAuth,
-    })
+    const hash = await this.broadcastTx(txHex)
     if (!hash) {
       throw Error('No Tx hash')
     }

--- a/packages/xchain-dash/src/const.ts
+++ b/packages/xchain-dash/src/const.ts
@@ -51,9 +51,9 @@ export const AssetDASH: Asset = { chain: DASHChain, symbol: 'DASH', ticker: 'DAS
  * Explorer provider for Dash mainnet.
  */
 const DASH_MAINNET_EXPLORER = new ExplorerProvider(
-  'https://insight.dash.org/insight',
-  'https://insight.dash.org/insight/address/%%ADDRESS%%',
-  'https://insight.dash.org/insight/tx/%%TX_ID%%',
+  'https://blockchair.com/dash',
+  'https://blockchair.com/dash/address/%%ADDRESS%%',
+  'https://blockchair.com/dash/transaction/%%TX_ID%%',
 )
 
 /**

--- a/tools/xchain-suite/src/components/operations/constants.ts
+++ b/tools/xchain-suite/src/components/operations/constants.ts
@@ -18,7 +18,7 @@ export const EXPLORER_TX_URLS: Record<string, string> = {
   // Cosmos chains
   GAIA: 'https://www.mintscan.io/cosmos/txs/',
   THOR: 'https://runescan.io/tx/',
-  MAYA: 'https://www.mayascan.org/tx/',
+  MAYA: 'https://www.explorer.mayachain.info/tx/',
   KUJI: 'https://finder.kujira.network/kaiyo-1/tx/',
   // Other chains
   SOL: 'https://solscan.io/tx/',

--- a/tools/xchain-suite/src/components/swap/SwapTrackingModal.tsx
+++ b/tools/xchain-suite/src/components/swap/SwapTrackingModal.tsx
@@ -251,7 +251,7 @@ export function SwapTrackingModal({
     ? `https://scan.chainflip.io/channels/${depositChannelId || ''}`
     : protocol === 'Thorchain'
     ? `https://track.thorchain.org/${txHash}`
-    : `https://www.mayascan.org/tx/${txHash}`
+    : `https://www.explorer.mayachain.info/tx/${txHash}`
 
   // THORChain/MAYAChain: find current active stage
   const activeStageIndex = status


### PR DESCRIPTION
insight.dash.org is now behind a Cloudflare bot challenge that returns HTTP 403 to programmatic clients, breaking Dash balance, history, and broadcast in xchain-suite.

- Reorder defaultDashParams.dataProviders to [Blockcypher, Bitgo] so the provider that answers is tried first.
- Delete the insight-bound getBalance/getTransactions/ getTransactionData overrides; inherit from UTXOClient and round-robin through dataProviders instead.
- Swap nodeApi.broadcastTx calls in ClientKeystore and ClientLedger transfer/transferMax for this.broadcastTx, which also routes through the providers.
- Move DASH_MAINNET_EXPLORER from insight.dash.org/insight to blockchair.com/dash for reliability and consistency with consumers.
- Update xchain-suite Mayachain swap tracker links from mayascan.org to explorer.mayachain.info.

Transfer-flow UTXO fetching (utils.ts, clientKeystore signing loop) still hits insight and is left for a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Dash network connectivity issues by routing balance and transaction queries through reliable data providers instead of the previously inaccessible Insight API
  * Reordered default data providers to prioritize a working Dash provider with fallback support
  * Updated Dash and Mayachain transaction explorer URLs to more reliable services

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xchainjs/xchainjs-lib/pull/1686)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->