### PR TITLE
chore(deps): propagate axios + lodash security pins to published packages

### DIFF
--- a/.changeset/security-axios-lodash-bump.md
+++ b/.changeset/security-axios-lodash-bump.md
@@ -1,0 +1,28 @@
+---
+'@xchainjs/xchain-aggregator': patch
+'@xchainjs/xchain-bitcoin': patch
+'@xchainjs/xchain-bitcoincash': patch
+'@xchainjs/xchain-client': patch
+'@xchainjs/xchain-cosmos': patch
+'@xchainjs/xchain-dash': patch
+'@xchainjs/xchain-doge': patch
+'@xchainjs/xchain-evm': patch
+'@xchainjs/xchain-evm-providers': patch
+'@xchainjs/xchain-litecoin': patch
+'@xchainjs/xchain-mayachain': patch
+'@xchainjs/xchain-mayachain-amm': patch
+'@xchainjs/xchain-mayachain-query': patch
+'@xchainjs/xchain-mayamidgard': patch
+'@xchainjs/xchain-mayamidgard-query': patch
+'@xchainjs/xchain-mayanode': patch
+'@xchainjs/xchain-midgard': patch
+'@xchainjs/xchain-midgard-query': patch
+'@xchainjs/xchain-thorchain': patch
+'@xchainjs/xchain-thorchain-amm': patch
+'@xchainjs/xchain-thorchain-query': patch
+'@xchainjs/xchain-thornode': patch
+'@xchainjs/xchain-utxo-providers': patch
+'@xchainjs/zcash-js': patch
+---
+
+Bump direct `axios` dependency from 1.15.2 to 1.16.1 across all packages that declare it. Also bumps `lodash` from `^4.18.0` to `4.18.1` in `@xchainjs/zcash-js`. This propagates the security fixes from the earlier yarn-resolutions PR to actual consumers of the published packages — root resolutions only affect builds within this repo, not what downstream installers receive. Closes axios prototype-pollution / NO_PROXY-bypass / SSRF / CRLF / DoS advisories (GHSA-* covering versions <1.16.1) and the lodash code-injection-via-template advisory for the affected published packages.

--- a/packages/xchain-aggregator/package.json
+++ b/packages/xchain-aggregator/package.json
@@ -47,7 +47,7 @@
     "@xchainjs/xchain-bsc": "workspace:*",
     "@xchainjs/xchain-ethereum": "workspace:*",
     "@xchainjs/xchain-kujira": "workspace:*",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "axios-mock-adapter": "^2.1.0"
   }
 }

--- a/packages/xchain-bitcoin/package.json
+++ b/packages/xchain-bitcoin/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "axios-mock-adapter": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/xchain-bitcoincash/package.json
+++ b/packages/xchain-bitcoincash/package.json
@@ -50,7 +50,7 @@
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
     "@types/bitcore-lib-cash": "^8.23.8",
     "@types/cashaddrjs": "^0",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "axios-mock-adapter": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/xchain-client/package.json
+++ b/packages/xchain-client/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@xchainjs/xchain-crypto": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.15.2"
+    "axios": "1.16.1"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/xchain-cosmos/package.json
+++ b/packages/xchain-cosmos/package.json
@@ -46,7 +46,7 @@
     "@xchainjs/xchain-cosmos-sdk": "workspace:*",
     "@xchainjs/xchain-crypto": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "bignumber.js": "^11.0.0",
     "cosmjs-types": "0.9.0",
     "protobufjs": "7.5.8"

--- a/packages/xchain-dash/package.json
+++ b/packages/xchain-dash/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "axios-mock-adapter": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/xchain-doge/package.json
+++ b/packages/xchain-doge/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "axios-mock-adapter": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/xchain-evm-providers/package.json
+++ b/packages/xchain-evm-providers/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@xchainjs/xchain-client": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "ethers": "^6.14.3"
   }
 }

--- a/packages/xchain-evm/package.json
+++ b/packages/xchain-evm/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@ledgerhq/hw-transport": "^6.31.6",
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "axios-mock-adapter": "^2.1.0"
   }
 }

--- a/packages/xchain-litecoin/package.json
+++ b/packages/xchain-litecoin/package.json
@@ -41,7 +41,7 @@
     "@xchainjs/xchain-util": "workspace:*",
     "@xchainjs/xchain-utxo": "workspace:*",
     "@xchainjs/xchain-utxo-providers": "workspace:*",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "bitcoinjs-lib": "^6.1.7",
     "coinselect": "3.1.12",
     "ecpair": "2.1.0"

--- a/packages/xchain-mayachain-amm/package.json
+++ b/packages/xchain-mayachain-amm/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "axios-mock-adapter": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/xchain-mayachain-query/package.json
+++ b/packages/xchain-mayachain-query/package.json
@@ -38,7 +38,7 @@
     "@xchainjs/xchain-mayamidgard-query": "workspace:*",
     "@xchainjs/xchain-mayanode": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "axios-retry": "3.2.5",
     "bignumber.js": "^11.0.0"
   },

--- a/packages/xchain-mayachain/package.json
+++ b/packages/xchain-mayachain/package.json
@@ -47,7 +47,7 @@
     "@xchainjs/xchain-cosmos-sdk": "workspace:*",
     "@xchainjs/xchain-crypto": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "bignumber.js": "^11.0.0",
     "cosmjs-types": "0.9.0",
     "protobufjs": "7.5.8"

--- a/packages/xchain-mayamidgard-query/package.json
+++ b/packages/xchain-mayamidgard-query/package.json
@@ -35,7 +35,7 @@
     "@xchainjs/xchain-client": "workspace:*",
     "@xchainjs/xchain-mayamidgard": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "axios-retry": "^3.9.1"
   },
   "devDependencies": {

--- a/packages/xchain-mayamidgard/package.json
+++ b/packages/xchain-mayamidgard/package.json
@@ -34,7 +34,7 @@
     "clean:types:midgard": "rimraf ./src/generated/midgardApi"
   },
   "dependencies": {
-    "axios": "1.15.2"
+    "axios": "1.16.1"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.20.2",

--- a/packages/xchain-mayanode/package.json
+++ b/packages/xchain-mayanode/package.json
@@ -34,7 +34,7 @@
     "clean:types:mayanode": "rimraf ./src/generated/mayanodeApi"
   },
   "dependencies": {
-    "axios": "1.15.2"
+    "axios": "1.16.1"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.20.2",

--- a/packages/xchain-midgard-query/package.json
+++ b/packages/xchain-midgard-query/package.json
@@ -35,7 +35,7 @@
     "@xchainjs/xchain-client": "workspace:*",
     "@xchainjs/xchain-midgard": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "axios-retry": "^3.9.1"
   },
   "devDependencies": {

--- a/packages/xchain-midgard/package.json
+++ b/packages/xchain-midgard/package.json
@@ -34,7 +34,7 @@
     "clean:types:midgard": "rimraf ./src/generated/midgardApi"
   },
   "dependencies": {
-    "axios": "1.15.2"
+    "axios": "1.16.1"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.20.2",

--- a/packages/xchain-thorchain-amm/package.json
+++ b/packages/xchain-thorchain-amm/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "axios-mock-adapter": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/xchain-thorchain-query/package.json
+++ b/packages/xchain-thorchain-query/package.json
@@ -37,7 +37,7 @@
     "@xchainjs/xchain-midgard-query": "workspace:*",
     "@xchainjs/xchain-thornode": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "axios-retry": "3.2.5",
     "bignumber.js": "^11.0.0"
   },

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -49,7 +49,7 @@
     "@xchainjs/xchain-cosmos-sdk": "workspace:*",
     "@xchainjs/xchain-crypto": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "bignumber.js": "^11.0.0",
     "cosmjs-types": "0.9.0",
     "protobufjs": "7.5.8"

--- a/packages/xchain-thornode/package.json
+++ b/packages/xchain-thornode/package.json
@@ -34,7 +34,7 @@
     "clean:types:thornode": "rimraf ./src/generated/thornodeApi"
   },
   "dependencies": {
-    "axios": "1.15.2"
+    "axios": "1.16.1"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.20.2",

--- a/packages/xchain-utxo-providers/package.json
+++ b/packages/xchain-utxo-providers/package.json
@@ -31,7 +31,7 @@
     "@supercharge/promise-pool": "2.4.0",
     "@xchainjs/xchain-client": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.15.2"
+    "axios": "1.16.1"
   },
   "devDependencies": {
     "axios-mock-adapter": "^2.1.0"

--- a/packages/zcash-js/package.json
+++ b/packages/zcash-js/package.json
@@ -32,11 +32,11 @@
   "dependencies": {
     "@noble/curves": "^1.7.0",
     "@noble/hashes": "^1.6.1",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "bs58check": "^4.0.0",
     "buffer": "^6.0.3",
     "json-rpc-2.0": "^1.7.0",
-    "lodash": "^4.18.0"
+    "lodash": "4.18.1"
   },
   "devDependencies": {
     "@types/lodash": "^4.17.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5031,7 +5031,7 @@ __metadata:
     "@xchainjs/xchain-thorchain-query": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-wallet": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     axios-mock-adapter: "npm:^2.1.0"
   languageName: unknown
   linkType: soft
@@ -5092,7 +5092,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-utxo": "workspace:*"
     "@xchainjs/xchain-utxo-providers": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     axios-mock-adapter: "npm:^2.1.0"
     bitcoinjs-lib: "npm:^6.1.7"
     coinselect: "npm:3.1.12"
@@ -5114,7 +5114,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-utxo": "workspace:*"
     "@xchainjs/xchain-utxo-providers": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     axios-mock-adapter: "npm:^2.1.0"
     bitcore-lib-cash: "npm:11.0.0"
     bs58check: "npm:^4.0.0"
@@ -5156,7 +5156,7 @@ __metadata:
   dependencies:
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
   languageName: unknown
   linkType: soft
 
@@ -5197,7 +5197,7 @@ __metadata:
     "@xchainjs/xchain-cosmos-sdk": "workspace:*"
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     bignumber.js: "npm:^11.0.0"
     cosmjs-types: "npm:0.9.0"
     protobufjs: "npm:7.5.8"
@@ -5230,7 +5230,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-utxo": "workspace:*"
     "@xchainjs/xchain-utxo-providers": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     axios-mock-adapter: "npm:^2.1.0"
     bitcoinjs-lib: "npm:^6.1.7"
     coinselect: "npm:3.1.12"
@@ -5251,7 +5251,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-utxo": "workspace:*"
     "@xchainjs/xchain-utxo-providers": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     axios-mock-adapter: "npm:^2.1.0"
     bitcoinjs-lib: "npm:^6.1.7"
     coinselect: "npm:3.1.12"
@@ -5279,7 +5279,7 @@ __metadata:
   dependencies:
     "@xchainjs/xchain-client": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     ethers: "npm:^6.14.3"
   languageName: unknown
   linkType: soft
@@ -5295,7 +5295,7 @@ __metadata:
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-evm-providers": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     axios-mock-adapter: "npm:^2.1.0"
     bignumber.js: "npm:^11.0.0"
     ethers: "npm:^6.14.3"
@@ -5335,7 +5335,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-utxo": "workspace:*"
     "@xchainjs/xchain-utxo-providers": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     axios-mock-adapter: "npm:^2.1.0"
     bitcoinjs-lib: "npm:^6.1.7"
     coinselect: "npm:3.1.12"
@@ -5364,7 +5364,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-wallet": "workspace:*"
     "@xchainjs/xchain-zcash": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     axios-mock-adapter: "npm:^2.1.0"
     ethers: "npm:^6.14.3"
   languageName: unknown
@@ -5379,7 +5379,7 @@ __metadata:
     "@xchainjs/xchain-mayamidgard-query": "workspace:*"
     "@xchainjs/xchain-mayanode": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     axios-mock-adapter: "npm:2.1.0"
     axios-retry: "npm:3.2.5"
     bignumber.js: "npm:^11.0.0"
@@ -5403,7 +5403,7 @@ __metadata:
     "@xchainjs/xchain-cosmos-sdk": "workspace:*"
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     bignumber.js: "npm:^11.0.0"
     cosmjs-types: "npm:0.9.0"
     protobufjs: "npm:7.5.8"
@@ -5417,7 +5417,7 @@ __metadata:
     "@xchainjs/xchain-client": "workspace:*"
     "@xchainjs/xchain-mayamidgard": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     axios-mock-adapter: "npm:^2.1.0"
     axios-retry: "npm:^3.9.1"
   languageName: unknown
@@ -5428,7 +5428,7 @@ __metadata:
   resolution: "@xchainjs/xchain-mayamidgard@workspace:packages/xchain-mayamidgard"
   dependencies:
     "@openapitools/openapi-generator-cli": "npm:^2.20.2"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     rimraf: "npm:5.0.0"
   languageName: unknown
   linkType: soft
@@ -5438,7 +5438,7 @@ __metadata:
   resolution: "@xchainjs/xchain-mayanode@workspace:packages/xchain-mayanode"
   dependencies:
     "@openapitools/openapi-generator-cli": "npm:^2.20.2"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     rimraf: "npm:5.0.0"
   languageName: unknown
   linkType: soft
@@ -5450,7 +5450,7 @@ __metadata:
     "@xchainjs/xchain-client": "workspace:*"
     "@xchainjs/xchain-midgard": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     axios-mock-adapter: "npm:^2.1.0"
     axios-retry: "npm:^3.9.1"
     dotenv: "npm:16.0.0"
@@ -5462,7 +5462,7 @@ __metadata:
   resolution: "@xchainjs/xchain-midgard@workspace:packages/xchain-midgard"
   dependencies:
     "@openapitools/openapi-generator-cli": "npm:^2.20.2"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     rimraf: "npm:5.0.0"
   languageName: unknown
   linkType: soft
@@ -5563,7 +5563,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-wallet": "workspace:*"
     "@xchainjs/xchain-zcash": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     axios-mock-adapter: "npm:^2.1.0"
     ethers: "npm:^6.14.3"
   languageName: unknown
@@ -5577,7 +5577,7 @@ __metadata:
     "@xchainjs/xchain-midgard-query": "workspace:*"
     "@xchainjs/xchain-thornode": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     axios-mock-adapter: "npm:2.1.0"
     axios-retry: "npm:3.2.5"
     bignumber.js: "npm:^11.0.0"
@@ -5603,7 +5603,7 @@ __metadata:
     "@xchainjs/xchain-cosmos-sdk": "workspace:*"
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     bignumber.js: "npm:^11.0.0"
     cosmjs-types: "npm:0.9.0"
     protobufjs: "npm:7.5.8"
@@ -5615,7 +5615,7 @@ __metadata:
   resolution: "@xchainjs/xchain-thornode@workspace:packages/xchain-thornode"
   dependencies:
     "@openapitools/openapi-generator-cli": "npm:^2.20.2"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     rimraf: "npm:5.0.0"
   languageName: unknown
   linkType: soft
@@ -5649,7 +5649,7 @@ __metadata:
     "@supercharge/promise-pool": "npm:2.4.0"
     "@xchainjs/xchain-client": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     axios-mock-adapter: "npm:^2.1.0"
   languageName: unknown
   linkType: soft
@@ -5709,11 +5709,11 @@ __metadata:
     "@noble/curves": "npm:^1.7.0"
     "@noble/hashes": "npm:^1.6.1"
     "@types/lodash": "npm:^4.17.13"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.1"
     bs58check: "npm:^4.0.0"
     buffer: "npm:^6.0.3"
     json-rpc-2.0: "npm:^1.7.0"
-    lodash: "npm:^4.18.0"
+    lodash: "npm:4.18.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Follow-up to #1694. That PR added yarn \`resolutions\` to pin vulnerable transitives in this repo's build, but yarn resolutions are a **workspace-only override** — they don't reach downstream consumers. Anyone who runs \`npm install @xchainjs/xchain-bitcoin\` (or any other published \`@xchainjs/*\` package) gets whatever version range is declared in each package's own \`package.json\`, not whatever this monorepo resolves to internally.

This PR bumps the per-package direct deps so the published packages themselves declare safe versions:

| Dep | Old | New | Packages affected |
|---|---|---|---|
| \`axios\` | \`1.15.2\` | \`1.16.1\` | 24 packages |
| \`lodash\` | \`^4.18.0\` | \`4.18.1\` | \`@xchainjs/zcash-js\` only |

Both are **exact pins**, no caret — supply-chain attacks (axios in April 2026) mean float ranges auto-pull malicious patches.

The other 8 deps from #1694's resolutions list (\`tiny-secp256k1\`, \`secp256k1\`, \`basic-ftp\`, \`tar-fs\`, \`picomatch\`, \`path-to-regexp\`, \`rollup\`, \`validator\`) don't appear as direct dependencies in any per-package \`package.json\` — they only enter the tree transitively (via \`bitcoinjs-lib\`, \`@openapitools/openapi-generator-cli\`, etc.). Consumers' resolution of those transitives depends on their direct deps' constraints, not ours, so a root resolution can't help them. Real fix for those is either upstream PRs or consumer-side overrides; documented as out-of-scope here.

## Changeset

Single changeset (\`patch\` bump for 24 packages) so the next changeset release pushes the new versions to npm.

## Verification

- [x] \`yarn install\` clean
- [x] \`yarn build\` — 43/43 packages succeed
- [x] \`yarn test\` — 86/86 packages succeed (one flake on \`xchain-utxo\` first run, passes on rerun; same flake hit #1694 too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies across all XChainJS packages to maintain system stability and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xchainjs/xchainjs-lib/pull/1695)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->