### PR TITLE
fix(zcash): make consensus branch ID dynamic for NU6.2 (#1705)

### DIFF
--- a/.changeset/zcash-nu62-consensus-branch-id.md
+++ b/.changeset/zcash-nu62-consensus-branch-id.md
@@ -1,0 +1,7 @@
+---
+'@xchainjs/zcash-js': patch
+'@xchainjs/xchain-utxo-providers': patch
+'@xchainjs/xchain-zcash': patch
+---
+
+Fix Zcash broadcasts failing after the NU6.2 network upgrade (activated June 3, 2026 at block height 3364600). The consensus branch ID used to sign v5 transactions was hardcoded to the NU6.1 value (`0x4dec4df0`), so post-upgrade nodes rejected every spend with an HTTP 400. `signAndFinalize` now accepts an optional `consensusBranchId` (defaulting to the NU6.2 value `0x5437f330`), and the Zcash client fetches the live value from the Nownodes Blockbook backend status (`backend.consensus.nextblock`) before signing, falling back to the default if the node is unreachable. This keeps transactions valid across future consensus upgrades without a library change.

--- a/packages/xchain-utxo-providers/src/providers/nownodes/nownodes-api-types.ts
+++ b/packages/xchain-utxo-providers/src/providers/nownodes/nownodes-api-types.ts
@@ -74,3 +74,12 @@ export type GetAddressInfo = {
 export type BroadcastDTO = {
   result: string
 }
+
+export type StatusDTO = {
+  backend: {
+    consensus?: {
+      chaintip: string
+      nextblock: string
+    }
+  }
+}

--- a/packages/xchain-utxo-providers/src/providers/nownodes/nownodes-api.ts
+++ b/packages/xchain-utxo-providers/src/providers/nownodes/nownodes-api.ts
@@ -7,6 +7,7 @@ import {
   BalanceParams,
   BroadcastDTO,
   GetAddressInfo,
+  StatusDTO,
   Transaction,
   TxHashParams,
 } from './nownodes-api-types'
@@ -122,6 +123,34 @@ export const getBalance = async ({
     ? baseAmount(balanceResponse.balance, assetDecimals)
     : baseAmount(balanceResponse.balance).plus(balanceResponse.unconfirmedBalance, assetDecimals)
   return balance
+}
+
+/**
+ * Get the consensus branch ID for the next block from the Blockbook backend status.
+ *
+ * Returned by Blockbook at its API root as `backend.consensus.nextblock`, a hex string
+ * (e.g. "5437f330"). Used to sign Zcash v5 transactions against the currently active
+ * network upgrade so they remain valid after consensus upgrades.
+ *
+ * @param {string} baseUrl The nownodes blockbook URL (already includes /api/v2).
+ * @returns {number | undefined} The consensus branch ID, or undefined if unavailable.
+ */
+export const getConsensusBranchId = async ({
+  apiKey,
+  baseUrl,
+}: {
+  apiKey: string
+  baseUrl: string
+}): Promise<number | undefined> => {
+  const response = await axios.get(baseUrl, {
+    headers: {
+      'api-key': apiKey,
+    },
+  })
+  const nextblock = (response.data as StatusDTO).backend?.consensus?.nextblock
+  if (!nextblock) return undefined
+  const branchId = parseInt(nextblock, 16)
+  return Number.isNaN(branchId) ? undefined : branchId
 }
 
 export const broadcastTx = async ({

--- a/packages/xchain-utxo-providers/src/providers/nownodes/nownodes-api.ts
+++ b/packages/xchain-utxo-providers/src/providers/nownodes/nownodes-api.ts
@@ -146,11 +146,13 @@ export const getConsensusBranchId = async ({
     headers: {
       'api-key': apiKey,
     },
+    timeout: 10_000, // fail fast so the caller can fall back to the default branch ID
   })
   const nextblock = (response.data as StatusDTO).backend?.consensus?.nextblock
-  if (!nextblock) return undefined
-  const branchId = parseInt(nextblock, 16)
-  return Number.isNaN(branchId) ? undefined : branchId
+  // A consensus branch ID is a 32-bit value, always exactly 8 hex digits. Reject anything
+  // else rather than risk signing with a malformed branch ID parsed from a partial match.
+  if (!nextblock || !/^[0-9a-fA-F]{8}$/.test(nextblock)) return undefined
+  return parseInt(nextblock, 16)
 }
 
 export const broadcastTx = async ({

--- a/packages/xchain-utxo-providers/src/providers/nownodes/nownodes-data-provider.ts
+++ b/packages/xchain-utxo-providers/src/providers/nownodes/nownodes-data-provider.ts
@@ -101,6 +101,18 @@ export class NownodesProvider implements UtxoOnlineDataProvider {
     throw Error('Zcash has flat fees. Fee rates not apply')
   }
 
+  /**
+   * Get the consensus branch ID for the next block from the backend status.
+   * Used to sign Zcash transactions against the active network upgrade.
+   * @returns {number | undefined} The consensus branch ID, or undefined if unavailable.
+   */
+  async getConsensusBranchId(): Promise<number | undefined> {
+    return await nownodes.getConsensusBranchId({
+      apiKey: this._apiKey,
+      baseUrl: this.baseUrl,
+    })
+  }
+
   private mapTransactionToTx(rawTx: Transaction): Tx {
     return {
       asset: this.asset,

--- a/packages/xchain-zcash/src/client.ts
+++ b/packages/xchain-zcash/src/client.ts
@@ -121,7 +121,8 @@ abstract class Client extends UTXOClient {
           if (branchId) return branchId
         }
       } catch (error) {
-        console.warn(error)
+        // Log only the message: the full axios error serializes request headers, including the api-key.
+        console.warn(error instanceof Error ? error.message : error)
       }
     }
     return DEFAULT_CONSENSUS_BRANCH_ID

--- a/packages/xchain-zcash/src/client.ts
+++ b/packages/xchain-zcash/src/client.ts
@@ -1,4 +1,4 @@
-import { buildMaxTx, buildTx, getFee, memoToScript } from '@xchainjs/zcash-js'
+import { DEFAULT_CONSENSUS_BRANCH_ID, buildMaxTx, buildTx, getFee, memoToScript } from '@xchainjs/zcash-js'
 import {
   AssetInfo,
   FeeEstimateOptions,
@@ -19,6 +19,7 @@ import {
   UtxoError,
   UtxoTransactionValidator,
 } from '@xchainjs/xchain-utxo'
+import { NownodesProvider } from '@xchainjs/xchain-utxo-providers'
 
 import {
   AssetZEC,
@@ -99,6 +100,31 @@ abstract class Client extends UTXOClient {
    */
   protected compileMemo(memo: string): Buffer {
     return memoToScript(memo)
+  }
+
+  /**
+   * Get the consensus branch ID to sign transactions against.
+   *
+   * Zcash v5 transactions commit to the branch ID of the active network upgrade; signing
+   * against a stale value causes nodes to reject the broadcast (e.g. after NU6.2). This
+   * fetches the live value from the data provider so transactions stay valid across upgrades
+   * without a library change, falling back to {@link DEFAULT_CONSENSUS_BRANCH_ID} if no
+   * provider can supply it.
+   * @returns {Promise<number>} The consensus branch ID for the next block.
+   */
+  protected async getConsensusBranchId(): Promise<number> {
+    for (const provider of this.dataProviders) {
+      try {
+        const prov = provider[this.network]
+        if (prov instanceof NownodesProvider) {
+          const branchId = await prov.getConsensusBranchId()
+          if (branchId) return branchId
+        }
+      } catch (error) {
+        console.warn(error)
+      }
+    }
+    return DEFAULT_CONSENSUS_BRANCH_ID
   }
 
   /**

--- a/packages/xchain-zcash/src/clientKeystore.ts
+++ b/packages/xchain-zcash/src/clientKeystore.ts
@@ -127,7 +127,14 @@ class ClientKeystore extends Client {
       throw Error('Error getting private key')
     }
 
-    const signedBuffer = await signAndFinalize(0, (zecKeys.privateKey as Buffer).toString('hex'), tx.inputs, tx.outputs)
+    const consensusBranchId = await this.getConsensusBranchId()
+    const signedBuffer = await signAndFinalize(
+      0,
+      (zecKeys.privateKey as Buffer).toString('hex'),
+      tx.inputs,
+      tx.outputs,
+      consensusBranchId,
+    )
 
     const txId = await this.roundRobinBroadcastTx(signedBuffer.toString('hex'))
 
@@ -180,7 +187,14 @@ class ClientKeystore extends Client {
 
     checkFeeBounds(this.feeBounds, tx.fee)
 
-    const signedBuffer = await signAndFinalize(0, (zecKeys.privateKey as Buffer).toString('hex'), tx.inputs, tx.outputs)
+    const consensusBranchId = await this.getConsensusBranchId()
+    const signedBuffer = await signAndFinalize(
+      0,
+      (zecKeys.privateKey as Buffer).toString('hex'),
+      tx.inputs,
+      tx.outputs,
+      consensusBranchId,
+    )
     const hash = await this.roundRobinBroadcastTx(signedBuffer.toString('hex'))
 
     return { hash, maxAmount: tx.maxAmount, fee: tx.fee }

--- a/packages/zcash-js/src/builder.ts
+++ b/packages/zcash-js/src/builder.ts
@@ -7,9 +7,13 @@ import { addressToScript, memoToScript, writeSigScript } from './script'
 import { Output, OutputMemo, OutputPKH, Tx, UTXO } from './types'
 import { writeCompactInt } from './writer'
 
-// NU6.1 Consensus Branch ID - activated November 24, 2025 at block height 3146400
-// See ZIP 255: https://zips.z.cash/zip-0255
-const NU6_1_CONSENSUS_BRANCH_ID = 0x4dec4df0
+// Default consensus branch ID - NU6.2, activated June 3, 2026 at block height 3364600.
+// Transactions commit to the active branch ID; when a network upgrade activates, this value
+// changes and nodes reject transactions signed with the previous one. Callers can override it
+// per-call via signAndFinalize's `consensusBranchId` argument (e.g. fetched live from a node)
+// to remain forward-compatible across future upgrades without a library change.
+// Previous value was NU6.1 (0x4dec4df0). See https://zips.z.cash/.
+export const DEFAULT_CONSENSUS_BRANCH_ID = 0x5437f330
 
 // Version Group ID for transaction version 5
 const TX_VERSION_GROUP_ID = 0x26a7270a
@@ -180,16 +184,22 @@ export async function buildTx(
   }
 }
 
-export async function signAndFinalize(height: number, skb: string, utxos: UTXO[], outputs: Output[]): Promise<Buffer> {
+export async function signAndFinalize(
+  height: number,
+  skb: string,
+  utxos: UTXO[],
+  outputs: Output[],
+  consensusBranchId: number = DEFAULT_CONSENSUS_BRANCH_ID,
+): Promise<Buffer> {
   const sk = new Uint8Array(Buffer.from(skb, 'hex'))
   const pk = secp256k1.getPublicKey(sk, true)
   let offset = 0
 
-  // HEADER with NU6.1 consensus branch ID
+  // HEADER with consensus branch ID
   let buf = Buffer.alloc(20)
   buf.writeUInt32LE(TX_VERSION, 0) // Transaction version 5 with overwinter flag
   buf.writeUInt32LE(TX_VERSION_GROUP_ID, 4) // Version group ID
-  buf.writeUInt32LE(NU6_1_CONSENSUS_BRANCH_ID, 8) // NU6.1 consensus branch ID (FIXED!)
+  buf.writeUInt32LE(consensusBranchId, 8) // Consensus branch ID
   buf.writeUInt32LE(0x00000000, 12) // Lock time
   buf.writeUInt32LE(height, 16) // Expiry height
 
@@ -309,10 +319,10 @@ export async function signAndFinalize(height: number, skb: string, utxos: UTXO[]
     Buffer.from('9fbe4ed13b0c08e671c11a3407d84e1117cd45028a2eee1b9feae78b48a6e2c1', 'hex').copy(buf, offset)
     offset += 32
 
-    // Create personalization with NU6.1 branch ID
+    // Create personalization with consensus branch ID
     const personal = Buffer.alloc(16)
     Buffer.from('ZcashTxHash_').copy(personal)
-    personal.writeUInt32LE(NU6_1_CONSENSUS_BRANCH_ID, 12) // NU6.1 consensus branch ID (FIXED!)
+    personal.writeUInt32LE(consensusBranchId, 12) // Consensus branch ID
 
     const sigHash = blake2bWithPersonal(buf, personal)
     const signature = secp256k1.sign(sigHash, sk, { lowS: true, prehash: false })
@@ -346,7 +356,7 @@ export async function signAndFinalize(height: number, skb: string, utxos: UTXO[]
   offset += 4
   buf.writeUInt32LE(TX_VERSION_GROUP_ID, offset) // Version group ID
   offset += 4
-  buf.writeUInt32LE(NU6_1_CONSENSUS_BRANCH_ID, offset) // NU6.1 consensus branch ID (FIXED!)
+  buf.writeUInt32LE(consensusBranchId, offset) // Consensus branch ID
   offset += 4
   buf.writeUInt32LE(0x00000000, offset) // Lock time
   offset += 4


### PR DESCRIPTION
## Summary

Fixes #1705 — Zcash broadcasts have been failing since the **NU6.2** network upgrade activated (June 3, 2026, block height 3364600).

Zcash v5 transactions cryptographically commit to the consensus branch ID of the *active* network upgrade. The branch ID was hardcoded to the NU6.1 value (`0x4dec4df0`) in `zcash-js/builder.ts`, so after NU6.2 every spend was rejected by nodes with an HTTP 400. Each upgrade previously required a manual constant edit + republish; this change removes that treadmill.

## Changes

- **`@xchainjs/zcash-js`** — `signAndFinalize` now accepts an optional `consensusBranchId` argument (defaulting to the NU6.2 value `0x5437f330`, exported as `DEFAULT_CONSENSUS_BRANCH_ID`). All three internal uses of the old constant now use the parameter.
- **`@xchainjs/xchain-utxo-providers`** — `NownodesProvider.getConsensusBranchId()` reads the live value from the Blockbook backend status (`backend.consensus.nextblock`).
- **`@xchainjs/xchain-zcash`** — the client fetches the live branch ID before signing (`transfer` / `transferMax`), falling back to `DEFAULT_CONSENSUS_BRANCH_ID` if no provider can supply it. This keeps transactions valid across future consensus upgrades without a library change.

## Testing

- `yarn build` — ✅ all affected packages
- `yarn test --filter=@xchainjs/xchain-zcash --filter=@xchainjs/xchain-utxo-providers` — ✅
- `eslint` — ✅ no errors

## Note

The live fetch is wired to `NownodesProvider` (ZEC's only data provider); other providers fall back to the hardcoded default rather than generalizing the method onto the shared `UtxoOnlineDataProvider` interface. Easy to broaden later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Zcash transaction broadcasts failing after the NU6.2 network upgrade by updating consensus branch ID handling.
  * The client now determines the live consensus branch ID from backend status when reachable, and automatically falls back to the NU6.2 default if it isn’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->