### PR TITLE
fix(crypto): restore browser compatibility for keystore MAC comparison

### DIFF
--- a/.changeset/crypto-timingsafeequal-browser.md
+++ b/.changeset/crypto-timingsafeequal-browser.md
@@ -1,0 +1,5 @@
+---
+'@xchainjs/xchain-crypto': patch
+---
+
+Fix `decryptFromKeystore` throwing `TypeError: crypto.timingSafeEqual is not a function` in browser/bundler environments. The MAC comparison now falls back to a manual constant-time comparison when Node's `crypto.timingSafeEqual` is unavailable (e.g. under `crypto-browserify`), preserving timing-attack hardening on Node while restoring browser/Electron-renderer compatibility.

--- a/packages/xchain-crypto/__tests__/crypto.test.ts
+++ b/packages/xchain-crypto/__tests__/crypto.test.ts
@@ -87,6 +87,30 @@ describe('Keystore regression test for encrypt/decrypt with internal migration',
   it('decryptFromKeystore() should reject an incorrect password', async () => {
     await expect(decryptFromKeystore(expectedKeystore, 'wrong-password')).rejects.toThrow('Invalid password')
   })
+
+  // Browsers/bundlers polyfill `crypto` with crypto-browserify, which lacks
+  // timingSafeEqual. Simulate its absence and ensure decrypt still works.
+  describe('without crypto.timingSafeEqual (browser polyfill)', () => {
+    const original = crypto.timingSafeEqual
+
+    beforeEach(() => {
+      // @ts-expect-error simulate a polyfill that does not implement timingSafeEqual
+      crypto.timingSafeEqual = undefined
+    })
+
+    afterEach(() => {
+      crypto.timingSafeEqual = original
+    })
+
+    it('decryptFromKeystore() should return original phrase via fallback comparison', async () => {
+      const result = await decryptFromKeystore(expectedKeystore, password)
+      expect(result).toBe(phrase)
+    })
+
+    it('decryptFromKeystore() should still reject an incorrect password via fallback comparison', async () => {
+      await expect(decryptFromKeystore(expectedKeystore, 'wrong-password')).rejects.toThrow('Invalid password')
+    })
+  })
 })
 
 describe('Validate Phrase', () => {

--- a/packages/xchain-crypto/src/crypto.ts
+++ b/packages/xchain-crypto/src/crypto.ts
@@ -50,6 +50,26 @@ const _isNode = (): boolean => {
 }
 
 /**
+ * Constant-time comparison of two equal-length buffers.
+ *
+ * Uses Node's `crypto.timingSafeEqual` when available, and falls back to a
+ * manual constant-time comparison for browser/bundler environments whose
+ * `crypto` polyfill (e.g. `crypto-browserify`) does not implement it.
+ *
+ * @param {Buffer} a First buffer.
+ * @param {Buffer} b Second buffer.
+ * @returns {boolean} True if the buffers are equal in constant time.
+ */
+const constantTimeEqual = (a: Buffer, b: Buffer): boolean => {
+  if (a.length !== b.length) return false
+  if (typeof crypto.timingSafeEqual === 'function') return crypto.timingSafeEqual(a, b)
+  // Fallback for browser polyfills (crypto-browserify) that lack timingSafeEqual
+  let diff = 0
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i]
+  return diff === 0
+}
+
+/**
  * Generates a new mnemonic phrase.
  * @param {number} size The size of the phrase in words. Default is 12.
  * @returns {string} The generated mnemonic phrase.
@@ -165,7 +185,7 @@ export const decryptFromKeystore = async (keystore: Keystore, password: string):
   const expectedMac = Buffer.from(keystore.crypto.mac, 'hex')
 
   // Constant-time comparison to avoid leaking MAC bytes via timing
-  if (computedMac.length !== expectedMac.length || !crypto.timingSafeEqual(computedMac, expectedMac))
+  if (computedMac.length !== expectedMac.length || !constantTimeEqual(computedMac, expectedMac))
     throw new Error('Invalid password')
   const decipher = crypto.createDecipheriv(
     keystore.crypto.cipher,


### PR DESCRIPTION
## Summary

Fixes #1715.

`@xchainjs/xchain-crypto` 1.0.7 changed `decryptFromKeystore` to verify the keystore MAC with Node's `crypto.timingSafeEqual()`. That API is **not implemented by `crypto-browserify`** (the standard `crypto` polyfill for Vite/webpack bundles), so any browser / Electron-renderer / bundled consumer throws at runtime when unlocking a keystore:

```
TypeError: crypto.timingSafeEqual is not a function
```

The keystore *format* was unchanged (source/format-backwards-compatible), but the change was **not runtime-compatible for non-Node consumers**. CI didn't catch it because Jest/Vitest run under Node, where `timingSafeEqual` exists.

## Fix

Add a `constantTimeEqual` helper that:
- uses `crypto.timingSafeEqual` when available (Node), and
- falls back to a manual constant-time comparison when it's absent (browser polyfills).

This preserves the timing-attack hardening on Node while restoring browser/Electron compatibility.

## Tests

Added a regression test group that simulates the polyfill case (`crypto.timingSafeEqual` undefined) and verifies that:
- a correct password still decrypts via the fallback, and
- a wrong password is still rejected via the fallback.

All 13 tests pass; build and lint are clean.

## Changeset

Patch bump for `@xchainjs/xchain-crypto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keystore decryption compatibility in browser and Electron-like environments.
  * Decryption now works even when native constant-time crypto support is unavailable, while still rejecting incorrect passwords.
  * Preserved secure MAC comparison behavior across supported environments.

* **Tests**
  * Added coverage for environments without native constant-time comparison support to verify successful decryption and password failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->