### PR TITLE
feat(xchain-suite): wire up Tron chain support

### DIFF
--- a/tools/xchain-suite/package.json
+++ b/tools/xchain-suite/package.json
@@ -11,7 +11,7 @@
     "test:run": "vitest run"
   },
   "dependencies": {
-    "@chainflip/sdk": "2.1.1",
+    "@chainflip/sdk": "2.2.1",
     "@xchainjs/xchain-arbitrum": "workspace:*",
     "@xchainjs/xchain-avax": "workspace:*",
     "@xchainjs/xchain-bitcoin": "workspace:*",
@@ -43,6 +43,7 @@
     "@xchainjs/xchain-thorchain-amm": "workspace:*",
     "@xchainjs/xchain-thorchain-query": "workspace:*",
     "@xchainjs/xchain-thornode": "workspace:*",
+    "@xchainjs/xchain-tron": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
     "@xchainjs/xchain-wallet": "workspace:*",
     "@xchainjs/xchain-zcash": "workspace:*",

--- a/tools/xchain-suite/src/components/layout/Sidebar.tsx
+++ b/tools/xchain-suite/src/components/layout/Sidebar.tsx
@@ -48,6 +48,7 @@ const CHAIN_GROUPS: ChainGroup[] = [
       { id: 'XRD', name: 'Radix' },
       { id: 'ADA', name: 'Cardano' },
       { id: 'XRP', name: 'Ripple' },
+      { id: 'TRON', name: 'Tron' },
     ],
   },
 ]

--- a/tools/xchain-suite/src/components/operations/constants.ts
+++ b/tools/xchain-suite/src/components/operations/constants.ts
@@ -25,6 +25,7 @@ export const EXPLORER_TX_URLS: Record<string, string> = {
   SUI: 'https://suiscan.xyz/mainnet/tx/',
   XRD: 'https://dashboard.radixdlt.com/transaction/',
   ADA: 'https://cardanoscan.io/transaction/',
+  TRON: 'https://tronscan.org/#/transaction/',
 }
 
 /**

--- a/tools/xchain-suite/src/components/swap/AssetSelector.tsx
+++ b/tools/xchain-suite/src/components/swap/AssetSelector.tsx
@@ -63,6 +63,7 @@ const CHAIN_GROUPS: ChainGroup[] = [
       { chainId: 'SOL', chainName: 'Solana', symbol: 'SOL' },
       { chainId: 'SUI', chainName: 'Sui', symbol: 'SUI' },
       { chainId: 'ADA', chainName: 'Cardano', symbol: 'ADA' },
+      { chainId: 'TRON', chainName: 'Tron', symbol: 'TRX' },
     ],
   },
 ]

--- a/tools/xchain-suite/src/components/swap/assetIcons.tsx
+++ b/tools/xchain-suite/src/components/swap/assetIcons.tsx
@@ -29,6 +29,7 @@ const CDN_SYMBOL_MAP: Record<string, string> = {
   BSC: 'bnb',
   GAIA: 'atom',
   SOL: 'sol',
+  TRON: 'trx',
 }
 
 export function getAssetIconUrl(chainId: string, symbol?: string): string {

--- a/tools/xchain-suite/src/hooks/useAggregator.ts
+++ b/tools/xchain-suite/src/hooks/useAggregator.ts
@@ -25,6 +25,7 @@ const SWAP_SUPPORTED_CHAINS: string[] = [
   'SUI',
   'XRP',
   'ADA',
+  'TRON',
 ]
 
 interface UseSwapResult {

--- a/tools/xchain-suite/src/lib/chains/index.ts
+++ b/tools/xchain-suite/src/lib/chains/index.ts
@@ -33,6 +33,7 @@ export const SUPPORTED_CHAINS: ChainConfig[] = [
   { id: 'XRD', name: 'Radix', symbol: 'XRD', category: 'other', decimals: 18 },
   { id: 'ADA', name: 'Cardano', symbol: 'ADA', category: 'other', decimals: 6 },
   { id: 'XRP', name: 'Ripple', symbol: 'XRP', category: 'other', decimals: 6 },
+  { id: 'TRON', name: 'Tron', symbol: 'TRX', category: 'other', decimals: 6 },
 ]
 
 export const getChainById = (id: string): ChainConfig | undefined => SUPPORTED_CHAINS.find((c) => c.id === id)

--- a/tools/xchain-suite/src/lib/clients/factory.ts
+++ b/tools/xchain-suite/src/lib/clients/factory.ts
@@ -328,6 +328,7 @@ import { Client as SuiClient, defaultSuiParams } from '@xchainjs/xchain-sui'
 import { Client as XrdClient } from '@xchainjs/xchain-radix'
 import { Client as AdaClient, defaultAdaParams } from '@xchainjs/xchain-cardano'
 import { Client as XrpClient, defaultXRPParams } from '@xchainjs/xchain-ripple'
+import { Client as TronClient, defaultTRONParams } from '@xchainjs/xchain-tron'
 
 export interface ClientConfig {
   phrase: string
@@ -421,6 +422,8 @@ export function createClient(chainId: string, config: ClientConfig): XChainClien
     }
     case 'XRP':
       return new XrpClient({ ...defaultXRPParams, network, phrase })
+    case 'TRON':
+      return new TronClient({ ...defaultTRONParams, network, phrase })
 
     default:
       throw new Error(`Unsupported chain: ${chainId}`)

--- a/tools/xchain-suite/src/lib/codeExamples.ts
+++ b/tools/xchain-suite/src/lib/codeExamples.ts
@@ -121,6 +121,12 @@ const CHAIN_CONFIGS: Record<string, ChainConfig> = {
     paramsImport: 'defaultXRPParams',
     clientInit: 'new Client({ ...defaultXRPParams, network: Network.Mainnet, phrase })',
   },
+  TRON: {
+    packageName: '@xchainjs/xchain-tron',
+    clientImport: 'Client',
+    paramsImport: 'defaultTRONParams',
+    clientInit: 'new Client({ ...defaultTRONParams, network: Network.Mainnet, phrase })',
+  },
 }
 
 function getChainConfig(chainId: string): ChainConfig {

--- a/tools/xchain-suite/src/lib/swap/SwapService.ts
+++ b/tools/xchain-suite/src/lib/swap/SwapService.ts
@@ -126,6 +126,7 @@ const CHAINFLIP_CHAINS: Record<string, string> = {
   ETH: 'Ethereum',
   ARB: 'Arbitrum',
   SOL: 'Solana',
+  TRON: 'Tron',
 }
 
 function isChainflipCompatible(chain: string): boolean {
@@ -329,7 +330,7 @@ export class SwapService {
 
         if (bestQuote) {
           // Chainflip egressAmount is in base units with native decimals per chain
-          const CF_DECIMALS: Record<string, number> = { BTC: 8, ETH: 18, ARB: 18, SOL: 9 }
+          const CF_DECIMALS: Record<string, number> = { BTC: 8, ETH: 18, ARB: 18, SOL: 9, TRON: 6 }
           const destDecimals = CF_DECIMALS[params.destinationAsset.chain] || 18
           const expectedCrypto = new CryptoAmountClass(
             baseAmountFn(bestQuote.egressAmount, destDecimals),

--- a/tools/xchain-suite/src/pages/SwapPage.tsx
+++ b/tools/xchain-suite/src/pages/SwapPage.tsx
@@ -196,6 +196,7 @@ export default function SwapPage() {
     THOR: 0.02,
     MAYA: 0.02,
     KUJI: 0.01,
+    TRON: 2,
   }
 
   // Set amount to percentage of balance

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,6 +700,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@chainflip/bitcoin@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@chainflip/bitcoin@npm:2.2.0"
+  dependencies:
+    "@chainflip/utils": "npm:2.2.0"
+    bignumber.js: "npm:^11.1.1"
+    bitcoinjs-lib: "npm:7.0.1"
+    scale-ts: "npm:^1.6.1"
+    zod: "npm:^3.25.75"
+  checksum: 10c0/b600b411bfc9acc971b38a9a15b865824ff80c0f99e160d90f142a0f5ebc5c67356958e9ea8ae0429fa06bcd1f7ec7d9f2c1ddca84e7c67d93a1394dc1e10f57
+  languageName: node
+  linkType: hard
+
 "@chainflip/rpc@npm:2.1.3":
   version: 2.1.3
   resolution: "@chainflip/rpc@npm:2.1.3"
@@ -710,6 +723,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@chainflip/rpc@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@chainflip/rpc@npm:2.2.0"
+  dependencies:
+    "@chainflip/utils": "npm:2.2.0"
+    zod: "npm:^3.25.75"
+  checksum: 10c0/c37386f41d465cadd94e489f582d284a42e07493c1c360881383a5b4c8ab1d24e0083c4f7f32626fb32d613f753f6eaf34b29c0832ccdddd3c719edabd0d9130
+  languageName: node
+  linkType: hard
+
 "@chainflip/scale@npm:^1.11.0":
   version: 1.11.0
   resolution: "@chainflip/scale@npm:1.11.0"
@@ -717,6 +740,16 @@ __metadata:
     "@chainflip/utils": "npm:^0.8.22"
     scale-ts: "npm:^1.6.1"
   checksum: 10c0/d90ab2ad0d609f6c416995d31b9fa11d7cc5bc79e95ebc5a0ca1354048683d3dff59bb8a185c63a4d53e8ec09435395de622a1ad67be5ce176c173b00b1ac6cb
+  languageName: node
+  linkType: hard
+
+"@chainflip/scale@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@chainflip/scale@npm:2.2.0"
+  dependencies:
+    "@chainflip/utils": "npm:2.2.0"
+    scale-ts: "npm:^1.6.1"
+  checksum: 10c0/0462d2c5c55746201fc3038dddbb841dca4ebbbcc45ab8ad9255b453190cfe69d22746fd6473810012b61f7192561992969e27063bbe740c521fcc4b8ff76264
   languageName: node
   linkType: hard
 
@@ -737,6 +770,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@chainflip/sdk@npm:2.2.1":
+  version: 2.2.1
+  resolution: "@chainflip/sdk@npm:2.2.1"
+  dependencies:
+    "@chainflip/bitcoin": "npm:2.2.0"
+    "@chainflip/rpc": "npm:2.2.0"
+    "@chainflip/solana": "npm:2.2.5"
+    "@chainflip/utils": "npm:2.2.0"
+    "@ts-rest/core": "npm:^3.52.1"
+    axios: "npm:^1.15.0"
+    bignumber.js: "npm:^9.3.0"
+    ethers: "npm:^6.14.4"
+    zod: "npm:^3.25.76"
+  checksum: 10c0/a7f461739be2e7d45101b1424ac7419b19f8ddd8dbafd13b22ff2ff7cbd3fb9245533b050ee620ee3217202030f162f4e5cf9a819c1030bae9824d681c29134f
+  languageName: node
+  linkType: hard
+
 "@chainflip/solana@npm:2.2.2":
   version: 2.2.2
   resolution: "@chainflip/solana@npm:2.2.2"
@@ -749,6 +799,21 @@ __metadata:
     scale-ts: "npm:^1.6.1"
     zod: "npm:^3.25.75"
   checksum: 10c0/711d75274b8ccea494803c62cd5a5c5236a2b46835b341acf400ab208a56762af746a62c189e386bc0e35e64bc249d076662318ee397ab6712c065299880cd50
+  languageName: node
+  linkType: hard
+
+"@chainflip/solana@npm:2.2.5":
+  version: 2.2.5
+  resolution: "@chainflip/solana@npm:2.2.5"
+  dependencies:
+    "@chainflip/scale": "npm:^2.2.0"
+    "@chainflip/utils": "npm:2.2.0"
+    "@coral-xyz/anchor": "npm:^0.32.1"
+    "@solana/web3.js": "npm:^1.98.4"
+    bn.js: "npm:^5.2.3"
+    scale-ts: "npm:^1.6.1"
+    zod: "npm:^3.25.75"
+  checksum: 10c0/eb46b9be19d1c162d88df48e834a46c977497cb55bcb4744ac91fcb57d3246a3aa4df25007f2f6bde73db31b7bce2f64cf9e90aeb8ea6cfa60d4c925a2a71814
   languageName: node
   linkType: hard
 
@@ -773,6 +838,18 @@ __metadata:
     bignumber.js: "npm:^9.3.1"
     date-fns: "npm:4.1.0"
   checksum: 10c0/021616cc8f79c4da37c55d064a7a603f3d472d6fc3820a136878040ec98b2c0af87244e1c82e797beb79f02a5acff6e67afecc8e315019cb21de2c5963ef0a1b
+  languageName: node
+  linkType: hard
+
+"@chainflip/utils@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@chainflip/utils@npm:2.2.0"
+  dependencies:
+    "@date-fns/utc": "npm:^2.1.1"
+    "@noble/hashes": "npm:^2.2.0"
+    bignumber.js: "npm:^11.1.1"
+    date-fns: "npm:4.1.0"
+  checksum: 10c0/fe3aeacc8bbfae287dc1d8a41abc3e4f7e3d6f37ff284307da39253c1189c365f728621b9416bd26a081f97ce026a1d9acc9fb7a96447f14a9249e7d9d554b1c
   languageName: node
   linkType: hard
 
@@ -3270,6 +3347,13 @@ __metadata:
   version: 2.0.1
   resolution: "@noble/hashes@npm:2.0.1"
   checksum: 10c0/e81769ce21c3b1c80141a3b99bd001f17edea09879aa936692ae39525477386d696101cd573928a304806efb2b9fa751e1dd83241c67d0c84d30091e85c79bdb
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@noble/hashes@npm:2.2.0"
+  checksum: 10c0/cad8630c504d6b9271984f685cd0af9101b40988fc2dfbe17ccdf068a9941f95cc5c9957d89e9ca4b7ca94c15cb35f93510c5d53a09fbcc83ee503b93d0a1034
   languageName: node
   linkType: hard
 
@@ -6633,6 +6717,13 @@ __metadata:
   version: 11.0.0
   resolution: "bignumber.js@npm:11.0.0"
   checksum: 10c0/a3675125b7bff72a618981d05e938e5318b1b9994fed6802a6d1330ea00ef2f3f8a0b90fa44872d43f34331aa4f5977276c775c170748ace516e4eecf6f216a3
+  languageName: node
+  linkType: hard
+
+"bignumber.js@npm:^11.1.1":
+  version: 11.1.4
+  resolution: "bignumber.js@npm:11.1.4"
+  checksum: 10c0/18a0830b51816f4225cf4a5d2df355bfdec79427dfa5d7b6fac0853d8c846bd020678aa4ee11460fff030132e6b4b0b05c40f2f5b9d52bca0361b2612d4c6960
   languageName: node
   linkType: hard
 
@@ -16891,7 +16982,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "xchain-suite@workspace:tools/xchain-suite"
   dependencies:
-    "@chainflip/sdk": "npm:2.1.1"
+    "@chainflip/sdk": "npm:2.2.1"
     "@testing-library/jest-dom": "npm:^6.2.0"
     "@testing-library/react": "npm:^14.1.0"
     "@types/react": "npm:^18.2.0"
@@ -16928,6 +17019,7 @@ __metadata:
     "@xchainjs/xchain-thorchain-amm": "workspace:*"
     "@xchainjs/xchain-thorchain-query": "workspace:*"
     "@xchainjs/xchain-thornode": "workspace:*"
+    "@xchainjs/xchain-tron": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-wallet": "workspace:*"
     "@xchainjs/xchain-zcash": "workspace:*"


### PR DESCRIPTION
## Summary

Wires the **Tron** chain into the testing suite using `@xchainjs/xchain-tron`, so Tron (TRX + Tron USDT) can be exercised end-to-end — including Chainflip swaps.

- Registers the TRON client in the client factory (`defaultTRONParams`, TRX, 6 decimals)
- Adds chain metadata, sidebar navigation, and swap asset-selector entries
- Enables Tron in the Chainflip swap path (`CHAINFLIP_CHAINS` map + egress decimals) and bumps the suite's `@chainflip/sdk` to **2.2.1** to match the aggregator
- Adds explorer URL, icon mapping, fee reserve, and code-example entries

Pairs with the aggregator Chainflip/Tron upgrade in #1708.

## Notes
- Tron uses a public RPC, so no API key is required.
- Tron's client supports sync `getAddress()`, so it is intentionally **not** added to `ASYNC_ONLY_CHAINS`.
- THORChain/MAYAChain name-alias lists are intentionally left unchanged — Tron is only routable via Chainflip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Tron in the app, including wallet/client setup, swap compatibility, and chain discovery.
  * Tron now appears in the chain selector, asset picker, and navigation lists.
  * Tron transaction links now open in the correct block explorer.

* **Bug Fixes**
  * Improved swap behavior for Tron, including correct amount calculations and native balance handling.
  * Updated Tron icon and asset details to display properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->