### PR TITLE
fix: default THORChain endpoints to Liquify after *.thorchain.network DNS failure

### DIFF
--- a/.changeset/thorchain-defaults-to-liquify.md
+++ b/.changeset/thorchain-defaults-to-liquify.md
@@ -1,0 +1,17 @@
+---
+'@xchainjs/xchain-thorchain': patch
+'@xchainjs/xchain-client': patch
+'@xchainjs/xchain-thorchain-query': patch
+'@xchainjs/xchain-midgard': patch
+'@xchainjs/xchain-midgard-query': patch
+'@xchainjs/xchain-aggregator': patch
+---
+
+Point mainnet THORChain public defaults at the Liquify gateway after `*.thorchain.network` hosts stopped resolving (DNS failure for `rpc`, `thornode`, and `midgard`).
+
+Defaults are now:
+- RPC: `https://gateway.liquify.com/chain/thorchain_rpc`
+- THORNode: `https://gateway.liquify.com/chain/thorchain_api`
+- Midgard: `https://gateway.liquify.com/chain/thorchain_midgard`
+
+Dead `*.thorchain.network` primaries are removed rather than kept as fallbacks. Consumers that pass their own `clientUrls` / thornode / midgard configs are unaffected (including authenticated Liquify portal URLs).

--- a/packages/xchain-aggregator/__tests__/custom-endpoints.test.ts
+++ b/packages/xchain-aggregator/__tests__/custom-endpoints.test.ts
@@ -28,9 +28,9 @@ describe('Custom THORNode/Midgard endpoint configuration', () => {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const cache = (protocol as any).thorchainQuery.thorchainCache
-      expect(cache.thornode.config.thornodeBaseUrls).toContain('https://thornode.thorchain.network')
+      expect(cache.thornode.config.thornodeBaseUrls).toContain('https://gateway.liquify.com/chain/thorchain_api')
       expect(cache.midgardQuery.midgardCache.midgard.config.midgardBaseUrls).toContain(
-        'https://midgard.thorchain.network',
+        'https://gateway.liquify.com/chain/thorchain_midgard',
       )
     })
   })

--- a/packages/xchain-client/src/BaseXChainClient.ts
+++ b/packages/xchain-client/src/BaseXChainClient.ts
@@ -23,7 +23,7 @@ import {
   XChainClientParams,
 } from './types'
 
-const MAINNET_THORNODE_API_BASE = 'https://thornode.thorchain.network/thorchain'
+const MAINNET_THORNODE_API_BASE = 'https://gateway.liquify.com/chain/thorchain_api/thorchain'
 const STAGENET_THORNODE_API_BASE = ''
 const TESTNET_THORNODE_API_BASE = 'https://testnet.thornode.thorchain.info/thorchain'
 

--- a/packages/xchain-midgard-query/src/utils/midgard.ts
+++ b/packages/xchain-midgard-query/src/utils/midgard.ts
@@ -16,7 +16,7 @@ import { GetActionsParams, MidgardConfig } from '../types'
 const defaultMidgardConfig: Record<Network, MidgardConfig> = {
   mainnet: {
     apiRetries: 3,
-    midgardBaseUrls: ['https://midgard.thorchain.network', 'https://gateway.liquify.com/chain/thorchain_midgard'],
+    midgardBaseUrls: ['https://gateway.liquify.com/chain/thorchain_midgard'],
   },
   stagenet: {
     apiRetries: 3,

--- a/packages/xchain-midgard/src/config.ts
+++ b/packages/xchain-midgard/src/config.ts
@@ -1,6 +1,6 @@
 /**
  * The base URL for the Midgard API endpoint.
  */
-export const MIDGARD_API_URL = 'https://midgard.thorchain.network/'
+export const MIDGARD_API_URL = 'https://gateway.liquify.com/chain/thorchain_midgard/'
 /** @deprecated Use MIDGARD_API_URL instead. Will be removed in next major version. */
 export const MIDGARD_API_9R_URL = MIDGARD_API_URL

--- a/packages/xchain-thorchain-query/src/utils/thornode.ts
+++ b/packages/xchain-thorchain-query/src/utils/thornode.ts
@@ -47,7 +47,7 @@ export type ThornodeConfig = {
 const defaultThornodeConfig: Record<Network, ThornodeConfig> = {
   mainnet: {
     apiRetries: 3,
-    thornodeBaseUrls: [`https://thornode.thorchain.network`, `https://gateway.liquify.com/chain/thorchain_api`],
+    thornodeBaseUrls: [`https://gateway.liquify.com/chain/thorchain_api`],
   },
   stagenet: {
     apiRetries: 3,

--- a/packages/xchain-thorchain/src/utils.ts
+++ b/packages/xchain-thorchain/src/utils.ts
@@ -24,7 +24,7 @@ export const getDefaultClientUrls = (): Record<Network, string[]> => {
   return {
     [Network.Testnet]: ['deprecated'],
     [Network.Stagenet]: [],
-    [Network.Mainnet]: ['https://rpc.thorchain.network', 'https://gateway.liquify.com/chain/thorchain_rpc'],
+    [Network.Mainnet]: ['https://gateway.liquify.com/chain/thorchain_rpc'],
   }
 }
 /**


### PR DESCRIPTION
## Summary

- `rpc.thorchain.network`, `thornode.thorchain.network`, and `midgard.thorchain.network` no longer resolve (DNS failure). Public mainnet defaults now point only at the Liquify gateway.
- Updated packages: `xchain-thorchain` (RPC), `xchain-client` (THORNode inbound lookups), `xchain-thorchain-query`, `xchain-midgard`, `xchain-midgard-query`, plus aggregator default-endpoint tests.
- Dead `*.thorchain.network` entries are removed rather than kept as fallbacks (a failed DNS hop only delays the real provider).
- Consumers that pass their own `clientUrls` / thornode / midgard configs are unaffected, including authenticated Liquify portal URLs (e.g. app-level `VITE_LIQUIFY_*` keys baked into the URL string).

Related to #1727 (misleading "No clients available" when round-robin swallows real errors) — this PR only fixes dead defaults; it does not change round-robin error fidelity.

## Defaults after this PR

| Service | URL |
|---------|-----|
| Tendermint RPC | `https://gateway.liquify.com/chain/thorchain_rpc` |
| THORNode | `https://gateway.liquify.com/chain/thorchain_api` |
| Midgard | `https://gateway.liquify.com/chain/thorchain_midgard` |

## Test plan

- [x] Confirmed `*.thorchain.network` hosts fail DNS from this environment
- [x] Confirmed Liquify RPC/API/Midgard return HTTP 200
- [ ] Run aggregator custom-endpoints unit test
- [ ] Smoke-test a THORChain client against default RPC (balance / status)
- [ ] Smoke-test midgard/thornode query packages with no custom config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Mainnet default endpoints to use reliable Liquify gateway URLs for RPC, THORNode, and Midgard.
  * Removed previously configured `*.thorchain.network` default endpoints that were no longer resolving.
  * Adjusted Mainnet fallback behavior to reduce reliance on unreachable public hostnames.

* **Tests**
  * Updated endpoint assertions to match the new Mainnet defaults for THORNode and Midgard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->