### PR TITLE
docs: note xchain-monero is WIP and excluded from cross-cutting work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,3 +64,15 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+
+---
+
+## Project-Specific Notes
+
+### `xchain-monero` is work-in-progress
+
+The `@xchainjs/xchain-monero` package is **not yet functional** and is under active development. Treat it as out of scope for cross-cutting work:
+
+- **Exclude it from monorepo-wide dependency bumps, refactors, and codemods** unless the task explicitly targets monero. It pins its own crypto dependency ranges (`@noble/curves`, `@noble/hashes`, `micro-key-producer`) and should be allowed to keep them independently — e.g. when upgrading `@scure`/`@noble` to 2.x elsewhere, leave monero on its current versions rather than forcing alignment.
+- Don't rely on its tests as a gate for shared changes, and don't "fix" its incomplete code as a side effect of unrelated work.
+- If a change genuinely must touch monero, call it out explicitly and scope it on its own.


### PR DESCRIPTION
## What

Adds a **Project-Specific Notes** section to `CLAUDE.md` recording that `@xchainjs/xchain-monero` is **work-in-progress / not yet functional**, and should be excluded from monorepo-wide dependency bumps, refactors, and codemods unless a task explicitly targets it.

## Why

The package pins its own crypto dependency ranges (`@noble/curves`, `@noble/hashes`, `micro-key-producer`) and its key-derivation code is incomplete/unverified. Notably, the planned `@scure`/`@noble` 1.x→2.x upgrade should bump the other packages and **leave monero on its current versions** rather than forcing alignment (monero is a separately published package, so dual-versioning is fine). This note prevents accidentally pulling monero into broad sweeps and treating its tests as a gate for shared changes.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added project-specific guidance clarifying that Monero-related package work is still in progress.
  * Included notes to keep broader dependency updates and shared changes separate from Monero-specific work.
  * Clarified that Monero tests should not be used as a blocker for unrelated repository-wide changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->