### PR TITLE
feat(aggregator): allow custom THORNode/Midgard URLs for THORChain protocol

### DIFF
--- a/.changeset/aggregator-configurable-thornode-midgard-urls.md
+++ b/.changeset/aggregator-configurable-thornode-midgard-urls.md
@@ -1,0 +1,9 @@
+---
+'@xchainjs/xchain-aggregator': minor
+---
+
+Allow custom THORNode/Midgard (and MAYANode/Maya Midgard) base URLs for the Thorchain and Mayachain protocols.
+
+The aggregator previously hardcoded the THORChain and MAYAChain clients with only the network, so it always talked to the public default endpoints. Consumers can now pass optional `thornodeConfig`, `midgardConfig`, `mayanodeConfig` and `mayaMidgardConfig` fields (the existing `ThornodeConfig` / `MidgardConfig` / `MayanodeConfig` shapes from the query packages) via the aggregator config. These are forwarded to the underlying `Thornode`, `Midgard`, `Mayanode` and `MidgardApi` clients so integrators can point at their own gateway/proxy.
+
+Fully backward compatible: when the new fields are omitted, behaviour is unchanged and the per-network default endpoints are used.

--- a/.changeset/thornode-default-gateway-url.md
+++ b/.changeset/thornode-default-gateway-url.md
@@ -1,0 +1,5 @@
+---
+'@xchainjs/xchain-thornode': patch
+---
+
+Change the default `THORNODE_API_URL` from `https://thornode.thorchain.network/` to `https://gateway.liquify.com/chain/thorchain_api`.

--- a/packages/xchain-aggregator/__tests__/custom-endpoints.test.ts
+++ b/packages/xchain-aggregator/__tests__/custom-endpoints.test.ts
@@ -1,0 +1,65 @@
+import { ThorchainProtocol } from '../src/protocols/thorchain'
+import { MayachainProtocol } from '../src/protocols/mayachain'
+
+// The AMM constructors are not relevant for these tests and are mocked away so that
+// building a protocol does not pull in unrelated behaviour.
+jest.mock('@xchainjs/xchain-thorchain-amm')
+jest.mock('@xchainjs/xchain-mayachain-amm')
+
+describe('Custom THORNode/Midgard endpoint configuration', () => {
+  describe('Thorchain protocol', () => {
+    it('Should forward custom thornode and midgard configs to the underlying clients', () => {
+      const thornodeBaseUrls = ['https://my-gateway.example.com/thorchain_api']
+      const midgardBaseUrls = ['https://my-gateway.example.com/thorchain_midgard']
+
+      const protocol = new ThorchainProtocol({
+        thornodeConfig: { apiRetries: 3, thornodeBaseUrls },
+        midgardConfig: { apiRetries: 3, midgardBaseUrls },
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const cache = (protocol as any).thorchainQuery.thorchainCache
+      expect(cache.thornode.config.thornodeBaseUrls).toEqual(thornodeBaseUrls)
+      expect(cache.midgardQuery.midgardCache.midgard.config.midgardBaseUrls).toEqual(midgardBaseUrls)
+    })
+
+    it('Should keep default endpoints when no custom config is provided', () => {
+      const protocol = new ThorchainProtocol()
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const cache = (protocol as any).thorchainQuery.thorchainCache
+      expect(cache.thornode.config.thornodeBaseUrls).toContain('https://thornode.thorchain.network')
+      expect(cache.midgardQuery.midgardCache.midgard.config.midgardBaseUrls).toContain(
+        'https://midgard.thorchain.network',
+      )
+    })
+  })
+
+  describe('Mayachain protocol', () => {
+    it('Should forward custom mayanode and midgard configs to the underlying clients', () => {
+      const mayanodeBaseUrls = ['https://my-gateway.example.com/mayanode']
+      const midgardBaseUrls = ['https://my-gateway.example.com/maya_midgard']
+
+      const protocol = new MayachainProtocol({
+        mayanodeConfig: { apiRetries: 3, mayanodeBaseUrls },
+        mayaMidgardConfig: { apiRetries: 3, midgardBaseUrls },
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const cache = (protocol as any).mayachainQuery.getMayachainCache()
+      expect(cache.mayanode.config.mayanodeBaseUrls).toEqual(mayanodeBaseUrls)
+      expect(cache.midgardQuery.midgardCache.midgardApi.config.midgardBaseUrls).toEqual(midgardBaseUrls)
+    })
+
+    it('Should keep default endpoints when no custom config is provided', () => {
+      const protocol = new MayachainProtocol()
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const cache = (protocol as any).mayachainQuery.getMayachainCache()
+      expect(cache.mayanode.config.mayanodeBaseUrls).toContain('https://mayanode.mayachain.info')
+      expect(cache.midgardQuery.midgardCache.midgardApi.config.midgardBaseUrls).toContain(
+        'https://midgard.mayachain.info',
+      )
+    })
+  })
+})

--- a/packages/xchain-aggregator/package.json
+++ b/packages/xchain-aggregator/package.json
@@ -34,6 +34,8 @@
     "@xchainjs/xchain-mayachain": "workspace:*",
     "@xchainjs/xchain-mayachain-amm": "workspace:*",
     "@xchainjs/xchain-mayachain-query": "workspace:*",
+    "@xchainjs/xchain-mayamidgard-query": "workspace:*",
+    "@xchainjs/xchain-midgard-query": "workspace:*",
     "@xchainjs/xchain-thorchain": "workspace:*",
     "@xchainjs/xchain-thorchain-amm": "workspace:*",
     "@xchainjs/xchain-thorchain-query": "workspace:*",

--- a/packages/xchain-aggregator/src/const.ts
+++ b/packages/xchain-aggregator/src/const.ts
@@ -3,7 +3,19 @@ import { Config, Protocol } from './types'
 
 export const SupportedProtocols: Protocol[] = ['Thorchain', 'Mayachain', 'Chainflip', 'OneClick']
 
-export const DEFAULT_CONFIG: Required<Omit<Config, 'wallet' | 'affiliate' | 'brokerUrl' | 'oneClickApiKey'>> = {
+export const DEFAULT_CONFIG: Required<
+  Omit<
+    Config,
+    | 'wallet'
+    | 'affiliate'
+    | 'brokerUrl'
+    | 'oneClickApiKey'
+    | 'thornodeConfig'
+    | 'midgardConfig'
+    | 'mayanodeConfig'
+    | 'mayaMidgardConfig'
+  >
+> = {
   protocols: SupportedProtocols,
   network: Network.Mainnet,
   affiliateBrokers: [],

--- a/packages/xchain-aggregator/src/protocols/mayachain/mayachainProtocol.ts
+++ b/packages/xchain-aggregator/src/protocols/mayachain/mayachainProtocol.ts
@@ -37,10 +37,14 @@ export class MayachainProtocol implements IProtocol {
     // Use network from configuration, fallback to wallet network, or default to mainnet
     const network = configuration?.network || configuration?.wallet?.getNetwork() || Network.Mainnet
 
-    // Create MayachainQuery with proper network configuration
-    // TODO: Fix MidgardQuery constructor to accept network parameter
-    const midgardCache = new MidgardCache(new MidgardApi(network))
-    const mayachainCache = new MayachainCache(new MidgardQuery(midgardCache), new Mayanode(network))
+    // Create MayachainQuery with proper network configuration.
+    // Forward optional custom Mayanode/Midgard configs when provided; otherwise the
+    // clients fall back to their per-network default endpoints.
+    const midgardCache = new MidgardCache(new MidgardApi(network, configuration?.mayaMidgardConfig))
+    const mayachainCache = new MayachainCache(
+      new MidgardQuery(midgardCache),
+      new Mayanode(network, configuration?.mayanodeConfig),
+    )
     this.mayachainQuery = new MayachainQuery(mayachainCache)
     this.mayachainAmm = new MayachainAMM(this.mayachainQuery, configuration?.wallet)
     this.configuration = configuration

--- a/packages/xchain-aggregator/src/protocols/protocolFactory.ts
+++ b/packages/xchain-aggregator/src/protocols/protocolFactory.ts
@@ -14,6 +14,10 @@ const getProtocolConfig = (name: Protocol, configuration: Config): ProtocolConfi
     affiliateBrokers: configuration.affiliateBrokers,
     brokerUrl: configuration.brokerUrl,
     oneClickApiKey: configuration.oneClickApiKey,
+    thornodeConfig: configuration.thornodeConfig,
+    midgardConfig: configuration.midgardConfig,
+    mayanodeConfig: configuration.mayanodeConfig,
+    mayaMidgardConfig: configuration.mayaMidgardConfig,
   }
 }
 

--- a/packages/xchain-aggregator/src/protocols/thorchain/thorchainProtocol.ts
+++ b/packages/xchain-aggregator/src/protocols/thorchain/thorchainProtocol.ts
@@ -36,9 +36,14 @@ export class ThorchainProtocol implements IProtocol {
     // Use network from configuration, fallback to wallet network, or default to mainnet
     const network = configuration?.network || configuration?.wallet?.getNetwork() || Network.Mainnet
 
-    // Create ThorchainQuery with proper network configuration
-    const midgardCache = new MidgardCache(new Midgard(network))
-    const thorchainCache = new ThorchainCache(new Thornode(network), new MidgardQuery(midgardCache))
+    // Create ThorchainQuery with proper network configuration.
+    // Forward optional custom Thornode/Midgard configs when provided; otherwise the
+    // clients fall back to their per-network default endpoints.
+    const midgardCache = new MidgardCache(new Midgard(network, configuration?.midgardConfig))
+    const thorchainCache = new ThorchainCache(
+      new Thornode(network, configuration?.thornodeConfig),
+      new MidgardQuery(midgardCache),
+    )
     this.thorchainQuery = new ThorchainQuery(thorchainCache)
     this.thorchainAmm = new ThorchainAMM(this.thorchainQuery, configuration?.wallet)
     this.configuration = configuration

--- a/packages/xchain-aggregator/src/types.ts
+++ b/packages/xchain-aggregator/src/types.ts
@@ -1,4 +1,8 @@
 import { TxHash, Network } from '@xchainjs/xchain-client'
+import { MidgardConfig } from '@xchainjs/xchain-midgard-query'
+import { MidgardConfig as MayaMidgardConfig } from '@xchainjs/xchain-mayamidgard-query'
+import { MayanodeConfig } from '@xchainjs/xchain-mayachain-query'
+import { ThornodeConfig } from '@xchainjs/xchain-thorchain-query'
 import {
   Address,
   AnyAsset,
@@ -84,6 +88,26 @@ export type Config = Partial<{
    * API key for OneClick (NEAR Intents) protocol
    */
   oneClickApiKey: string
+  /**
+   * Custom THORNode client configuration (base URLs and retries) for the Thorchain protocol.
+   * When omitted, the network default THORNode endpoints are used.
+   */
+  thornodeConfig: ThornodeConfig
+  /**
+   * Custom Midgard client configuration (base URLs and retries) for the Thorchain protocol.
+   * When omitted, the network default Midgard endpoints are used.
+   */
+  midgardConfig: MidgardConfig
+  /**
+   * Custom MAYANode client configuration (base URLs and retries) for the Mayachain protocol.
+   * When omitted, the network default MAYANode endpoints are used.
+   */
+  mayanodeConfig: MayanodeConfig
+  /**
+   * Custom Maya Midgard client configuration (base URLs and retries) for the Mayachain protocol.
+   * When omitted, the network default Maya Midgard endpoints are used.
+   */
+  mayaMidgardConfig: MayaMidgardConfig
 }>
 
 /**
@@ -100,6 +124,10 @@ export type ProtocolConfig = Partial<{
   }[]
   brokerUrl: string
   oneClickApiKey: string
+  thornodeConfig: ThornodeConfig
+  midgardConfig: MidgardConfig
+  mayanodeConfig: MayanodeConfig
+  mayaMidgardConfig: MayaMidgardConfig
 }>
 
 /**

--- a/packages/xchain-thornode/src/config.ts
+++ b/packages/xchain-thornode/src/config.ts
@@ -1,6 +1,6 @@
 /**
  * The base URL for the THORNode API endpoint.
  */
-export const THORNODE_API_URL = 'https://thornode.thorchain.network/'
+export const THORNODE_API_URL = 'https://gateway.liquify.com/chain/thorchain_api'
 /** @deprecated Use THORNODE_API_URL instead. Will be removed in next major version. */
 export const THORNODE_API_9R_URL = THORNODE_API_URL

--- a/yarn.lock
+++ b/yarn.lock
@@ -5237,6 +5237,8 @@ __metadata:
     "@xchainjs/xchain-mayachain": "workspace:*"
     "@xchainjs/xchain-mayachain-amm": "workspace:*"
     "@xchainjs/xchain-mayachain-query": "workspace:*"
+    "@xchainjs/xchain-mayamidgard-query": "workspace:*"
+    "@xchainjs/xchain-midgard-query": "workspace:*"
     "@xchainjs/xchain-thorchain": "workspace:*"
     "@xchainjs/xchain-thorchain-amm": "workspace:*"
     "@xchainjs/xchain-thorchain-query": "workspace:*"


### PR DESCRIPTION
## Problem

Downstream apps (e.g. ASGARDEX) that use `@xchainjs/xchain-aggregator` cannot point the THORChain protocol at a custom THORNode or Midgard endpoint. `ThorchainProtocol` hardcodes the clients with only the network:

```ts
const midgardCache = new MidgardCache(new Midgard(network))
const thorchainCache = new ThorchainCache(new Thornode(network), new MidgardQuery(midgardCache))
```

So it always talks to the public default `https://thornode.thorchain.network/` (from `@xchainjs/xchain-thornode`'s `THORNODE_API_URL`). This is a single point of failure and gives integrators no way to use their own gateway/proxy. The same applies to `MayachainProtocol` (MAYANode / Maya Midgard). The aggregator's public config exposed no field for these URLs.

## Fix (commit 1 — the mergeable part)

The plumbing already exists at the query layer — `Thornode`, `Midgard`, `Mayanode` and `MidgardApi` all accept a `(network, config?)` constructor. The aggregator just never forwarded anything. This PR:

- Adds optional `thornodeConfig`, `midgardConfig`, `mayanodeConfig` and `mayaMidgardConfig` fields to the aggregator `Config` and `ProtocolConfig`, reusing the existing `ThornodeConfig` / `MidgardConfig` / `MayanodeConfig` shapes from the query packages (no new invented types).
- Threads them through `ProtocolFactory` into `ThorchainProtocol` and `MayachainProtocol`, which forward them to the underlying clients.
- Declares `@xchainjs/xchain-midgard-query` and `@xchainjs/xchain-mayamidgard-query` as explicit dependencies (they were already imported transitively).

### Backward compatibility

Fully backward compatible. Every new field is optional; when omitted, `configuration?.xConfig` is `undefined` and the underlying clients fall back to their existing per-network default endpoints. No default behaviour changed in this commit.

### Usage

```ts
import { Aggregator } from '@xchainjs/xchain-aggregator'

const aggregator = new Aggregator({
  protocols: ['Thorchain'],
  thornodeConfig: {
    apiRetries: 3,
    thornodeBaseUrls: ['https://my-gateway.example.com/thorchain_api'],
  },
  midgardConfig: {
    apiRetries: 3,
    midgardBaseUrls: ['https://my-gateway.example.com/thorchain_midgard'],
  },
})
```

The same works for Mayachain via `mayanodeConfig` / `mayaMidgardConfig`.

### Tests

Added `__tests__/custom-endpoints.test.ts` proving that a custom config reaches the underlying Thornode/Midgard/Mayanode/MidgardApi clients, and that omitting it preserves the current defaults. Full suite: 73 passed. Lint clean.

## ⚠️ Optional / contentious (commit 2 — safe to drop)

The **second commit** (`feat(thornode): default THORNODE_API_URL to liquify gateway`) changes the default `THORNODE_API_URL` in `@xchainjs/xchain-thornode` from `https://thornode.thorchain.network/` to `https://gateway.liquify.com/chain/thorchain_api`.

This is **intentionally independent and optional**. Hardcoding one integrator's gateway as the library-wide default may be undesirable, and this commit can be dropped/reverted without affecting commit 1. The valuable, mergeable part of this PR is the configurability in commit 1; the default change is just a convenience. Please cherry-pick or drop commit 2 as you see fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring custom THORChain and MayaChain node and Midgard gateway URLs.
  * Existing default endpoints remain available when custom URLs are not provided.

* **Bug Fixes**
  * Updated the default THORNode API endpoint to use the Liquify gateway.

* **Tests**
  * Added coverage for custom endpoint configuration and default fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->