### PR TITLE
chore(github): disable blank issues and add bug/feature/docs templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,141 @@
+name: Bug report
+description: Something in an xchainjs-lib package is broken or behaves incorrectly.
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. A reproducible report makes
+        triage dramatically faster.
+
+        **Before filing:**
+        - Search [existing issues](https://github.com/xchainjs/xchainjs-lib/issues?q=is%3Aissue) — your bug may already be reported.
+        - Usage / integration questions belong on [Discord](https://discord.com/channels/838986635756044328/842252939149967382) or [Telegram](https://t.me/xchainjs), not here.
+        - Security vulnerabilities → use the [private advisory flow](https://github.com/xchainjs/xchainjs-lib/security/advisories/new), not a public issue.
+  - type: dropdown
+    id: package
+    attributes:
+      label: Affected package
+      description: Which `@xchainjs/*` package is the bug in? Pick "Other / multiple" if it spans several.
+      options:
+        - "@xchainjs/xchain-aggregator"
+        - "@xchainjs/xchain-arbitrum"
+        - "@xchainjs/xchain-avax"
+        - "@xchainjs/xchain-base"
+        - "@xchainjs/xchain-bitcoin"
+        - "@xchainjs/xchain-bitcoincash"
+        - "@xchainjs/xchain-bsc"
+        - "@xchainjs/xchain-cardano"
+        - "@xchainjs/xchain-client"
+        - "@xchainjs/xchain-cosmos"
+        - "@xchainjs/xchain-cosmos-sdk"
+        - "@xchainjs/xchain-crypto"
+        - "@xchainjs/xchain-dash"
+        - "@xchainjs/xchain-doge"
+        - "@xchainjs/xchain-ethereum"
+        - "@xchainjs/xchain-evm"
+        - "@xchainjs/xchain-evm-providers"
+        - "@xchainjs/xchain-kujira"
+        - "@xchainjs/xchain-litecoin"
+        - "@xchainjs/xchain-mayachain"
+        - "@xchainjs/xchain-mayachain-amm"
+        - "@xchainjs/xchain-mayachain-query"
+        - "@xchainjs/xchain-mayamidgard"
+        - "@xchainjs/xchain-mayamidgard-query"
+        - "@xchainjs/xchain-mayanode"
+        - "@xchainjs/xchain-midgard"
+        - "@xchainjs/xchain-midgard-query"
+        - "@xchainjs/xchain-monero"
+        - "@xchainjs/xchain-radix"
+        - "@xchainjs/xchain-ripple"
+        - "@xchainjs/xchain-solana"
+        - "@xchainjs/xchain-sui"
+        - "@xchainjs/xchain-thorchain"
+        - "@xchainjs/xchain-thorchain-amm"
+        - "@xchainjs/xchain-thorchain-query"
+        - "@xchainjs/xchain-thornode"
+        - "@xchainjs/xchain-tron"
+        - "@xchainjs/xchain-util"
+        - "@xchainjs/xchain-utxo"
+        - "@xchainjs/xchain-utxo-providers"
+        - "@xchainjs/xchain-wallet"
+        - "@xchainjs/xchain-zcash"
+        - "zcash-js"
+        - "Other / multiple"
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Package version
+      description: Exact version installed (check `yarn.lock` or your `node_modules/.../package.json`, not the range in your `package.json`).
+      placeholder: "1.2.3"
+    validations:
+      required: true
+  - type: input
+    id: network
+    attributes:
+      label: Network
+      description: Mainnet, stagenet, testnet, or N/A.
+      placeholder: "mainnet"
+    validations:
+      required: false
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Briefly describe the bug — what you observed vs. what you expected.
+      placeholder: |
+        e.g., "Calling client.transfer() on xchain-thorchain with a memo longer
+        than 250 chars silently drops the memo instead of throwing."
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: |
+        Steps and/or a minimal code snippet that reproduces the bug. Smaller is
+        much better than complete — strip everything that isn't load-bearing.
+      render: ts
+      placeholder: |
+        import { Client } from '@xchainjs/xchain-thorchain'
+        const c = new Client({ network: Network.Mainnet })
+        await c.transfer({ /* ... */ })
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: "Expected the transfer to throw a validation error for memos > 250 bytes."
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include the full error message and stack trace if there is one.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: Node version, OS, package manager, framework (if any).
+      placeholder: |
+        - Node: 20.11.0
+        - OS: macOS 14.5 / Ubuntu 22.04 / Windows 11
+        - Package manager: yarn 4.9.2
+        - Runtime: Node / React Native / browser (bundler?)
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Anything else worth knowing — related issues, recent upgrade, workarounds tried.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug report
 description: Something in an xchainjs-lib package is broken or behaves incorrectly.
 title: "[Bug] "
-labels: ["bug"]
+labels: [bug]
 body:
   - type: markdown
     attributes:
@@ -61,8 +61,8 @@ body:
         - "@xchainjs/xchain-utxo-providers"
         - "@xchainjs/xchain-wallet"
         - "@xchainjs/xchain-zcash"
-        - "zcash-js"
-        - "Other / multiple"
+        - zcash-js
+        - Other / multiple
     validations:
       required: true
   - type: input
@@ -70,7 +70,7 @@ body:
     attributes:
       label: Package version
       description: Exact version installed (check `yarn.lock` or your `node_modules/.../package.json`, not the range in your `package.json`).
-      placeholder: "1.2.3"
+      placeholder: 1.2.3
     validations:
       required: true
   - type: input
@@ -78,7 +78,7 @@ body:
     attributes:
       label: Network
       description: Mainnet, stagenet, testnet, or N/A.
-      placeholder: "mainnet"
+      placeholder: mainnet
     validations:
       required: false
   - type: textarea
@@ -109,7 +109,7 @@ body:
     id: expected
     attributes:
       label: Expected behavior
-      placeholder: "Expected the transfer to throw a validation error for memos > 250 bytes."
+      placeholder: Expected the transfer to throw a validation error for memos > 250 bytes.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Report a vulnerability privately
     url: https://github.com/xchainjs/xchainjs-lib/security/advisories/new
@@ -7,3 +7,12 @@ contact_links:
       project (not already covered by a public CVE/GHSA), do NOT open a public
       issue. Use GitHub's private security advisory flow instead so the issue
       can be triaged and patched before disclosure.
+  - name: Ask a question on Discord
+    url: https://discord.com/channels/838986635756044328/842252939149967382
+    about: |
+      Usage questions, integration help, "how do I…" — please ask in Discord
+      first. The issue tracker is for bug reports and feature requests.
+  - name: Ask a question on Telegram
+    url: https://t.me/xchainjs
+    about: |
+      Alternative community channel for usage questions and general discussion.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,7 +1,7 @@
 name: Documentation issue
 description: README, package docs, or code comments are wrong, missing, or misleading.
 title: "[Docs] "
-labels: ["documentation"]
+labels: [documentation]
 body:
   - type: markdown
     attributes:
@@ -16,7 +16,7 @@ body:
     attributes:
       label: Where is the issue?
       description: Link to the file, line, or rendered page. Permalinks (with commit SHA) are ideal.
-      placeholder: "https://github.com/xchainjs/xchainjs-lib/blob/master/packages/xchain-thorchain/README.md#L42"
+      placeholder: https://github.com/xchainjs/xchainjs-lib/blob/master/packages/xchain-thorchain/README.md#L42
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,48 @@
+name: Documentation issue
+description: README, package docs, or code comments are wrong, missing, or misleading.
+title: "[Docs] "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for documentation problems — typos, broken examples,
+        outdated API signatures, missing usage notes, etc.
+
+        Behavior bugs (the docs are correct but the code does the wrong thing)
+        belong in the **Bug report** template instead.
+  - type: input
+    id: location
+    attributes:
+      label: Where is the issue?
+      description: Link to the file, line, or rendered page. Permalinks (with commit SHA) are ideal.
+      placeholder: "https://github.com/xchainjs/xchainjs-lib/blob/master/packages/xchain-thorchain/README.md#L42"
+    validations:
+      required: true
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind of problem
+      options:
+        - Incorrect / outdated information
+        - Broken or non-runnable example
+        - Missing documentation
+        - Typo / formatting
+        - Unclear or ambiguous
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's wrong?
+      description: Quote the problematic text or describe what's missing.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested correction
+      description: If you know the right answer, share it. PRs welcome.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,83 @@
+name: Feature request
+description: Suggest a new capability, API, or chain integration for xchainjs-lib.
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing an improvement. Strong feature requests describe a
+        concrete problem and at least one proposed shape for the solution —
+        please avoid open-ended "it would be nice if…" framing.
+
+        **Before filing:**
+        - Search [existing issues](https://github.com/xchainjs/xchainjs-lib/issues?q=is%3Aissue) — your idea may already be tracked.
+        - Usage / "how do I…" questions belong on [Discord](https://discord.com/channels/838986635756044328/842252939149967382) or [Telegram](https://t.me/xchainjs).
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: What kind of change is this?
+      options:
+        - New chain / asset support
+        - New API or method on an existing package
+        - Enhancement to existing behavior
+        - Developer experience (tooling, types, docs ergonomics)
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: package
+    attributes:
+      label: Target package(s)
+      description: Which `@xchainjs/*` package(s) would this affect? Use "new package" if you're proposing a new chain integration.
+      placeholder: "@xchainjs/xchain-thorchain-amm, or 'new package: @xchainjs/xchain-foo'"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do, and why is it hard or impossible today? Be concrete — name the call site or the missing primitive.
+      placeholder: |
+        e.g., "I'm building a wallet that needs to display pending inbound swap
+        status. xchain-thorchain-query exposes finalized swaps but not the
+        pre-finality observation count, so the UI can't show progress."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Sketch the API or behavior change. Pseudo-code or a type signature is fine; you do not need a full implementation.
+      render: ts
+      placeholder: |
+        // e.g. extend ThorchainQuery:
+        getSwapObservations(txid: string): Promise<{
+          observed: number
+          required: number
+          status: 'pending' | 'finalized'
+        }>
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed, or workarounds you're currently using.
+    validations:
+      required: false
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Links to specs, upstream chain docs, related issues, prior art in other libraries.
+    validations:
+      required: false
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Are you willing to help?
+      options:
+        - label: I am willing to open a PR for this.
+        - label: I can help test a PR if someone else implements it.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: Suggest a new capability, API, or chain integration for xchainjs-lib.
 title: "[Feature] "
-labels: ["enhancement"]
+labels: [enhancement]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary
- Disable blank issues (`blank_issues_enabled: false`) so every new issue goes through a structured template.
- Add **bug report**, **feature request**, and **documentation** templates alongside the existing security-report template.
- Add Discord and Telegram contact links to `config.yml` so usage / "how do I…" questions have a non-issue outlet.

The bug-report template includes a package dropdown listing every package under `packages/` (validated 1:1 against the directory) so triage can route quickly in this monorepo.

## Test plan
- [ ] Open the "New issue" page on this branch and confirm the blank option is gone.
- [ ] Confirm Bug report, Feature request, Documentation, and Security advisory templates all appear.
- [ ] Confirm Discord, Telegram, and the private security-advisory link appear under contact links.
- [x] Render each template and confirm dropdowns / required fields behave as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added structured issue forms for bug reports, feature requests, and documentation issues to standardize submissions.
  * Bug form collects package, version, reproduction steps, expected vs actual behavior, environment, and optional context.
  * Feature form captures scope, target package, use case, proposed solution, and contribution willingness.
  * Documentation form gathers location, issue type, problem description, and optional suggested correction.
  * Disabled blank issues and added Telegram and Discord contact links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xchainjs/xchainjs-lib/pull/1698)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->