### PR TITLE
chore(github): add security-report issue template (closes loophole exploited in #1690)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a vulnerability privately
+    url: https://github.com/xchainjs/xchainjs-lib/security/advisories/new
+    about: |
+      If you have found an UNDISCLOSED security vulnerability affecting this
+      project (not already covered by a public CVE/GHSA), do NOT open a public
+      issue. Use GitHub's private security advisory flow instead so the issue
+      can be triaged and patched before disclosure.

--- a/.github/ISSUE_TEMPLATE/security-report.yml
+++ b/.github/ISSUE_TEMPLATE/security-report.yml
@@ -1,0 +1,101 @@
+name: Security advisory follow-up (public CVE/GHSA)
+description: Report a PUBLIC vulnerability (existing CVE or GHSA) in xchainjs-lib or one of its dependencies.
+title: "[Security] "
+labels: ["security"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Use this template only for vulnerabilities that are already public
+        Already-published CVE or GHSA → continue with this form.
+
+        **Undisclosed vulnerability in this repo?** Stop and use the
+        [private security advisory flow](https://github.com/xchainjs/xchainjs-lib/security/advisories/new)
+        instead. Public issues for undisclosed vulns make exploitation easier.
+
+        **Recommending a security tool, auditor, or scanner?** That is not a vulnerability
+        report. Please don't file it as one — issues that recommend installing third-party
+        "audit tools" are routinely used for social-engineering attacks against crypto
+        projects and will be closed.
+  - type: checkboxes
+    id: confirm-public
+    attributes:
+      label: Confirmations
+      options:
+        - label: This is an already-public vulnerability (CVE or GHSA exists).
+          required: true
+        - label: I am NOT recommending or promoting a third-party security tool, scanner, or auditor.
+          required: true
+  - type: input
+    id: cve
+    attributes:
+      label: CVE or GHSA ID
+      description: Must be a published advisory. Format `CVE-YYYY-NNNNN` or `GHSA-xxxx-yyyy-zzzz`.
+      placeholder: CVE-2026-12345 or GHSA-1234-5678-9abc
+    validations:
+      required: true
+  - type: input
+    id: advisory-url
+    attributes:
+      label: Upstream advisory URL
+      description: Link to the NVD, GitHub Security Advisory, or upstream maintainer's disclosure.
+      placeholder: https://nvd.nist.gov/vuln/detail/CVE-2026-12345
+    validations:
+      required: true
+  - type: input
+    id: affected-package
+    attributes:
+      label: Affected package + version
+      description: |
+        Exact name and version of the package in this repo's dependency tree that
+        is vulnerable. Check `yarn.lock` for the resolved version, not the range.
+      placeholder: "example: axios@1.15.2 (transitive via @xchainjs/xchain-cosmos)"
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: CVSS severity (from the advisory)
+      options:
+        - Critical (9.0–10.0)
+        - High (7.0–8.9)
+        - Medium (4.0–6.9)
+        - Low (0.1–3.9)
+        - Not yet scored
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Vulnerability summary
+      description: |
+        One paragraph: what the vulnerability is, the attacker capability required,
+        and the impact. Copy the advisory's summary if you don't have a custom write-up.
+      placeholder: |
+        e.g., "Axios <1.16.1 is vulnerable to prototype pollution in mergeConfig
+        via attacker-controlled __proto__ keys. Triggered when..."
+    validations:
+      required: true
+  - type: textarea
+    id: reachability
+    attributes:
+      label: Reachability in this repo
+      description: |
+        Is the vulnerable code path actually reachable through xchainjs-lib's public
+        API, or only via paths that consumers don't hit? Be specific. If you haven't
+        verified reachability, say so — "I don't know" is acceptable.
+      placeholder: |
+        e.g., "Reachable via @xchainjs/xchain-cosmos when caller passes a
+        user-controlled value into Client.transfer({...}). NOT reachable in
+        the read-only Midgard query path because Midgard responses are
+        validated before merge."
+    validations:
+      required: true
+  - type: textarea
+    id: fix
+    attributes:
+      label: Suggested fix
+      description: Version to bump to, code change, or other mitigation. Optional but speeds up triage.
+      placeholder: "Bump axios to 1.16.1 via the root resolutions block."
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Adds a GitHub issue form for public CVE/GHSA reports that forces submitters to provide specifics, plus a contact link routing undisclosed vulnerabilities to the private security-advisory flow where they belong.

### Why now

Issue #1690 was a social-engineering attempt that fit a known pattern targeting crypto/DeFi repos: a low-rep account files an "audit recommendation" suggesting maintainers \`pip install\` a typo-squatted package masquerading as a security tool, with a link to an unrelated but legit-looking repo for cover.

A structured form makes this much harder to disguise. A real security report fills in: CVE/GHSA ID, advisory URL, affected package@version, reachability analysis. A scam that recommends a "tool" can't fill any of those fields without obvious nonsense, and the second required confirmation specifically reads "I am NOT recommending or promoting a third-party security tool, scanner, or auditor."

### What the form requires

- **Public-disclosure confirmation** (checkbox) — undisclosed vulns must go to the private advisory flow instead, not be filed here.
- **No-tool-recommendation confirmation** (checkbox) — explicit, targeted at the #1690 pattern.
- **CVE or GHSA ID** (required, with format hint).
- **Upstream advisory URL** (required) — link to NVD or GHSA.
- **Affected package + version in our tree** (required) — exact \`yarn.lock\`-resolved version.
- **CVSS severity dropdown** (required).
- **Vulnerability summary** (required textarea).
- **Reachability in this repo** (required textarea) — is the vuln code path callable via our public API?
- **Suggested fix** (optional).

### What this doesn't change

- Blank issues remain enabled, so the normal bug-report / feature-request flow is unchanged.
- This is preventive, not retroactive — old issues aren't affected.
- A determined attacker can still file via a blank issue, but those stand out as having bypassed the template, which is itself a triage signal.

## Verification

- Both YAML files parse cleanly via \`js-yaml\`.
- File layout matches GitHub's [issue-forms schema](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms).
- Will only be visible after merge (GitHub picks up templates from default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)