### PR TITLE
ci(release): enable npm Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ name: Release workflow
 permissions:
   contents: write
   pull-requests: write
+  id-token: write # Required for npm Trusted Publishing (OIDC) and provenance attestations
 
 on:
   push:
@@ -35,6 +36,13 @@ jobs:
           node-version: 20.x
           cache: yarn
 
+      # npm Trusted Publishing (OIDC) requires npm >= 11.5.1. Node 20 ships npm 10.x,
+      # so upgrade the globally-installed npm that `changeset publish` shells out to.
+      - name: Upgrade npm for Trusted Publishing (OIDC)
+        run: |
+          npm install -g npm@latest
+          npm --version
+
       - name: Install dependencies
         run: yarn install --immutable
 
@@ -47,6 +55,11 @@ jobs:
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # NPM_TOKEN is a TEMPORARY fallback during the Trusted Publishing migration.
+          # Packages with a trusted publisher configured on npmjs.com publish via OIDC
+          # (no token); packages not yet configured fall back to this token.
+          # Remove this line — and revoke the token — once every package under
+          # packages/* has a trusted publisher registered. See the PR that introduced OIDC.
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Prepare notification for Discord

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,17 +30,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      - name: Setup Node.js 20.x
+      # Trusted Publishing requires Node >= 22.14.0 and npm >= 11.5.1
+      # (https://docs.npmjs.com/trusted-publishers/). Pin npm for a deterministic release.
+      - name: Setup Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: yarn
 
-      # npm Trusted Publishing (OIDC) requires npm >= 11.5.1. Node 20 ships npm 10.x,
-      # so upgrade the globally-installed npm that `changeset publish` shells out to.
       - name: Upgrade npm for Trusted Publishing (OIDC)
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11.5.1
+          node --version
           npm --version
 
       - name: Install dependencies


### PR DESCRIPTION
## Why

npm now recommends [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) for CI/CD and discourages long-lived automation tokens, which **bypass 2FA**. Our release workflow currently authenticates with a stored `NPM_TOKEN` — a single secret that can publish all packages if leaked.

Trusted Publishing replaces that with short-lived **OIDC** tokens minted per run, and attaches **provenance attestations** automatically (supply-chain signing) at no extra cost.

## What this PR changes (`release.yaml` only)

1. **`id-token: write` permission** — lets GitHub Actions request the OIDC token npm needs.
2. **Node 22.x** — Trusted Publishing requires **Node ≥ 22.14.0** (Node 20 is not sufficient for the OIDC path).
3. **Pinned npm@11.5.1** — OIDC needs **npm ≥ 11.5.1**; pin for a deterministic release (`changeset publish` shells out to `npm publish`).
4. **`NPM_TOKEN` kept as a temporary, documented fallback** (see below).

## Why the token is *not* removed here (transition safety)

OIDC only works for a package **after** its trusted publisher is registered on npmjs.com, and there's no org-wide bulk toggle — it's per package. If we removed `NPM_TOKEN` now, publishing would break for every package until all are registered.

So this PR is **non-breaking**: packages already configured for Trusted Publishing publish via OIDC (no token); the rest transparently fall back to `NPM_TOKEN`. Both can coexist on npm during migration.

## Required follow-up (manual, not in this PR)

1. For each package under `packages/*`, on npmjs.com → **Package → Settings → Trusted Publisher**, add:
   - Publisher: **GitHub Actions**
   - Repository: `xchainjs/xchainjs-lib`
   - Workflow filename: `release.yaml`
2. Once **all** packages are registered and a release has published cleanly via OIDC, open a follow-up PR to **remove the `NPM_TOKEN` line** and then **revoke the token** in npm settings.

(Happy to script step 1 against the npm registry API so it isn't N manual entries — say the word.)

## Notes / things to verify on first release

- Release logs should show `node --version` ≥ 22.14.0 and `npm --version` = 11.5.1, and provenance should appear on published package pages.
- No changeset included: this is a CI/tooling-only change.

## Review feedback addressed

- CodeRabbit: Node 22.x + pin npm@11.5.1 (not `npm@latest`).
