### PR TITLE
feat(thorchain): default to official thorchain.network public gateway

### DIFF
--- a/.changeset/thorchain-network-gateway.md
+++ b/.changeset/thorchain-network-gateway.md
@@ -1,0 +1,10 @@
+---
+'@xchainjs/xchain-client': patch
+'@xchainjs/xchain-thorchain': patch
+'@xchainjs/xchain-thornode': patch
+'@xchainjs/xchain-thorchain-query': patch
+'@xchainjs/xchain-midgard': patch
+'@xchainjs/xchain-midgard-query': patch
+---
+
+Point THORChain endpoint defaults at the new official public gateway hosted at `*.thorchain.network` (announced in xchainjs/xchainjs-lib#1665). Mainnet defaults now use `https://thornode.thorchain.network`, `https://midgard.thorchain.network`, and `https://rpc.thorchain.network` as the primary URLs, with the existing Liquify gateway (`gateway.liquify.com`) retained as a fallback in packages that support multiple base URLs (`xchain-thorchain`, `xchain-thorchain-query`, `xchain-midgard-query`). The single-URL constants in `xchain-thornode` (`THORNODE_API_URL`) and `xchain-midgard` (`MIDGARD_API_URL`) are switched to the new gateway, as is the `MAINNET_THORNODE_API_BASE` used by `BaseXChainClient.thornodeAPIGet` in `xchain-client`. Consumers that pass their own URLs are unaffected.

--- a/packages/xchain-client/src/BaseXChainClient.ts
+++ b/packages/xchain-client/src/BaseXChainClient.ts
@@ -23,7 +23,7 @@ import {
   XChainClientParams,
 } from './types'
 
-const MAINNET_THORNODE_API_BASE = 'https://gateway.liquify.com/chain/thorchain_api/thorchain'
+const MAINNET_THORNODE_API_BASE = 'https://thornode.thorchain.network/thorchain'
 const STAGENET_THORNODE_API_BASE = ''
 const TESTNET_THORNODE_API_BASE = 'https://testnet.thornode.thorchain.info/thorchain'
 

--- a/packages/xchain-midgard-query/src/utils/midgard.ts
+++ b/packages/xchain-midgard-query/src/utils/midgard.ts
@@ -16,7 +16,7 @@ import { GetActionsParams, MidgardConfig } from '../types'
 const defaultMidgardConfig: Record<Network, MidgardConfig> = {
   mainnet: {
     apiRetries: 3,
-    midgardBaseUrls: ['https://gateway.liquify.com/chain/thorchain_midgard'],
+    midgardBaseUrls: ['https://midgard.thorchain.network', 'https://gateway.liquify.com/chain/thorchain_midgard'],
   },
   stagenet: {
     apiRetries: 3,

--- a/packages/xchain-midgard/src/config.ts
+++ b/packages/xchain-midgard/src/config.ts
@@ -1,6 +1,6 @@
 /**
  * The base URL for the Midgard API endpoint.
  */
-export const MIDGARD_API_URL = 'https://gateway.liquify.com/chain/thorchain_midgard/'
+export const MIDGARD_API_URL = 'https://midgard.thorchain.network/'
 /** @deprecated Use MIDGARD_API_URL instead. Will be removed in next major version. */
 export const MIDGARD_API_9R_URL = MIDGARD_API_URL

--- a/packages/xchain-thorchain-query/src/utils/thornode.ts
+++ b/packages/xchain-thorchain-query/src/utils/thornode.ts
@@ -47,7 +47,7 @@ export type ThornodeConfig = {
 const defaultThornodeConfig: Record<Network, ThornodeConfig> = {
   mainnet: {
     apiRetries: 3,
-    thornodeBaseUrls: [`https://gateway.liquify.com/chain/thorchain_api`],
+    thornodeBaseUrls: [`https://thornode.thorchain.network`, `https://gateway.liquify.com/chain/thorchain_api`],
   },
   stagenet: {
     apiRetries: 3,

--- a/packages/xchain-thorchain/src/utils.ts
+++ b/packages/xchain-thorchain/src/utils.ts
@@ -24,7 +24,7 @@ export const getDefaultClientUrls = (): Record<Network, string[]> => {
   return {
     [Network.Testnet]: ['deprecated'],
     [Network.Stagenet]: [],
-    [Network.Mainnet]: ['https://gateway.liquify.com/chain/thorchain_rpc'],
+    [Network.Mainnet]: ['https://rpc.thorchain.network', 'https://gateway.liquify.com/chain/thorchain_rpc'],
   }
 }
 /**

--- a/packages/xchain-thornode/src/config.ts
+++ b/packages/xchain-thornode/src/config.ts
@@ -1,6 +1,6 @@
 /**
  * The base URL for the THORNode API endpoint.
  */
-export const THORNODE_API_URL = 'https://gateway.liquify.com/chain/thorchain_api/'
+export const THORNODE_API_URL = 'https://thornode.thorchain.network/'
 /** @deprecated Use THORNODE_API_URL instead. Will be removed in next major version. */
 export const THORNODE_API_9R_URL = THORNODE_API_URL


### PR DESCRIPTION
## Summary

- Point THORChain endpoint defaults at the new official public API gateway hosted at `*.thorchain.network`, announced in #1665 (the "Nine Realms Transition Announcement" Discord post).
- Mainnet defaults now use `thornode.thorchain.network`, `midgard.thorchain.network`, and `rpc.thorchain.network` as the primary URLs.
- The existing Liquify gateway (`gateway.liquify.com`) is retained as a fallback in packages that support multi-URL configs (`xchain-thorchain` RPC, `xchain-thorchain-query`, `xchain-midgard-query`).
- Single-URL constants (`xchain-thornode/THORNODE_API_URL`, `xchain-midgard/MIDGARD_API_URL`, and `xchain-client/BaseXChainClient`'s `MAINNET_THORNODE_API_BASE`) are switched to the new gateway. Consumers passing their own URLs are unaffected.

## Endpoints touched

| Package | File | Before | After |
| --- | --- | --- | --- |
| `xchain-thorchain` (RPC) | `src/utils.ts` | `gateway.liquify.com/chain/thorchain_rpc` | `rpc.thorchain.network` (primary), Liquify (fallback) |
| `xchain-thornode` | `src/config.ts` | `gateway.liquify.com/chain/thorchain_api/` | `thornode.thorchain.network/` |
| `xchain-midgard` | `src/config.ts` | `gateway.liquify.com/chain/thorchain_midgard/` | `midgard.thorchain.network/` |
| `xchain-thorchain-query` | `src/utils/thornode.ts` | Liquify | `thornode.thorchain.network` (primary), Liquify (fallback) |
| `xchain-midgard-query` | `src/utils/midgard.ts` | Liquify | `midgard.thorchain.network` (primary), Liquify (fallback) |
| `xchain-client` | `src/BaseXChainClient.ts` | `gateway.liquify.com/chain/thorchain_api/thorchain` | `thornode.thorchain.network/thorchain` |

Verified live `200`s before swapping: `/thorchain/version`, `/thorchain/inbound_addresses`, `/thorchain/network`, `/v2/pools`, `/v2/health`, `/status`.

## Test plan

- [x] `yarn build` for the six affected packages
- [x] `yarn test` for the six affected packages (15/15 tasks pass)
- [x] `npx eslint` clean on the changed files
- [ ] Smoke test against mainnet endpoints from a downstream consumer (e.g. tools/testing-gui)

Closes #1665.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated default THORChain mainnet endpoints across multiple services to official public gateway domains for improved reliability and performance.
  * Implemented fallback endpoint support to enhance service continuity and availability.
  * Custom endpoint configurations remain unaffected by these infrastructure updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xchainjs/xchainjs-lib/pull/1687)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->