### PR TITLE
fix(crypto): harden keystore KDF iterations and MAC comparison

### DIFF
--- a/.changeset/xchain-crypto-keystore-hardening.md
+++ b/.changeset/xchain-crypto-keystore-hardening.md
@@ -1,0 +1,5 @@
+---
+'@xchainjs/xchain-crypto': patch
+---
+
+Harden keystore encryption. The PBKDF2 iteration count for newly created keystores is raised from 262,144 to 600,000 (the current OWASP minimum for PBKDF2-HMAC-SHA256). The count is stored inside each keystore, so existing keystores continue to decrypt unchanged. The keystore MAC check now uses a constant-time comparison (`crypto.timingSafeEqual`) instead of a plain string comparison, removing a minor timing side channel during password verification.

--- a/packages/xchain-crypto/__tests__/crypto.test.ts
+++ b/packages/xchain-crypto/__tests__/crypto.test.ts
@@ -22,6 +22,28 @@ describe('Keystore regression test for encrypt/decrypt with internal migration',
     crypto: {
       cipher: 'aes-128-ctr',
       ciphertext:
+        '14bdcc0565d4ecd101a61a129b4cf109d80a496ee46547013086daab702554f6fa6b78596cc0bc008e2c26518b0c38e066fb215746639674b8f1be4693ef17ae77b35dbab753421af10307df1f177a',
+      cipherparams: { iv: 'dffdb8bbe92e9a00e173eaa20f1a3784' },
+      kdf: 'pbkdf2',
+      kdfparams: {
+        prf: 'hmac-sha256',
+        dklen: 32,
+        salt: 'ead4ad6c09f5a5586235a642fa39c95741b35283304e3fd464d942e300fe0514',
+        c: 600000,
+      },
+      mac: 'f2b7858b9f46cc5a4391f1b747561ec5e7197463774b8cc6c62a2da6eb2a9d30',
+    },
+    id: '9ad9ea91-22ad-46a7-9613-4f9d190e32ab',
+    version: 1,
+    meta: 'xchain-keystore',
+  }
+
+  // Keystore produced with the legacy c=262144 iteration count. The iteration count is
+  // stored in the keystore itself, so older keystores must still decrypt unchanged.
+  const legacyKeystore = {
+    crypto: {
+      cipher: 'aes-128-ctr',
+      ciphertext:
         'aa6838a2aded226922107d5a2322513e5dd706149831580356dec17d8ab531f873d3f173c2775f125d2b3203c498214039cfa78ac1d0ecb29c3f9be35483c1e4d0e2267bba7b36cec14172f760a91a',
       cipherparams: { iv: 'dffdb8bbe92e9a00e173eaa20f1a3784' },
       kdf: 'pbkdf2',
@@ -56,6 +78,15 @@ describe('Keystore regression test for encrypt/decrypt with internal migration',
     const result = await decryptFromKeystore(expectedKeystore, password)
     expect(result).toBe(phrase)
   })
+
+  it('decryptFromKeystore() should still decrypt legacy (c=262144) keystores', async () => {
+    const result = await decryptFromKeystore(legacyKeystore, password)
+    expect(result).toBe(phrase)
+  })
+
+  it('decryptFromKeystore() should reject an incorrect password', async () => {
+    await expect(decryptFromKeystore(expectedKeystore, 'wrong-password')).rejects.toThrow('Invalid password')
+  })
 })
 
 describe('Validate Phrase', () => {
@@ -84,7 +115,7 @@ describe('Export Keystore', () => {
     expect(keystore.crypto.cipher).toEqual('aes-128-ctr')
     expect(keystore.crypto.kdf).toEqual('pbkdf2')
     expect(keystore.crypto.kdfparams.prf).toEqual('hmac-sha256')
-    expect(keystore.crypto.kdfparams.c).toEqual(262144)
+    expect(keystore.crypto.kdfparams.c).toEqual(600000)
     expect(keystore.version).toEqual(1)
     expect(keystore.meta).toEqual('xchain-keystore')
   })

--- a/packages/xchain-crypto/src/crypto.ts
+++ b/packages/xchain-crypto/src/crypto.ts
@@ -12,7 +12,7 @@ const cipher = 'aes-128-ctr' // Encryption cipher
 const kdf = 'pbkdf2' // Key derivation function
 const prf = 'hmac-sha256' // Pseudorandom function
 const dklen = 32 // Derived key length
-const c = 262144 // Iteration count
+const c = 600000 // Iteration count (OWASP-recommended minimum for PBKDF2-HMAC-SHA256)
 const hashFunction = 'sha256' // Hash function
 const meta = 'xchain-keystore' // Metadata
 
@@ -161,9 +161,12 @@ export const decryptFromKeystore = async (keystore: Keystore, password: string):
 
   const ciphertext = Buffer.from(keystore.crypto.ciphertext, 'hex')
   const mac_bytes: Uint8Array = blake2b(Buffer.concat([derivedKey.slice(16, 32), ciphertext]), { dkLen: 32 })
-  const mac: string = Buffer.from(mac_bytes).toString('hex')
+  const computedMac = Buffer.from(mac_bytes)
+  const expectedMac = Buffer.from(keystore.crypto.mac, 'hex')
 
-  if (mac !== keystore.crypto.mac) throw new Error('Invalid password')
+  // Constant-time comparison to avoid leaking MAC bytes via timing
+  if (computedMac.length !== expectedMac.length || !crypto.timingSafeEqual(computedMac, expectedMac))
+    throw new Error('Invalid password')
   const decipher = crypto.createDecipheriv(
     keystore.crypto.cipher,
     derivedKey.slice(0, 16),


### PR DESCRIPTION
## What

Two safe, backward-compatible hardenings to `@xchainjs/xchain-crypto` keystore encryption, from a review of the crypto key-generation code.

1. **PBKDF2 iterations 262,144 → 600,000** — the current OWASP minimum for PBKDF2-HMAC-SHA256. The iteration count is stored inside each keystore, so this applies only to *newly created* keystores; existing keystores decrypt unchanged.
2. **Constant-time MAC comparison** — `decryptFromKeystore` now uses `crypto.timingSafeEqual` instead of a plain string compare, removing a minor timing side channel during password verification.

## Why

The mnemonic/seed/HD-derivation paths audited clean (CSPRNG entropy via `@scure/bip39` → `@noble/hashes`). The only dated parameters were in keystore encryption: the iteration count matched the old geth default, and MAC verification was timing-variable.

## Tests

- Regenerated the known-answer ciphertext/mac for `c=600000` (computed from the real source logic).
- Added a **legacy `c=262144` keystore decrypt test** proving backward compatibility.
- Added a **wrong-password rejection test** exercising the new MAC path.
- All 11 tests pass; lint clean.

## Out of scope

Bumping `@scure/*`/`@noble/*` to 2.x is intentionally left for a separate, tested PR — `@scure/bip32` is consumed by nearly every chain package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened keystore password verification with a safer comparison method.
  * Added support for opening older keystores while continuing to work with newly created ones.
  * Improved password validation behavior so incorrect passwords are consistently rejected.
* **Chores**
  * Updated the release note entry to document a patch update for the crypto package.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->