### PR TITLE
Fix/cardano memo metadata 6676

### DIFF
--- a/.changeset/cardano-memo-metadata-6676.md
+++ b/.changeset/cardano-memo-metadata-6676.md
@@ -1,0 +1,5 @@
+---
+'@xchainjs/xchain-cardano': patch
+---
+
+Emit the swap memo as CIP-20 transaction-message metadata (label `674`, shape `{"msg": [chunks]}`) inside Conway-era (CBOR tag 259) auxiliary data. Previously the memo was written to label `674` as a bare text value, which is not CIP-20, so MAYA's Cardano observer could not parse it and memo-carrying swaps/deposits were refunded with an empty memo. The memo is now split into chunks of at most 64 UTF-8 bytes (without splitting a multi-byte codepoint) as required for Cardano metadata text values. Verified against successful on-chain ADA->MAYA swaps, which all use label 674 / `msg`.

--- a/.changeset/mayachain-amm-ada-feerate.md
+++ b/.changeset/mayachain-amm-ada-feerate.md
@@ -1,0 +1,5 @@
+---
+'@xchainjs/xchain-mayachain-amm': patch
+---
+
+Fix ADA (Cardano) swap execution: `makeNonProtocolAction` no longer calls `wallet.getFeeRates` for Cardano. The Cardano client derives its fee internally from on-chain protocol params and has no per-byte fee rate, so the call threw `getFeeRates method not supported in ADA chain` and the swap could not be broadcast. ADA now takes the same no-feeRate transfer path as BFT/Cosmos chains. Follow-up to the ADA swap support added in #1700.

--- a/packages/xchain-cardano/__mocks__/@emurgo/cardano-serialization-lib-browser.js
+++ b/packages/xchain-cardano/__mocks__/@emurgo/cardano-serialization-lib-browser.js
@@ -35,22 +35,32 @@ const Cardano = {
     }),
   },
   TransactionBuilder: {
-    new: jest.fn().mockImplementation((_config) => ({
-      add_input: jest.fn().mockReturnThis(),
-      add_output: jest.fn().mockReturnThis(),
-      add_regular_input: jest.fn().mockReturnThis(),
-      set_ttl: jest.fn().mockReturnThis(),
-      add_inputs_from: jest.fn().mockReturnThis(),
-      add_change_if_needed: jest.fn().mockReturnThis(),
-      set_metadata: jest.fn().mockReturnThis(),
-      set_fee: jest.fn().mockReturnThis(),
-      min_fee: jest.fn().mockReturnValue({
-        to_str: jest.fn().mockReturnValue('155381'),
-      }),
-      build_tx: jest.fn().mockReturnValue({
-        to_hex: jest.fn().mockReturnValue('mock-tx-hex'),
-      }),
-    })),
+    new: jest.fn().mockImplementation((_config) => {
+      const builder = {
+        add_input: jest.fn().mockReturnThis(),
+        add_output: jest.fn().mockReturnThis(),
+        add_regular_input: jest.fn().mockReturnThis(),
+        set_ttl: jest.fn().mockReturnThis(),
+        add_inputs_from: jest.fn().mockReturnThis(),
+        add_change_if_needed: jest.fn().mockReturnThis(),
+        // Legacy label-674 path. Kept so tests can assert the memo path no longer uses it.
+        set_metadata: jest.fn().mockReturnThis(),
+        // Conway aux-data path. Records the attached AuxiliaryData for introspection in tests.
+        set_auxiliary_data: jest.fn(function (auxData) {
+          this._auxData = auxData
+          return this
+        }),
+        set_fee: jest.fn().mockReturnThis(),
+        min_fee: jest.fn().mockReturnValue({
+          to_str: jest.fn().mockReturnValue('155381'),
+        }),
+        build_tx: jest.fn().mockReturnValue({
+          to_hex: jest.fn().mockReturnValue('mock-tx-hex'),
+        }),
+      }
+      Cardano.__builders.push(builder)
+      return builder
+    }),
   },
   TransactionBuilderConfigBuilder: {
     new: jest.fn().mockReturnValue({
@@ -67,7 +77,8 @@ const Cardano = {
     new: jest.fn().mockReturnValue({}),
   },
   BigNum: {
-    from_str: jest.fn().mockReturnValue({}),
+    // Records the string so tests can assert which metadata label was used (6676 vs legacy 674).
+    from_str: jest.fn().mockImplementation((value) => ({ value })),
   },
   TransactionOutput: {
     new: jest.fn().mockImplementation((_address, _value) => ({
@@ -105,14 +116,91 @@ const Cardano = {
   CoinSelectionStrategyCIP2: {
     LargestFirst: {},
   },
+  // Metadata is modelled as plain tagged objects so the structure the client builds can be
+  // introspected and decoded back to JSON the way the real serialization library would.
   GeneralTransactionMetadata: {
-    new: jest.fn().mockReturnValue({
-      insert: jest.fn().mockReturnThis(),
+    new: jest.fn().mockImplementation(() => {
+      const byLabel = new Map()
+      return {
+        insert: jest.fn(function (label, metadatum) {
+          byLabel.set(label.value, metadatum)
+          return this
+        }),
+        get: (label) => byLabel.get(label.value),
+      }
+    }),
+  },
+  MetadataList: {
+    new: jest.fn().mockImplementation(() => {
+      const items = []
+      return {
+        items,
+        add: jest.fn((metadatum) => items.push(metadatum)),
+      }
+    }),
+  },
+  MetadataMap: {
+    new: jest.fn().mockImplementation(() => {
+      const entries = []
+      return {
+        entries,
+        insert: jest.fn(function (key, value) {
+          entries.push([key, value])
+          return this
+        }),
+      }
     }),
   },
   TransactionMetadatum: {
-    new_text: jest.fn().mockReturnValue({}),
+    new_text: jest.fn().mockImplementation((text) => ({ kind: 'text', text })),
+    new_list: jest.fn().mockImplementation((list) => ({ kind: 'list', list })),
+    new_map: jest.fn().mockImplementation((map) => ({ kind: 'map', map })),
   },
+  AuxiliaryData: {
+    new: jest.fn().mockImplementation(() => {
+      const auxData = {
+        _metadata: undefined,
+        _preferAlonzo: false,
+        set_metadata: jest.fn(function (metadata) {
+          this._metadata = metadata
+        }),
+        set_prefer_alonzo_format: jest.fn(function (prefer) {
+          this._preferAlonzo = prefer
+        }),
+        metadata() {
+          return this._metadata
+        },
+      }
+      return auxData
+    }),
+  },
+  MetadataJsonSchema: {
+    BasicConversions: 'BasicConversions',
+  },
+  // Mirrors @emurgo's decode_metadatum_to_json_str for the tagged objects above: text -> string,
+  // list -> array, map (text keys only) -> object. Sufficient for the swap-memo shape.
+  decode_metadatum_to_json_str: jest.fn().mockImplementation((metadatum) => {
+    const decode = (node) => {
+      switch (node.kind) {
+        case 'text':
+          return node.text
+        case 'list':
+          return node.list.items.map(decode)
+        case 'map': {
+          const obj = {}
+          for (const [key, value] of node.map.entries) obj[decode(key)] = decode(value)
+          return obj
+        }
+        default:
+          throw new Error(`Unsupported metadatum kind: ${node.kind}`)
+      }
+    }
+    return JSON.stringify(decode(metadatum))
+  }),
 }
+
+// Records every TransactionBuilder created during a test so assertions can inspect the auxiliary
+// data attached to the builder for a given prepareTx/prepareMaxTx call.
+Cardano.__builders = []
 
 module.exports = Cardano

--- a/packages/xchain-cardano/__tests__/client.test.ts
+++ b/packages/xchain-cardano/__tests__/client.test.ts
@@ -3,6 +3,36 @@ import { assetAmount, assetToBase, assetToString, baseAmount, eqAsset } from '@x
 
 import cardanoApi from '../__mocks__/cardano/api'
 import { ADAAsset, Client, defaultAdaParams } from '../src'
+import { chunkMemoUtf8 } from '../src/utils'
+import { getCardano } from '../src/wasm'
+
+// Inspects the auxiliary data the client attached to the most recently built transaction. The CSL
+// mock records every builder it creates on __builders, and prepareTx builds exactly one, so the
+// last builder is the one for the call under test. Returns the CIP-20 message decoded from metadata
+// label 674 ({msg: [chunks]}), whether the legacy bare-text set_metadata path was used, and whether
+// the Conway tag-259 (prefer-alonzo) form was requested. Real CBOR-byte validation against live
+// MAYA is done manually in xchain-suite; the stub mock can't produce real serialization.
+const inspectLastBuiltTx = async () => {
+  const cardanoLib = await getCardano()
+  const builders = (cardanoLib as unknown as { __builders: { _auxData?: AttachedAuxData; set_metadata: jest.Mock }[] })
+    .__builders
+  const builder = builders[builders.length - 1]
+  const auxData = builder._auxData
+  const legacyMetadataUsed = builder.set_metadata.mock.calls.length > 0
+  if (!auxData) return { auxData: undefined, legacyMetadataUsed, preferAlonzo: false, msg: undefined }
+  const metadatum = auxData.metadata()?.get(cardanoLib.BigNum.from_str('674'))
+  const msg = metadatum
+    ? (JSON.parse(
+        cardanoLib.decode_metadatum_to_json_str(metadatum, cardanoLib.MetadataJsonSchema.BasicConversions),
+      ) as { msg: string[] })
+    : undefined
+  return { auxData, legacyMetadataUsed, preferAlonzo: auxData._preferAlonzo, msg }
+}
+
+type AttachedAuxData = {
+  _preferAlonzo: boolean
+  metadata: () => { get: (label: { value: string }) => unknown } | undefined
+}
 
 describe('Cardano client', () => {
   let client: Client
@@ -102,6 +132,57 @@ describe('Cardano client', () => {
 
       expect(typeof rawUnsignedTx).toBe('string')
       expect(rawUnsignedTx.length).toBeGreaterThan(0)
+    })
+
+    const memoSender =
+      'addr1qy8ac7qqy0vtulyl7wntmsxc6wex80gvcyjy33qffrhm7sh927ysx5sftuw0dlft05dz3c7revpf7jx0xnlcjz3g69mq4afdhv'
+
+    it('Should not attach auxiliary data when no memo is given', async () => {
+      await client.prepareTx({
+        sender: memoSender,
+        recipient: memoSender,
+        amount: assetToBase(assetAmount(1, 6)),
+      })
+
+      const { auxData, legacyMetadataUsed } = await inspectLastBuiltTx()
+      expect(auxData).toBeUndefined()
+      expect(legacyMetadataUsed).toBe(false)
+    })
+
+    it('Should embed a short memo at CIP-20 label 674 as {msg: [chunks]} in Conway (prefer-alonzo) aux data', async () => {
+      const memo = '=:ADA.ADA:addr1...:0/1/0'
+
+      await client.prepareTx({
+        sender: memoSender,
+        recipient: memoSender,
+        amount: assetToBase(assetAmount(1, 6)),
+        memo,
+      })
+
+      const { msg: decoded, preferAlonzo, legacyMetadataUsed } = await inspectLastBuiltTx()
+      expect(decoded).toEqual({ msg: [memo] })
+      // prefer-alonzo emits the CBOR tag-259 form the MAYA Cardano observer reads the memo from.
+      expect(preferAlonzo).toBe(true)
+      // The legacy bare-text set_metadata path must no longer be used.
+      expect(legacyMetadataUsed).toBe(false)
+    })
+
+    it('Should split a long memo into <=64-byte chunks at CIP-20 label 674', async () => {
+      const longMemo = 'A'.repeat(150)
+
+      await client.prepareTx({
+        sender: memoSender,
+        recipient: memoSender,
+        amount: assetToBase(assetAmount(1, 6)),
+        memo: longMemo,
+      })
+
+      const { msg: decoded } = await inspectLastBuiltTx()
+      const chunks = decoded!.msg
+      expect(chunks).toEqual(chunkMemoUtf8(longMemo))
+      expect(chunks.join('')).toBe(longMemo)
+      expect(chunks.length).toBe(3)
+      expect(chunks.every((chunk) => new TextEncoder().encode(chunk).length <= 64)).toBe(true)
     })
 
     it('Should reject a prepareTx that drains the wallet (amount > balance - fee)', async () => {
@@ -253,6 +334,31 @@ describe('Cardano client', () => {
           'https://adastat.net/transactions/f479bd4b1a77a61ce90248065d903ccee8629351132d77fae90cda73731fd0d3',
         )
       })
+    })
+  })
+
+  describe('chunkMemoUtf8', () => {
+    it('Should return an empty array for an empty memo', () => {
+      expect(chunkMemoUtf8('')).toEqual([])
+    })
+
+    it('Should keep a memo at or below 64 bytes as a single chunk', () => {
+      const memo = 'A'.repeat(64)
+      expect(chunkMemoUtf8(memo)).toEqual([memo])
+    })
+
+    it('Should split a 65-byte memo into two chunks', () => {
+      const memo = 'A'.repeat(65)
+      expect(chunkMemoUtf8(memo)).toEqual(['A'.repeat(64), 'A'])
+    })
+
+    it('Should chunk by UTF-8 byte length without splitting a multi-byte codepoint', () => {
+      // '€' is 3 UTF-8 bytes. 63 'A' (63 bytes) + '€' would be 66 bytes, so the euro sign must
+      // start a new chunk rather than being split across the 64-byte boundary.
+      const memo = 'A'.repeat(63) + '€'
+      const chunks = chunkMemoUtf8(memo)
+      expect(chunks).toEqual(['A'.repeat(63), '€'])
+      expect(chunks.every((chunk) => new TextEncoder().encode(chunk).length <= 64)).toBe(true)
     })
   })
 

--- a/packages/xchain-cardano/src/client.ts
+++ b/packages/xchain-cardano/src/client.ts
@@ -1,4 +1,8 @@
-import { type Bip32PrivateKey, type TransactionBuilder } from '@emurgo/cardano-serialization-lib-browser'
+import {
+  type AuxiliaryData,
+  type Bip32PrivateKey,
+  type TransactionBuilder,
+} from '@emurgo/cardano-serialization-lib-browser'
 import {
   AssetInfo,
   BaseXChainClient,
@@ -21,8 +25,18 @@ import WAValidator from 'multicoin-address-validator'
 import { BlockFrostClient } from './blockfrost-client'
 import { ADAAsset, ADAChain, ADA_DECIMALS, LOWER_FEE_BOUND, UPPER_FEE_BOUND, defaultAdaParams } from './const'
 import { ADAClientParams, Balance, Tx, TxParams } from './types'
-import { getCardanoNetwork } from './utils'
+import { chunkMemoUtf8, getCardanoNetwork } from './utils'
 import { getCardano } from './wasm'
+
+/**
+ * CIP-20 transaction-message metadata label. MAYA's Cardano observer reads the swap memo from the
+ * standard CIP-20 location: label 674 as the map {"msg": [chunks]} inside Conway-era (CBOR tag 259)
+ * auxiliary data. The previous code used label 674 but as a bare text value, which is not CIP-20 and
+ * the observer could not parse. (The mayanode quote `notes` field currently advertises label 6676 /
+ * {"memo": [...]}, but on-chain reality is that only 674 / {"msg": [...]} is observed — verified
+ * against successful ADA->MAYA swaps and a failed 6676 attempt.)
+ */
+const MEMO_METADATA_LABEL = '674'
 
 export class Client extends BaseXChainClient {
   private explorerProviders: ExplorerProviders
@@ -445,10 +459,9 @@ export class Client extends BaseXChainClient {
     }
     txBuilder.add_inputs_from(unspentOutputs, cardanoLib.CoinSelectionStrategyCIP2.LargestFirst)
 
-    if (memo) {
-      const metadata = cardanoLib.GeneralTransactionMetadata.new()
-      metadata.insert(cardanoLib.BigNum.from_str('674'), cardanoLib.TransactionMetadatum.new_text(memo))
-      txBuilder.set_metadata(metadata)
+    const auxData = this.buildMemoAuxiliaryData(cardanoLib, memo)
+    if (auxData) {
+      txBuilder.set_auxiliary_data(auxData)
     }
 
     // Validate that the input set covers amount + fee BEFORE add_change_if_needed.
@@ -534,10 +547,9 @@ export class Client extends BaseXChainClient {
         txBuilder.add_regular_input(senderAddr, input, value)
       }
 
-      if (memo) {
-        const metadata = cardanoLib.GeneralTransactionMetadata.new()
-        metadata.insert(cardanoLib.BigNum.from_str('674'), cardanoLib.TransactionMetadatum.new_text(memo))
-        txBuilder.set_metadata(metadata)
+      const auxData = this.buildMemoAuxiliaryData(cardanoLib, memo)
+      if (auxData) {
+        txBuilder.set_auxiliary_data(auxData)
       }
 
       return txBuilder
@@ -673,6 +685,39 @@ export class Client extends BaseXChainClient {
       .derive(1852 | 0x80000000)
       .derive(1815 | 0x80000000)
       .derive(walletIndex | 0x80000000)
+  }
+
+  /**
+   * Builds Conway-era (CBOR tag 259) auxiliary data carrying the swap memo in the CIP-20 shape MAYA's
+   * Cardano observer reads: metadata label 674 -> {"msg": [chunks]}, where each chunk is at most
+   * 64 UTF-8 bytes. {@link AuxiliaryData.set_prefer_alonzo_format} is forced on so the tag-259 form
+   * is emitted regardless of the serialization library's default.
+   *
+   * @param {Awaited<ReturnType<typeof getCardano>>} cardanoLib - The loaded serialization library.
+   * @param {string} [memo] - The memo to embed. An empty/undefined memo yields no auxiliary data.
+   * @returns {AuxiliaryData | undefined} The auxiliary data, or undefined when there is no memo.
+   */
+  private buildMemoAuxiliaryData(
+    cardanoLib: Awaited<ReturnType<typeof getCardano>>,
+    memo?: string,
+  ): AuxiliaryData | undefined {
+    if (!memo) return undefined
+
+    const msgList = cardanoLib.MetadataList.new()
+    for (const chunk of chunkMemoUtf8(memo)) {
+      msgList.add(cardanoLib.TransactionMetadatum.new_text(chunk))
+    }
+
+    const msgMap = cardanoLib.MetadataMap.new()
+    msgMap.insert(cardanoLib.TransactionMetadatum.new_text('msg'), cardanoLib.TransactionMetadatum.new_list(msgList))
+
+    const metadata = cardanoLib.GeneralTransactionMetadata.new()
+    metadata.insert(cardanoLib.BigNum.from_str(MEMO_METADATA_LABEL), cardanoLib.TransactionMetadatum.new_map(msgMap))
+
+    const auxData = cardanoLib.AuxiliaryData.new()
+    auxData.set_metadata(metadata)
+    auxData.set_prefer_alonzo_format(true)
+    return auxData
   }
 
   private async getTransactionBuilder(): Promise<TransactionBuilder> {

--- a/packages/xchain-cardano/src/utils.ts
+++ b/packages/xchain-cardano/src/utils.ts
@@ -12,6 +12,43 @@ export const getCardanoNetwork = async (network: Network): Promise<NetworkInfo> 
   }
   return networkMap[network]
 }
+/**
+ * Maximum size, in bytes, of a single Cardano transaction metadata text value. Values longer
+ * than this must be stored as a list of chunks.
+ */
+export const MEMO_CHUNK_MAX_BYTES = 64
+
+/**
+ * Splits a memo into chunks of at most {@link MEMO_CHUNK_MAX_BYTES} UTF-8 bytes without splitting
+ * a multi-byte codepoint across a chunk boundary. The boundary is governed by UTF-8 byte length,
+ * not character count, so multi-byte characters are kept whole.
+ *
+ * @param {string} memo - The memo to split.
+ * @returns {string[]} The memo split into <=64-byte chunks. Empty for an empty memo.
+ */
+export const chunkMemoUtf8 = (memo: string): string[] => {
+  const encoder = new TextEncoder()
+  const chunks: string[] = []
+  let current = ''
+  let currentBytes = 0
+
+  // Iterating a string with for...of yields whole codepoints, so a multi-byte character is never
+  // split. A single codepoint is at most 4 bytes, so it always fits within a 64-byte chunk.
+  for (const codepoint of memo) {
+    const size = encoder.encode(codepoint).length
+    if (currentBytes + size > MEMO_CHUNK_MAX_BYTES) {
+      chunks.push(current)
+      current = ''
+      currentBytes = 0
+    }
+    current += codepoint
+    currentBytes += size
+  }
+  if (current.length > 0) chunks.push(current)
+
+  return chunks
+}
+
 export const getCardanoPrefix = (network: Network): string => {
   switch (network) {
     case Network.Mainnet:

--- a/packages/xchain-mayachain-amm/src/mayachain-action.ts
+++ b/packages/xchain-mayachain-amm/src/mayachain-action.ts
@@ -1,3 +1,4 @@
+import { ADAChain } from '@xchainjs/xchain-cardano'
 import { Protocol } from '@xchainjs/xchain-client'
 import { abi } from '@xchainjs/xchain-evm'
 import { MAYAChain } from '@xchainjs/xchain-mayachain'
@@ -73,7 +74,9 @@ export class MayachainAction {
   }: NonProtocolActionParams): Promise<TxSubmitted> {
     // Non EVM actions and non Radix action
     if (!isProtocolEVMChain(assetAmount.asset.chain) && !eqAsset(assetAmount.asset, AssetXRD)) {
-      if (isProtocolBFTChain(assetAmount.asset.chain)) {
+      // BFT/Cosmos chains and Cardano derive their fee internally (Cardano from on-chain
+      // protocol params) and do not accept a caller-supplied per-byte feeRate, unlike UTXO chains.
+      if (isProtocolBFTChain(assetAmount.asset.chain) || assetAmount.asset.chain === ADAChain) {
         const hash = await wallet.transfer({
           asset: assetAmount.asset,
           amount: assetAmount.baseAmount,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected Cardano swap memo formatting to use CIP-20 transaction metadata, resolving MAYA parsing failures that previously caused swap and deposit refunds.
  * Fixed ADA swap execution by removing unsupported fee-rate calls, enabling transactions to broadcast successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->