### PR TITLE
chore(deps): bump axios to 1.18.1 (GHSA-gcfj-64vw-6mp9)

### DIFF
--- a/.changeset/security-axios-1.18.1.md
+++ b/.changeset/security-axios-1.18.1.md
@@ -1,0 +1,28 @@
+---
+'@xchainjs/xchain-aggregator': patch
+'@xchainjs/xchain-bitcoin': patch
+'@xchainjs/xchain-bitcoincash': patch
+'@xchainjs/xchain-client': patch
+'@xchainjs/xchain-cosmos': patch
+'@xchainjs/xchain-dash': patch
+'@xchainjs/xchain-doge': patch
+'@xchainjs/xchain-evm': patch
+'@xchainjs/xchain-evm-providers': patch
+'@xchainjs/xchain-litecoin': patch
+'@xchainjs/xchain-mayachain': patch
+'@xchainjs/xchain-mayachain-amm': patch
+'@xchainjs/xchain-mayachain-query': patch
+'@xchainjs/xchain-mayamidgard': patch
+'@xchainjs/xchain-mayamidgard-query': patch
+'@xchainjs/xchain-mayanode': patch
+'@xchainjs/xchain-midgard': patch
+'@xchainjs/xchain-midgard-query': patch
+'@xchainjs/xchain-thorchain': patch
+'@xchainjs/xchain-thorchain-amm': patch
+'@xchainjs/xchain-thorchain-query': patch
+'@xchainjs/xchain-thornode': patch
+'@xchainjs/xchain-utxo-providers': patch
+'@xchainjs/zcash-js': patch
+---
+
+Bump direct `axios` dependency from 1.16.1 to 1.18.1 across all packages that declare it, and pin the same version in the root yarn resolutions. This closes GHSA-gcfj-64vw-6mp9 (Axios Node HTTP adapter can use an inherited proxy after interceptor config cloning; vulnerable range `>=1.15.2 <1.18.0`). Exact pin only — no caret range — so consumers and the monorepo do not float onto a compromised patch.

--- a/package.json
+++ b/package.json
@@ -48,14 +48,15 @@
     "cipher-base": "1.0.7",
     "tiny-secp256k1": "1.1.7",
     "secp256k1": "5.0.1",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "basic-ftp": "5.3.1",
     "tar-fs": "2.1.4",
     "path-to-regexp": "8.4.2",
     "picomatch": "4.0.4",
     "rollup": "4.60.4",
     "validator": "13.15.35",
-    "lodash": "4.18.1"
+    "lodash": "4.18.1",
+    "postcss": "8.5.24"
   },
   "devDependencies": {
     "@actions/core": "1.10.0",

--- a/packages/xchain-aggregator/package.json
+++ b/packages/xchain-aggregator/package.json
@@ -49,7 +49,7 @@
     "@xchainjs/xchain-bsc": "workspace:*",
     "@xchainjs/xchain-ethereum": "workspace:*",
     "@xchainjs/xchain-kujira": "workspace:*",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "axios-mock-adapter": "^2.1.0"
   }
 }

--- a/packages/xchain-bitcoin/package.json
+++ b/packages/xchain-bitcoin/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "axios-mock-adapter": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/xchain-bitcoincash/package.json
+++ b/packages/xchain-bitcoincash/package.json
@@ -50,7 +50,7 @@
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
     "@types/bitcore-lib-cash": "^8.23.8",
     "@types/cashaddrjs": "^0",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "axios-mock-adapter": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/xchain-client/package.json
+++ b/packages/xchain-client/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@xchainjs/xchain-crypto": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.16.1"
+    "axios": "1.18.1"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/xchain-cosmos/package.json
+++ b/packages/xchain-cosmos/package.json
@@ -46,7 +46,7 @@
     "@xchainjs/xchain-cosmos-sdk": "workspace:*",
     "@xchainjs/xchain-crypto": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "bignumber.js": "^11.0.0",
     "cosmjs-types": "0.9.0",
     "protobufjs": "7.6.4"

--- a/packages/xchain-dash/package.json
+++ b/packages/xchain-dash/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "axios-mock-adapter": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/xchain-doge/package.json
+++ b/packages/xchain-doge/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "axios-mock-adapter": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/xchain-evm-providers/package.json
+++ b/packages/xchain-evm-providers/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@xchainjs/xchain-client": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "ethers": "^6.14.3"
   }
 }

--- a/packages/xchain-evm/package.json
+++ b/packages/xchain-evm/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@ledgerhq/hw-transport": "^6.31.6",
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "axios-mock-adapter": "^2.1.0"
   }
 }

--- a/packages/xchain-litecoin/package.json
+++ b/packages/xchain-litecoin/package.json
@@ -41,7 +41,7 @@
     "@xchainjs/xchain-util": "workspace:*",
     "@xchainjs/xchain-utxo": "workspace:*",
     "@xchainjs/xchain-utxo-providers": "workspace:*",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "bitcoinjs-lib": "^6.1.7",
     "coinselect": "3.1.12",
     "ecpair": "2.1.0"

--- a/packages/xchain-mayachain-amm/package.json
+++ b/packages/xchain-mayachain-amm/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "axios-mock-adapter": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/xchain-mayachain-query/package.json
+++ b/packages/xchain-mayachain-query/package.json
@@ -38,7 +38,7 @@
     "@xchainjs/xchain-mayamidgard-query": "workspace:*",
     "@xchainjs/xchain-mayanode": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "axios-retry": "3.2.5",
     "bignumber.js": "^11.0.0"
   },

--- a/packages/xchain-mayachain/package.json
+++ b/packages/xchain-mayachain/package.json
@@ -47,7 +47,7 @@
     "@xchainjs/xchain-cosmos-sdk": "workspace:*",
     "@xchainjs/xchain-crypto": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "bignumber.js": "^11.0.0",
     "cosmjs-types": "0.9.0",
     "protobufjs": "7.6.4"

--- a/packages/xchain-mayamidgard-query/package.json
+++ b/packages/xchain-mayamidgard-query/package.json
@@ -35,7 +35,7 @@
     "@xchainjs/xchain-client": "workspace:*",
     "@xchainjs/xchain-mayamidgard": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "axios-retry": "^3.9.1"
   },
   "devDependencies": {

--- a/packages/xchain-mayamidgard/package.json
+++ b/packages/xchain-mayamidgard/package.json
@@ -34,7 +34,7 @@
     "clean:types:midgard": "rimraf ./src/generated/midgardApi"
   },
   "dependencies": {
-    "axios": "1.16.1"
+    "axios": "1.18.1"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.20.2",

--- a/packages/xchain-mayanode/package.json
+++ b/packages/xchain-mayanode/package.json
@@ -34,7 +34,7 @@
     "clean:types:mayanode": "rimraf ./src/generated/mayanodeApi"
   },
   "dependencies": {
-    "axios": "1.16.1"
+    "axios": "1.18.1"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.20.2",

--- a/packages/xchain-midgard-query/package.json
+++ b/packages/xchain-midgard-query/package.json
@@ -35,7 +35,7 @@
     "@xchainjs/xchain-client": "workspace:*",
     "@xchainjs/xchain-midgard": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "axios-retry": "^3.9.1"
   },
   "devDependencies": {

--- a/packages/xchain-midgard/package.json
+++ b/packages/xchain-midgard/package.json
@@ -34,7 +34,7 @@
     "clean:types:midgard": "rimraf ./src/generated/midgardApi"
   },
   "dependencies": {
-    "axios": "1.16.1"
+    "axios": "1.18.1"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.20.2",

--- a/packages/xchain-thorchain-amm/package.json
+++ b/packages/xchain-thorchain-amm/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "axios-mock-adapter": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/xchain-thorchain-query/package.json
+++ b/packages/xchain-thorchain-query/package.json
@@ -37,7 +37,7 @@
     "@xchainjs/xchain-midgard-query": "workspace:*",
     "@xchainjs/xchain-thornode": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "axios-retry": "3.2.5",
     "bignumber.js": "^11.0.0"
   },

--- a/packages/xchain-thorchain/package.json
+++ b/packages/xchain-thorchain/package.json
@@ -49,7 +49,7 @@
     "@xchainjs/xchain-cosmos-sdk": "workspace:*",
     "@xchainjs/xchain-crypto": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "bignumber.js": "^11.0.0",
     "cosmjs-types": "0.9.0",
     "protobufjs": "7.6.4"

--- a/packages/xchain-thornode/package.json
+++ b/packages/xchain-thornode/package.json
@@ -34,7 +34,7 @@
     "clean:types:thornode": "rimraf ./src/generated/thornodeApi"
   },
   "dependencies": {
-    "axios": "1.16.1"
+    "axios": "1.18.1"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.20.2",

--- a/packages/xchain-utxo-providers/package.json
+++ b/packages/xchain-utxo-providers/package.json
@@ -31,7 +31,7 @@
     "@supercharge/promise-pool": "2.4.0",
     "@xchainjs/xchain-client": "workspace:*",
     "@xchainjs/xchain-util": "workspace:*",
-    "axios": "1.16.1"
+    "axios": "1.18.1"
   },
   "devDependencies": {
     "axios-mock-adapter": "^2.1.0"

--- a/packages/zcash-js/package.json
+++ b/packages/zcash-js/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@noble/curves": "^1.7.0",
     "@noble/hashes": "^1.6.1",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "bs58check": "^4.0.0",
     "buffer": "^6.0.3",
     "json-rpc-2.0": "^1.7.0",

--- a/tools/xchain-suite/package.json
+++ b/tools/xchain-suite/package.json
@@ -63,7 +63,7 @@
     "autoprefixer": "^10.4.17",
     "jsdom": "^24.0.0",
     "node-stdlib-browser": "^1.2.0",
-    "postcss": "^8.4.35",
+    "postcss": "8.5.24",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.3.0",
     "vite": "^6.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5244,7 +5244,7 @@ __metadata:
     "@xchainjs/xchain-thorchain-query": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-wallet": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     axios-mock-adapter: "npm:^2.1.0"
   languageName: unknown
   linkType: soft
@@ -5305,7 +5305,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-utxo": "workspace:*"
     "@xchainjs/xchain-utxo-providers": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     axios-mock-adapter: "npm:^2.1.0"
     bitcoinjs-lib: "npm:^6.1.7"
     coinselect: "npm:3.1.12"
@@ -5327,7 +5327,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-utxo": "workspace:*"
     "@xchainjs/xchain-utxo-providers": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     axios-mock-adapter: "npm:^2.1.0"
     bitcore-lib-cash: "npm:11.0.0"
     bs58check: "npm:^4.0.0"
@@ -5369,7 +5369,7 @@ __metadata:
   dependencies:
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
   languageName: unknown
   linkType: soft
 
@@ -5410,7 +5410,7 @@ __metadata:
     "@xchainjs/xchain-cosmos-sdk": "workspace:*"
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     bignumber.js: "npm:^11.0.0"
     cosmjs-types: "npm:0.9.0"
     protobufjs: "npm:7.6.4"
@@ -5443,7 +5443,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-utxo": "workspace:*"
     "@xchainjs/xchain-utxo-providers": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     axios-mock-adapter: "npm:^2.1.0"
     bitcoinjs-lib: "npm:^6.1.7"
     coinselect: "npm:3.1.12"
@@ -5464,7 +5464,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-utxo": "workspace:*"
     "@xchainjs/xchain-utxo-providers": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     axios-mock-adapter: "npm:^2.1.0"
     bitcoinjs-lib: "npm:^6.1.7"
     coinselect: "npm:3.1.12"
@@ -5492,7 +5492,7 @@ __metadata:
   dependencies:
     "@xchainjs/xchain-client": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     ethers: "npm:^6.14.3"
   languageName: unknown
   linkType: soft
@@ -5508,7 +5508,7 @@ __metadata:
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-evm-providers": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     axios-mock-adapter: "npm:^2.1.0"
     bignumber.js: "npm:^11.0.0"
     ethers: "npm:^6.14.3"
@@ -5548,7 +5548,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-utxo": "workspace:*"
     "@xchainjs/xchain-utxo-providers": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     axios-mock-adapter: "npm:^2.1.0"
     bitcoinjs-lib: "npm:^6.1.7"
     coinselect: "npm:3.1.12"
@@ -5577,7 +5577,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-wallet": "workspace:*"
     "@xchainjs/xchain-zcash": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     axios-mock-adapter: "npm:^2.1.0"
     ethers: "npm:^6.14.3"
   languageName: unknown
@@ -5592,7 +5592,7 @@ __metadata:
     "@xchainjs/xchain-mayamidgard-query": "workspace:*"
     "@xchainjs/xchain-mayanode": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     axios-mock-adapter: "npm:2.1.0"
     axios-retry: "npm:3.2.5"
     bignumber.js: "npm:^11.0.0"
@@ -5616,7 +5616,7 @@ __metadata:
     "@xchainjs/xchain-cosmos-sdk": "workspace:*"
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     bignumber.js: "npm:^11.0.0"
     cosmjs-types: "npm:0.9.0"
     protobufjs: "npm:7.6.4"
@@ -5630,7 +5630,7 @@ __metadata:
     "@xchainjs/xchain-client": "workspace:*"
     "@xchainjs/xchain-mayamidgard": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     axios-mock-adapter: "npm:^2.1.0"
     axios-retry: "npm:^3.9.1"
   languageName: unknown
@@ -5641,7 +5641,7 @@ __metadata:
   resolution: "@xchainjs/xchain-mayamidgard@workspace:packages/xchain-mayamidgard"
   dependencies:
     "@openapitools/openapi-generator-cli": "npm:^2.20.2"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     rimraf: "npm:5.0.0"
   languageName: unknown
   linkType: soft
@@ -5651,7 +5651,7 @@ __metadata:
   resolution: "@xchainjs/xchain-mayanode@workspace:packages/xchain-mayanode"
   dependencies:
     "@openapitools/openapi-generator-cli": "npm:^2.20.2"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     rimraf: "npm:5.0.0"
   languageName: unknown
   linkType: soft
@@ -5663,7 +5663,7 @@ __metadata:
     "@xchainjs/xchain-client": "workspace:*"
     "@xchainjs/xchain-midgard": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     axios-mock-adapter: "npm:^2.1.0"
     axios-retry: "npm:^3.9.1"
     dotenv: "npm:16.0.0"
@@ -5675,7 +5675,7 @@ __metadata:
   resolution: "@xchainjs/xchain-midgard@workspace:packages/xchain-midgard"
   dependencies:
     "@openapitools/openapi-generator-cli": "npm:^2.20.2"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     rimraf: "npm:5.0.0"
   languageName: unknown
   linkType: soft
@@ -5776,7 +5776,7 @@ __metadata:
     "@xchainjs/xchain-util": "workspace:*"
     "@xchainjs/xchain-wallet": "workspace:*"
     "@xchainjs/xchain-zcash": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     axios-mock-adapter: "npm:^2.1.0"
     ethers: "npm:^6.14.3"
   languageName: unknown
@@ -5790,7 +5790,7 @@ __metadata:
     "@xchainjs/xchain-midgard-query": "workspace:*"
     "@xchainjs/xchain-thornode": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     axios-mock-adapter: "npm:2.1.0"
     axios-retry: "npm:3.2.5"
     bignumber.js: "npm:^11.0.0"
@@ -5816,7 +5816,7 @@ __metadata:
     "@xchainjs/xchain-cosmos-sdk": "workspace:*"
     "@xchainjs/xchain-crypto": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     bignumber.js: "npm:^11.0.0"
     cosmjs-types: "npm:0.9.0"
     protobufjs: "npm:7.6.4"
@@ -5828,7 +5828,7 @@ __metadata:
   resolution: "@xchainjs/xchain-thornode@workspace:packages/xchain-thornode"
   dependencies:
     "@openapitools/openapi-generator-cli": "npm:^2.20.2"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     rimraf: "npm:5.0.0"
   languageName: unknown
   linkType: soft
@@ -5862,7 +5862,7 @@ __metadata:
     "@supercharge/promise-pool": "npm:2.4.0"
     "@xchainjs/xchain-client": "workspace:*"
     "@xchainjs/xchain-util": "workspace:*"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     axios-mock-adapter: "npm:^2.1.0"
   languageName: unknown
   linkType: soft
@@ -5922,7 +5922,7 @@ __metadata:
     "@noble/curves": "npm:^1.7.0"
     "@noble/hashes": "npm:^1.6.1"
     "@types/lodash": "npm:^4.17.13"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     bs58check: "npm:^4.0.0"
     buffer: "npm:^6.0.3"
     json-rpc-2.0: "npm:^1.7.0"
@@ -6424,15 +6424,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.16.1":
-  version: 1.16.1
-  resolution: "axios@npm:1.16.1"
+"axios@npm:1.18.1":
+  version: 1.18.1
+  resolution: "axios@npm:1.18.1"
   dependencies:
     follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
     https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/2f77e37e6552bbff8a772d058fb09500198e9188c6b20dc799d82dbe12a8cb506f6eed4e4e62a9ba612a35cbab496faa26d68f9bff14a53af6d15c3e136391a7
+  checksum: 10c0/9d9378a3af0d0ad730a52ad9d15ec7201f3926ad6e7e8bbffc5ae21ca2835ad11d1d9598698f5dd9718917486039f55ea1d7dc23d8e44fa827a55cc3262c02fc
   languageName: node
   linkType: hard
 
@@ -12471,21 +12471,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
+"nanoid@npm:^3.3.16":
+  version: 3.3.16
+  resolution: "nanoid@npm:3.3.16"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.3.12":
-  version: 3.3.12
-  resolution: "nanoid@npm:3.3.12"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10c0/ba142b7b39e11e80c16dd74b0365d407880c87c1cf7e1480956981ae940ee36060fa5b6f092cd1e315184dd19244c657bd017d03327bd3c62247d691c5e8edfb
+  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
   languageName: node
   linkType: hard
 
@@ -13395,25 +13386,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.35, postcss@npm:^8.4.47":
-  version: 8.5.6
-  resolution: "postcss@npm:8.5.6"
+"postcss@npm:8.5.24":
+  version: 8.5.24
+  resolution: "postcss@npm:8.5.24"
   dependencies:
-    nanoid: "npm:^3.3.11"
+    nanoid: "npm:^3.3.16"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/5127cc7c91ed7a133a1b7318012d8bfa112da9ef092dddf369ae699a1f10ebbd89b1b9f25f3228795b84585c72aabd5ced5fc11f2ba467eedf7b081a66fad024
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.3, postcss@npm:^8.5.6":
-  version: 8.5.15
-  resolution: "postcss@npm:8.5.15"
-  dependencies:
-    nanoid: "npm:^3.3.12"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/7f2e63ae22fbe43aace1bf652bd99da4e90737c64194d49e51ddc9cd0f9e51ff2861a7d734379b494deffa03a880a5c65eec70bc29ee9ebaa7136dde3eee8f31
+  checksum: 10c0/b3854840ffee4604249a1bad97291105a974009d63b068b716dbee1d2e034bb965353a9fb4d6e957ede475b2acf4167cd4b1d41074f8dd3ce2fe488b60c8ce44
   languageName: node
   linkType: hard
 
@@ -16943,7 +16923,7 @@ __metadata:
     lightweight-charts: "npm:^4.2.0"
     lucide-react: "npm:^0.330.0"
     node-stdlib-browser: "npm:^1.2.0"
-    postcss: "npm:^8.4.35"
+    postcss: "npm:8.5.24"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     react-router-dom: "npm:^6.22.0"


### PR DESCRIPTION
## Summary

- Bump **axios** `1.16.1` → **`1.18.1`** (exact pin) in:
  - root `resolutions`
  - all 24 packages that declare axios as a direct dependency
- Fixes CI `yarn npm audit --all --severity high` failure from [GHSA-gcfj-64vw-6mp9](https://github.com/advisories/GHSA-gcfj-64vw-6mp9) (vulnerable range `>=1.15.2 <1.18.0`).
- Also pin **postcss** `8.5.24` (root resolution + `tools/xchain-suite`) so the same audit step stays green for the PostCSS sourceMappingURL highs that were failing alongside axios on #1728.

Exact pins only (no caret), consistent with #1695 / the April 2026 axios supply-chain incident.

## Why a separate PR

#1728 only changes THORChain default URLs but CI fails on install audit before build. This branch is from current `master` and unblocks audit-dependent PRs.

## Test plan

- [x] `yarn install` succeeds with axios@1.18.1 / postcss@8.5.24
- [x] `yarn npm audit --all --severity high` → `No audit suggestions`
- [ ] CI build/lint/test on this PR green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Axios across the project to address a known security vulnerability.
  - Pinned Axios to version 1.18.1 to prevent use of affected versions.

- **Chores**
  - Updated PostCSS to version 8.5.24.
  - Prepared patch releases for affected packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->