### PR TITLE
 add transfer max function, and test in xchain suite

### DIFF
--- a/.changeset/cardano-transfer-max.md
+++ b/.changeset/cardano-transfer-max.md
@@ -1,0 +1,5 @@
+---
+'@xchainjs/xchain-cardano': minor
+---
+
+Add `Client.transferMax({ recipient, memo, walletIndex })` to sweep the entire spendable ADA balance to a recipient in one call. The method wraps `prepareMaxTx`, signs, and broadcasts, returning `{ hash, maxAmount, fee }` where `maxAmount` and `fee` are lovelace numbers — matching the shape used by `xchain-bitcoin`'s `transferMax`. This lets callers surface what was actually swept without recomputing the fee. The signing path is factored into a private helper shared with `transfer()`, so the existing `LOWER_FEE_BOUND`/`UPPER_FEE_BOUND` checks apply to both.

--- a/packages/xchain-cardano/src/client.ts
+++ b/packages/xchain-cardano/src/client.ts
@@ -321,8 +321,41 @@ export class Client extends BaseXChainClient {
       asset: ADAAsset,
     })
 
-    const accountKey = await this.generatePrivateKey(params.walletIndex)
+    return this.signAndBroadcast(rawUnsignedTx, params.walletIndex)
+  }
 
+  /**
+   * Sweep the entire spendable balance to the recipient via `prepareMaxTx`, then sign and
+   * broadcast. Returns the resolved max amount and fee (lovelace) so callers can surface what
+   * was actually sent.
+   *
+   * @param {Object} params Sweep params.
+   * @returns {Promise<{ hash: TxHash; maxAmount: number; fee: number }>} Tx hash with the
+   *   swept amount and fee in lovelace.
+   */
+  public async transferMax(params: {
+    recipient: Address
+    memo?: string
+    walletIndex?: number
+  }): Promise<{ hash: TxHash; maxAmount: number; fee: number }> {
+    const sender = await this.getAddressAsync(params.walletIndex)
+    const { rawUnsignedTx, maxAmount, fee } = await this.prepareMaxTx({
+      sender,
+      recipient: params.recipient,
+      memo: params.memo,
+    })
+
+    const hash = await this.signAndBroadcast(rawUnsignedTx, params.walletIndex)
+
+    return {
+      hash,
+      maxAmount: Number(maxAmount.amount().toString()),
+      fee: Number(fee.amount().toString()),
+    }
+  }
+
+  private async signAndBroadcast(rawUnsignedTx: string, walletIndex?: number): Promise<TxHash> {
+    const accountKey = await this.generatePrivateKey(walletIndex)
     const privKey = accountKey.derive(0).derive(0)
 
     const cardanoLib = await getCardano()
@@ -331,27 +364,22 @@ export class Client extends BaseXChainClient {
     const auxData = usignedTx.auxiliary_data()
 
     const fixedTx = cardanoLib.FixedTransaction.new_from_body_bytes(txBody.to_bytes())
-
     const txHash = fixedTx.transaction_hash()
 
     const witnesses = cardanoLib.TransactionWitnessSet.new()
     const vKeyWitnesses = cardanoLib.Vkeywitnesses.new()
-
     const vKeyWitness = cardanoLib.make_vkey_witness(txHash, privKey.to_raw_key())
-
     vKeyWitnesses.add(vKeyWitness)
     witnesses.set_vkeys(vKeyWitnesses)
 
     const tx = cardanoLib.Transaction.new(txBody, witnesses, auxData)
 
     const fee = tx.body().fee().to_js_value()
-
     if (Number(fee) < LOWER_FEE_BOUND || Number(fee) > UPPER_FEE_BOUND) {
       throw Error('Fee is out of bounds')
     }
 
     const hash = await this.broadcastTx(tx.to_hex())
-
     return hash.replace(/"/g, '')
   }
 

--- a/tools/xchain-suite/src/components/operations/Sweep.tsx
+++ b/tools/xchain-suite/src/components/operations/Sweep.tsx
@@ -6,11 +6,12 @@ import { getExplorerTxUrl } from './constants'
 import type { FeeRates } from '@xchainjs/xchain-client'
 import { baseToAsset, baseAmount } from '@xchainjs/xchain-util'
 
-// UTXO client type with transferMax method
-interface UtxoClient {
+// Sweep-capable client. `getFeeRates`/`feeRate` are UTXO-only — Cardano has no fee rate
+// concept (the protocol params determine min_fee directly from tx size).
+interface SweepClient {
   getAddressAsync: (index: number) => Promise<string>
   getBalance: (address: string) => Promise<{ amount: { amount: () => bigint } }[]>
-  getFeeRates: () => Promise<FeeRates>
+  getFeeRates?: () => Promise<FeeRates>
   transferMax: (params: {
     recipient: string
     memo?: string
@@ -20,7 +21,7 @@ interface UtxoClient {
 
 interface SweepProps {
   chainId: string
-  client: UtxoClient | null
+  client: SweepClient | null
 }
 
 interface SweepResult {
@@ -76,12 +77,17 @@ export function Sweep({ chainId, client }: SweepProps) {
       // Fetch balance
       await fetchBalance()
 
-      // Fetch fee rate separately so balance still shows if this fails
-      try {
-        const feeRates = await client.getFeeRates()
-        setFeeRate(feeRates.fast)
-      } catch (e) {
-        console.error('Failed to fetch fee rates:', e)
+      // Fetch fee rate separately so balance still shows if this fails. Skip when the
+      // client has no fee-rate concept (e.g. Cardano).
+      if (client.getFeeRates) {
+        try {
+          const feeRates = await client.getFeeRates()
+          setFeeRate(feeRates.fast)
+        } catch (e) {
+          console.error('Failed to fetch fee rates:', e)
+          setFeeRate(null)
+        }
+      } else {
         setFeeRate(null)
       }
 

--- a/tools/xchain-suite/src/pages/ChainPage.tsx
+++ b/tools/xchain-suite/src/pages/ChainPage.tsx
@@ -25,6 +25,7 @@ type TabId =
   | 'prepare'
 
 const UTXO_CHAINS = ['BTC', 'BCH', 'LTC', 'DOGE', 'DASH', 'ZEC']
+const SWEEP_CHAINS = [...UTXO_CHAINS, 'ADA']
 
 interface Tab {
   id: TabId
@@ -37,7 +38,7 @@ const TABS: Tab[] = [
   { id: 'balance', label: 'Balance' },
   { id: 'fees', label: 'Fees' },
   { id: 'transfer', label: 'Transfer' },
-  { id: 'sweep', label: 'Sweep', chains: UTXO_CHAINS },
+  { id: 'sweep', label: 'Sweep', chains: SWEEP_CHAINS },
   { id: 'coin-control', label: 'Coin Control', chains: UTXO_CHAINS },
   { id: 'deposit', label: 'Deposit', chains: ['THOR', 'MAYA'] },
   { id: 'history', label: 'History' },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a balance sweep method for Cardano enabling single-transaction transfers of the entire spendable ADA balance to a specified recipient, with transaction hash and fee details returned.
  * Sweep functionality is now available for Cardano wallets in addition to existing supported blockchain chains, accessible via the Sweep tab.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xchainjs/xchainjs-lib/pull/1689)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->