### PR TITLE
feat(zcash): add optional fallback Blockbook data provider

### DIFF
--- a/.changeset/zcash-fallback-blockbook-provider.md
+++ b/.changeset/zcash-fallback-blockbook-provider.md
@@ -1,0 +1,5 @@
+---
+'@xchainjs/xchain-zcash': patch
+---
+
+Add an optional fallback Blockbook data provider so a single-provider outage (e.g. a nownodes 502) no longer blocks ZEC broadcasts or the consensus branch ID fetch. Configured via `ZEC_FALLBACK_BLOCKBOOK_URL` (and optional `ZEC_FALLBACK_BLOCKBOOK_API_KEY`) and disabled when unset; the default client now round-robins nownodes → fallback.

--- a/packages/xchain-zcash/src/client.ts
+++ b/packages/xchain-zcash/src/client.ts
@@ -24,10 +24,10 @@ import { NownodesProvider } from '@xchainjs/xchain-utxo-providers'
 import {
   AssetZEC,
   LOWER_FEE_BOUND,
-  NownodesProviders,
   UPPER_FEE_BOUND,
   ZECChain,
   ZEC_DECIMAL,
+  zcashDataProviders,
   zcashExplorerProviders,
 } from './const'
 import * as Utils from './utils'
@@ -37,7 +37,7 @@ export const defaultZECParams: UtxoClientParams = {
   network: Network.Mainnet,
   phrase: '',
   explorerProviders: zcashExplorerProviders,
-  dataProviders: [NownodesProviders],
+  dataProviders: zcashDataProviders,
   rootDerivationPaths: {
     [Network.Mainnet]: `m/44'/133'/0'/0/`,
     [Network.Testnet]: `m/44'/1'/0'/0/`,

--- a/packages/xchain-zcash/src/const.ts
+++ b/packages/xchain-zcash/src/const.ts
@@ -49,3 +49,42 @@ export const NownodesProviders: UtxoOnlineDataProviders = {
   [Network.Stagenet]: mainnetNownodesProvider,
   [Network.Mainnet]: mainnetNownodesProvider,
 }
+
+/**
+ * Optional fallback Blockbook backend so a single-provider outage (e.g. a nownodes 502)
+ * cannot block ZEC broadcasts. It reuses the Blockbook-based {@link NownodesProvider}, so any
+ * Blockbook-compatible Zcash endpoint works — GetBlock is the intended target.
+ *
+ * Configured entirely via env and disabled when unset:
+ * - `ZEC_FALLBACK_BLOCKBOOK_URL` — Blockbook `/api/v2` base URL. GetBlock embeds its access
+ *   token in the path (e.g. `https://go.getblock.io/<TOKEN>/api/v2`).
+ * - `ZEC_FALLBACK_BLOCKBOOK_API_KEY` — sent as the `api-key` header; leave empty for GetBlock
+ *   since its token lives in the URL.
+ */
+const fallbackBlockbookUrl = process.env.ZEC_FALLBACK_BLOCKBOOK_URL
+const fallbackBlockbookProvider = fallbackBlockbookUrl
+  ? new NownodesProvider(
+      fallbackBlockbookUrl,
+      ZECChain,
+      AssetZEC,
+      ZEC_DECIMAL,
+      process.env.ZEC_FALLBACK_BLOCKBOOK_API_KEY || '',
+    )
+  : undefined
+
+export const FallbackBlockbookProviders: UtxoOnlineDataProviders | undefined = fallbackBlockbookProvider
+  ? {
+      [Network.Testnet]: undefined,
+      [Network.Stagenet]: fallbackBlockbookProvider,
+      [Network.Mainnet]: fallbackBlockbookProvider,
+    }
+  : undefined
+
+/**
+ * Ordered data-provider list used by the default client: primary nownodes first, optional
+ * fallback second. `roundRobinBroadcastTx` and `getConsensusBranchId` try each in order, so the
+ * fallback only takes over when nownodes fails.
+ */
+export const zcashDataProviders: UtxoOnlineDataProviders[] = FallbackBlockbookProviders
+  ? [NownodesProviders, FallbackBlockbookProviders]
+  : [NownodesProviders]


### PR DESCRIPTION
## Summary

A single-provider outage (e.g. a nownodes **502 Bad Gateway**) currently blocks **all** ZEC broadcasts and the consensus branch ID fetch, because nownodes is the only Zcash data provider. This adds an optional fallback Blockbook backend so a nownodes outage no longer takes ZEC offline.

- Reuses the existing Blockbook-based `NownodesProvider` — any Blockbook-compatible Zcash endpoint works (**GetBlock** is the intended target).
- Configured entirely via env, **disabled when unset** (no behavior change by default):
  - `ZEC_FALLBACK_BLOCKBOOK_URL` — Blockbook `/api/v2` base URL (GetBlock embeds its access token in the path).
  - `ZEC_FALLBACK_BLOCKBOOK_API_KEY` — optional `api-key` header (leave empty for GetBlock).
- The default client now round-robins **nownodes → fallback** for both `roundRobinBroadcastTx` and `getConsensusBranchId`.

## Status

🚧 **Draft — not yet tested end-to-end against a live GetBlock endpoint.** Typecheck, unit tests, and lint pass locally. Wiring verified (env unset → 1 provider; env set → 2 providers), but the real broadcast/branch-ID fallback path still needs a live run.

## Test plan

- [ ] Provision a GetBlock Zcash **Blockbook** endpoint; set `ZEC_FALLBACK_BLOCKBOOK_URL`.
- [ ] Confirm `/api/v2` root exposes `backend.consensus.nextblock` (covers the Ironwood/NU6.3 branch-ID transition on 2026-07-28).
- [ ] Force nownodes to fail and confirm broadcast falls through to GetBlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional fallback Blockbook support for Zcash Mainnet and Stagenet.
  * Zcash can now continue broadcasting transactions and fetching network data when the primary provider is unavailable.
  * Provider fallback can be configured with an endpoint and optional API key.

* **Bug Fixes**
  * Improved resilience against outages affecting the primary Zcash data provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->