### PR TITLE
add ADA to maya AMM

### DIFF
--- a/.changeset/mayachain-ada-swap-support.md
+++ b/.changeset/mayachain-ada-swap-support.md
@@ -1,0 +1,6 @@
+---
+'@xchainjs/xchain-mayachain-query': patch
+'@xchainjs/xchain-mayachain-amm': patch
+---
+
+Add Cardano (ADA) support to MAYAChain swap estimation and execution. `MayachainQuery.getDustValues()` now includes an ADA entry (1 ADA), so `quoteSwap`/`estimateSwap` for ADA no longer throws `No dust value known for ADA chain` and returns a valid quote. `MayachainAMM` now registers an ADA client in its default wallet so ADA swaps can be executed (previously `getClient('ADA')` threw `Client not found for ADA chain`). ADA address validation was already supported.

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,19 @@
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.9.2.cjs
+
+# CI gates on `yarn npm audit --all --severity high`. The advisory below is ignored because
+# it is not reachable in this repo:
+#
+#   GHSA-5xrq-8626-4rwp (vitest <4.1.0, critical) — "Vitest UI server arbitrary file
+#   read/execute". Only affects setups that expose the Vitest UI server to the network
+#   (--api.host / api.host) or run UI/Browser Mode on Windows. xchain-suite (the only
+#   dependent) never starts the Vitest UI — `test:run` uses headless `vitest run`, and its
+#   tests are not executed in CI (`test` is a no-op). The only patched version is 4.1.0+,
+#   which is a major vite/vitest toolchain bump tracked as separate work. Remove this entry
+#   once xchain-suite is on vitest >= 4.1.0.
+#
+# Note: yarn matches advisories by their numeric registry ID (shown as "ID" in the audit
+# report), not the GHSA slug. 1120011 == GHSA-5xrq-8626-4rwp.
+npmAuditIgnoreAdvisories:
+  - '1120011'

--- a/packages/xchain-mayachain-amm/src/mayachain-amm.ts
+++ b/packages/xchain-mayachain-amm/src/mayachain-amm.ts
@@ -2,6 +2,7 @@
  * Import necessary modules and libraries
  */
 import { Client as ArbClient, defaultArbParams } from '@xchainjs/xchain-arbitrum'
+import { Client as AdaClient, defaultAdaParams } from '@xchainjs/xchain-cardano'
 import { defaultZECParams, Client as ZecClient } from '@xchainjs/xchain-zcash'
 import { Client as BtcClient, defaultBTCParams as defaultBtcParams } from '@xchainjs/xchain-bitcoin'
 import { Network } from '@xchainjs/xchain-client'
@@ -76,6 +77,7 @@ export class MayachainAMM {
       MAYA: new MayaClient({ network: Network.Mainnet }),
       XRD: new RadixClient({ network: Network.Mainnet }),
       ZEC: new ZecClient({ ...defaultZECParams, network: Network.Mainnet }),
+      ADA: new AdaClient({ ...defaultAdaParams, network: Network.Mainnet }),
     }),
   ) {
     this.mayachainQuery = mayachainQuery

--- a/packages/xchain-mayachain-query/__tests__/mayachain-query.test.ts
+++ b/packages/xchain-mayachain-query/__tests__/mayachain-query.test.ts
@@ -173,6 +173,13 @@ describe('Mayachain-query tests', () => {
     expect(await mayachainQuery.getAssetDecimals(assetFromStringEx('KUJI.USK') as TokenAsset)).toBe(6)
   })
 
+  it('Should return the ADA dust value (1 ADA) without throwing', () => {
+    const dust = mayachainQuery.getChainDustValue('ADA')
+    expect(assetToString(dust.asset)).toBe('ADA.ADA')
+    expect(dust.baseAmount.amount().toString()).toBe('1000000')
+    expect(dust.baseAmount.decimal).toBe(6)
+  })
+
   it('Should get swaps history', async () => {
     const swapResume = await mayachainQuery.getSwapHistory({ addresses: ['address'] })
     expect(swapResume.count === swapResume.swaps.length)

--- a/packages/xchain-mayachain-query/src/mayachain-query.ts
+++ b/packages/xchain-mayachain-query/src/mayachain-query.ts
@@ -38,6 +38,8 @@ import {
   TransactionAction,
 } from './types'
 import {
+  AdaAsset,
+  AdaChain,
   ArbAsset,
   ArbChain,
   BtcAsset,
@@ -238,6 +240,8 @@ export class MayachainQuery {
       [ArbChain]: new AssetCryptoAmount(baseAmount(0, 18), ArbAsset),
       [XdrChain]: new AssetCryptoAmount(baseAmount(0, 18), XdrAsset),
       [ZecChain]: new AssetCryptoAmount(baseAmount(1000, 8), ZecAsset),
+      // 1 ADA in lovelace (6 decimals); matches MAYAChain's 1 ADA inbound minimum.
+      [AdaChain]: new AssetCryptoAmount(baseAmount(1000000, 6), AdaAsset),
     }
   }
 

--- a/packages/xchain-mayachain-query/src/utils/const.ts
+++ b/packages/xchain-mayachain-query/src/utils/const.ts
@@ -10,6 +10,7 @@ export const KujiraAsset = assetFromStringEx('KUJI.KUJI') as Asset
 export const ArbAsset = assetFromStringEx('ARB.ETH') as Asset
 export const XdrAsset = assetFromStringEx('XRD.XRD') as Asset
 export const ZecAsset = assetFromStringEx('ZEC.ZEC') as Asset
+export const AdaAsset = assetFromStringEx('ADA.ADA') as Asset
 
 export const BtcChain = 'BTC'
 export const EthChain = 'ETH'
@@ -20,6 +21,7 @@ export const KujiraChain = 'KUJI'
 export const ArbChain = 'ARB'
 export const XdrChain = 'XRD'
 export const ZecChain = 'ZEC'
+export const AdaChain = 'ADA'
 
 export const DEFAULT_MAYACHAIN_DECIMALS = 8
 export const MAYA_DECIMAL = 4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cardano (ADA) is now supported for MAYAChain swap quoting and execution; ADA dust values are configured and ADA clients register automatically. ADA address validation remains supported.

* **Tests**
  * Added test coverage verifying ADA dust value retrieval.

* **Chores**
  * CI/tooling config updated to suppress a known advisory warning until an upstream patch is applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->