### PR TITLE
docs: add missing package READMEs and update root package list

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,14 @@ Blockchain clients with whom you can prepare, make and broadcast transactions, e
 |      [@xchainjs/xchain-kujira](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-kujira)      |        ✅        |       ❌       | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-kujira)](https://www.npmjs.com/package/@xchainjs/xchain-kujira)           |
 |      [@xchainjs/xchain-cosmos](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-cosmos)      |        ✅        |       ✅       | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-cosmos)](https://www.npmjs.com/package/@xchainjs/xchain-cosmos)           |
 |      [@xchainjs/xchain-solana](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-solana)      |        ✅        |       ❌       | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-solana)](https://www.npmjs.com/package/@xchainjs/xchain-solana)           |
-|     [@xchainjs/xchain-binance](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-binance)     |        ✅        |       ❌       | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-binance)](https://www.npmjs.com/package/@xchainjs/xchain-binance)         |
 |        [@xchainjs/xchain-base](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-base)        |        ✅        |       ✅       | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-base)](https://www.npmjs.com/package/@xchainjs/xchain-base)               |
 |       [@xchainjs/xchain-radix](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-radix)       |        ✅        |       ❌       | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-radix)](https://www.npmjs.com/package/@xchainjs/xchain-radix)             |
 |     [@xchainjs/xchain-cardano](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-cardano)     |        ✅        |       ❌       | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-cardano)](https://www.npmjs.com/package/@xchainjs/xchain-cardano)         |
 |       [@xchainjs/xchain-zcash](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-zcash)       |        ✅        |       ❌       | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-zcash)](https://www.npmjs.com/package/@xchainjs/xchain-zcash)             |
 |      [@xchainjs/xchain-ripple](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-ripple)      |        ✅        |       ❌       | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-ripple)](https://www.npmjs.com/package/@xchainjs/xchain-ripple)           |
-|      [@xchainjs/xchain-monero](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-monero)      |        ✅        |       ❌       | [\![npm](https://img.shields.io/npm/v/@xchainjs/xchain-monero)](https://www.npmjs.com/package/@xchainjs/xchain-monero)           |
+|      [@xchainjs/xchain-monero](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-monero)      |        ✅        |       ❌       | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-monero)](https://www.npmjs.com/package/@xchainjs/xchain-monero)           |
+|        [@xchainjs/xchain-tron](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-tron)        |        ✅        |       ❌       | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-tron)](https://www.npmjs.com/package/@xchainjs/xchain-tron)               |
+|         [@xchainjs/xchain-sui](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-sui)         |        ✅        |       ❌       | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-sui)](https://www.npmjs.com/package/@xchainjs/xchain-sui)                 |
 
 ### Utility packages
 
@@ -144,8 +145,6 @@ Data providers to retrieve blockchain data
 | [@xchainjs/xchain-utxo-providers](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-utxo-providers) | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-utxo-providers)](https://www.npmjs.com/package/@xchainjs/xchain-utxo-providers) |
 |  [@xchainjs/xchain-evm-providers](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-evm-providers)  | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-evm-providers)](https://www.npmjs.com/package/@xchainjs/xchain-evm-providers)   |
 
-</p>
-
 ### Protocol packages
 
 #### Thorchain
@@ -156,6 +155,7 @@ Packages to interact with Thorchain
 | :----------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------- |
 |        [@xchainjs/xchain-thornode](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-thornode)        | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-thornode)](https://www.npmjs.com/package/@xchainjs/xchain-thornode)               |
 |         [@xchainjs/xchain-midgard](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-midgard)         | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-midgard)](https://www.npmjs.com/package/@xchainjs/xchain-midgard)                 |
+|  [@xchainjs/xchain-midgard-query](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-midgard-query)  | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-midgard-query)](https://www.npmjs.com/package/@xchainjs/xchain-midgard-query)     |
 | [@xchainjs/xchain-thorchain-query](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-thorchain-query) | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-thorchain-query)](https://www.npmjs.com/package/@xchainjs/xchain-thorchain-query) |
 |   [@xchainjs/xchain-thorchain-amm](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-thorchain-amm)   | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-thorchain-amm)](https://www.npmjs.com/package/@xchainjs/xchain-thorchain-amm)     |
 
@@ -167,6 +167,7 @@ Packages to interact with Mayachain
 | :----------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------- |
 |        [@xchainjs/xchain-mayanode](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-mayanode)        | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-mayanode)](https://www.npmjs.com/package/@xchainjs/xchain-mayanode)               |
 |     [@xchainjs/xchain-mayamidgard](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-mayamidgard)     | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-mayamidgard)](https://www.npmjs.com/package/@xchainjs/xchain-mayamidgard)         |
+| [@xchainjs/xchain-mayamidgard-query](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-mayamidgard-query) | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-mayamidgard-query)](https://www.npmjs.com/package/@xchainjs/xchain-mayamidgard-query) |
 | [@xchainjs/xchain-mayachain-query](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-mayachain-query) | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-mayachain-query)](https://www.npmjs.com/package/@xchainjs/xchain-mayachain-query) |
 |   [@xchainjs/xchain-mayachain-amm](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-mayachain-amm)   | [![npm](https://img.shields.io/npm/v/@xchainjs/xchain-mayachain-amm)](https://www.npmjs.com/package/@xchainjs/xchain-mayachain-amm)     |
 

--- a/packages/xchain-dash/README.md
+++ b/packages/xchain-dash/README.md
@@ -52,9 +52,7 @@ This package uses the following service providers:
 | Transaction broadcast       | Insight API | https://insight.dash.org/insight-api               |
 | Explorer                    | Blockchair  | https://blockchair.com/dash                        |
 
-### UtxoOnlineDataProviders
-
-## default providers
+## Default providers
 
 Creating a no-arg DASH Client will default to the following settings:
 

--- a/packages/xchain-dash/README.md
+++ b/packages/xchain-dash/README.md
@@ -1,0 +1,108 @@
+# `@xchainjs/xchain-dash`
+
+## Modules
+
+- `client` - Custom client for communicating with Dash using [BIP39](https://github.com/bitcoinjs/bip39), [bitcoinjs-lib](https://github.com/bitcoinjs/bitcoinjs-lib), and [@dashevo/dashcore-lib](https://github.com/dashpay/dashcore-lib)
+- `clientKeystore` - Keystore-based client (`Client` default export alias)
+- `clientLedger` - Ledger hardware wallet client
+
+## Installation
+
+```
+yarn add @xchainjs/xchain-dash
+```
+
+Following peer dependencies have to be installed into your project. These are not included in `@xchainjs/xchain-dash`.
+
+```
+yarn add @xchainjs/xchain-client @xchainjs/xchain-crypto @xchainjs/xchain-util @xchainjs/xchain-utxo @xchainjs/xchain-utxo-providers axios bitcoinjs-lib
+```
+
+## Usage
+
+```typescript
+import { Client, defaultDashParams, AssetDASH } from '@xchainjs/xchain-dash'
+import { Network } from '@xchainjs/xchain-client'
+import { assetToBase, assetAmount } from '@xchainjs/xchain-util'
+
+const client = new Client({
+  ...defaultDashParams,
+  network: Network.Mainnet,
+  phrase: 'your mnemonic phrase',
+})
+
+const address = await client.getAddressAsync()
+const balances = await client.getBalance(address)
+
+const txHash = await client.transfer({
+  asset: AssetDASH,
+  recipient: 'X...',
+  amount: assetToBase(assetAmount('1', 8)),
+})
+```
+
+## Service Providers
+
+This package uses the following service providers:
+
+| Function                    | Service     | Notes                                              |
+| --------------------------- | ----------- | -------------------------------------------------- |
+| Balances / UTXOs            | BlockCypher | https://api.blockcypher.com/v1                     |
+| Transaction fees            | BitGo       | https://app.bitgo.com                              |
+| Transaction broadcast       | Insight API | https://insight.dash.org/insight-api               |
+| Explorer                    | Blockchair  | https://blockchair.com/dash                        |
+
+### UtxoOnlineDataProviders
+
+## default providers
+
+Creating a no-arg DASH Client will default to the following settings:
+
+```typescript
+const defaultDashParams: UtxoClientParams = {
+  network: Network.Mainnet,
+  phrase: '',
+  explorerProviders: explorerProviders,
+  dataProviders: [BlockcypherDataProviders, BitgoProviders],
+  rootDerivationPaths: {
+    [Network.Mainnet]: `m/44'/5'/0'/0/`,
+    [Network.Stagenet]: `m/44'/5'/0'/0/`,
+    [Network.Testnet]: `m/44'/1'/0'/0/`,
+  },
+  feeBounds: {
+    lower: LOWER_FEE_BOUND,
+    upper: UPPER_FEE_BOUND,
+  },
+  nodeUrls: {
+    [Network.Mainnet]: 'https://insight.dash.org/insight-api',
+    [Network.Stagenet]: 'https://insight.dash.org/insight-api',
+    [Network.Testnet]: 'http://insight.testnet.networks.dash.org:3001/insight-api',
+  },
+}
+```
+
+Note: BlockCypher is the default online data provider (to fetch realtime UTXOs, balances, etc), with BitGo as a secondary provider.
+
+## Overriding providers
+
+You can specify your own array of providers, which will be executed in array order, to provide automated failover to subsequent providers if calls to the first providers fail.
+
+```typescript
+import { Client, defaultDashParams, BlockcypherDataProviders, BitgoProviders } from '@xchainjs/xchain-dash'
+import { Network, UtxoClientParams } from '@xchainjs/xchain-client'
+
+// or set in env variables so default config can access.
+// `BLOCKCYPHER_API_KEY={YOUR_BLOCKCYPHER_API_KEY}`
+// process.env.BLOCKCYPHER_API_KEY
+
+const initParams: UtxoClientParams = {
+  ...defaultDashParams,
+  dataProviders: [BlockcypherDataProviders, BitgoProviders],
+  phrase: process.env.PHRASE,
+}
+const dashClient = new Client(initParams)
+```
+
+## Documentation
+
+More information about XChainJS clients can be found on [documentation](https://xchainjs.gitbook.io/xchainjs)

--- a/packages/xchain-sui/README.md
+++ b/packages/xchain-sui/README.md
@@ -92,10 +92,11 @@ With the Sui client you can:
 
 ## Explorer
 
-| Network | Explorer |
-| ------- | -------- |
-| Mainnet | https://suiscan.xyz/mainnet |
-| Testnet | https://suiscan.xyz/testnet |
+| Network  | Explorer |
+| -------- | -------- |
+| Mainnet  | https://suiscan.xyz/mainnet |
+| Testnet  | https://suiscan.xyz/testnet |
+| Stagenet | https://suiscan.xyz/mainnet (uses Mainnet explorer) |
 
 ## Documentation
 

--- a/packages/xchain-sui/README.md
+++ b/packages/xchain-sui/README.md
@@ -1,0 +1,102 @@
+# `@xchainjs/xchain-sui`
+
+## Modules
+
+- `client` - Custom client for communicating with the [Sui](https://sui.io/) blockchain using [@mysten/sui](https://github.com/MystenLabs/sui/tree/main/sdk/typescript)
+
+## Installation
+
+```
+yarn add @xchainjs/xchain-sui
+```
+
+Following peer dependencies have to be installed into your project. These are not included in `@xchainjs/xchain-sui`.
+
+```
+yarn add @xchainjs/xchain-client @xchainjs/xchain-crypto @xchainjs/xchain-util
+```
+
+## Usage
+
+Using the Sui client you can initialize the main class in consultation mode if you do not provide a phrase. That means you can retrieve information from the blockchain and prepare read operations, but you will not be able to sign transactions or derive owned addresses.
+
+```typescript
+import { Client } from '@xchainjs/xchain-sui'
+
+const client = new Client()
+
+// Make read operations with your client
+```
+
+To sign transactions and derive addresses, initialize with a mnemonic phrase:
+
+```typescript
+import { Client, defaultSuiParams, SUIAsset } from '@xchainjs/xchain-sui'
+import { Network } from '@xchainjs/xchain-client'
+import { assetToBase, assetAmount } from '@xchainjs/xchain-util'
+
+const client = new Client({
+  ...defaultSuiParams,
+  network: Network.Mainnet,
+  phrase: 'your mnemonic phrase',
+})
+
+const address = await client.getAddressAsync()
+const balances = await client.getBalance(address)
+
+const txHash = await client.transfer({
+  asset: SUIAsset,
+  recipient: '0x...',
+  amount: assetToBase(assetAmount('1', 9)), // 1 SUI (9 decimals)
+})
+```
+
+### Default parameters
+
+```typescript
+const defaultSuiParams = {
+  network: Network.Mainnet,
+  rootDerivationPaths: {
+    [Network.Mainnet]: "m/44'/784'/",
+    [Network.Testnet]: "m/44'/784'/",
+    [Network.Stagenet]: "m/44'/784'/",
+  },
+  explorerProviders: {
+    // Suiscan explorers for mainnet / testnet
+  },
+}
+```
+
+Default RPC endpoints:
+
+| Network  | URL                                      |
+| -------- | ---------------------------------------- |
+| Mainnet  | `https://fullnode.mainnet.sui.io:443`    |
+| Testnet  | `https://fullnode.testnet.sui.io:443`    |
+| Stagenet | `https://fullnode.mainnet.sui.io:443`    |
+
+You can override RPC URLs via `clientUrls` in the client params.
+
+## Features
+
+With the Sui client you can:
+
+- Get native SUI and coin/token balances for an address
+- Generate addresses from a secret phrase (SLIP-10, coin type `784`)
+- Transfer SUI and coins/tokens to another address
+- Get transaction details by digest
+- Get address transaction history
+- Estimate fees (gas-based model)
+
+**Note:** Memos are not supported for SUI transfers.
+
+## Explorer
+
+| Network | Explorer |
+| ------- | -------- |
+| Mainnet | https://suiscan.xyz/mainnet |
+| Testnet | https://suiscan.xyz/testnet |
+
+## Documentation
+
+More information about XChainJS clients can be found on [documentation](https://xchainjs.gitbook.io/xchainjs)

--- a/packages/xchain-utxo/README.md
+++ b/packages/xchain-utxo/README.md
@@ -1,0 +1,82 @@
+# `@xchainjs/xchain-utxo`
+
+## Modules
+
+- `client` - Abstract base client for UTXO-based chains (Bitcoin, Litecoin, Dash, Dogecoin, Bitcoin Cash, etc.)
+- `utxo-selector` - UTXO coin selection helpers
+- `strategies` - Coin selection strategies (branch-and-bound, accumulative, largest-first, small-first, single-random-draw)
+- `validators` - Transaction validation utilities
+- `errors` - UTXO-specific error types
+- `coininfo` / `toBitcoinJS` - Network parameter helpers for bitcoinjs-lib compatible coins
+
+## Installation
+
+```
+yarn add @xchainjs/xchain-utxo
+```
+
+Following peer dependencies have to be installed into your project. These are not included in `@xchainjs/xchain-utxo`.
+
+```
+yarn add @xchainjs/xchain-client @xchainjs/xchain-util @xchainjs/xchain-utxo-providers
+```
+
+## Overview
+
+This package provides the shared abstract `Client` used by UTXO chain packages in XChainJS. Chain-specific packages (for example `@xchainjs/xchain-bitcoin` or `@xchainjs/xchain-dash`) extend this base class and supply network constants, address formats, transaction building, and data providers.
+
+Typical responsibilities of the base UTXO client:
+
+- Explorer URL helpers
+- Balance and UTXO fetching via pluggable `UtxoOnlineDataProviders`
+- Transaction history and fee estimation wiring
+- UTXO selection strategies for building inputs
+- Shared types (`UTXO`, `UtxoClientParams`, `PreparedTx`, etc.)
+
+You generally do **not** instantiate this package directly in application code. Use a concrete chain client instead:
+
+```typescript
+import { Client, defaultBTCParams } from '@xchainjs/xchain-bitcoin'
+// or
+import { Client, defaultDashParams } from '@xchainjs/xchain-dash'
+```
+
+## Usage (library / package authors)
+
+When implementing a new UTXO chain client, extend the abstract `Client` and provide chain-specific logic:
+
+```typescript
+import { Client as UTXOClient, UtxoClientParams } from '@xchainjs/xchain-utxo'
+import { Network } from '@xchainjs/xchain-client'
+
+class Client extends UTXOClient {
+  constructor(params: UtxoClientParams) {
+    super('MYCHAIN', params)
+  }
+
+  // Implement abstract methods: address derivation, tx building, signing, etc.
+}
+```
+
+### Coin selection strategies
+
+```typescript
+import {
+  UtxoSelector,
+  // strategies are re-exported from the package
+} from '@xchainjs/xchain-utxo'
+```
+
+Strategies can be used when preparing transactions to control how inputs are chosen (fee efficiency, privacy, consolidating small UTXOs, etc.).
+
+## Related packages
+
+| Package | Role |
+| ------- | ---- |
+| [`@xchainjs/xchain-utxo-providers`](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-utxo-providers) | Online data providers (BlockCypher, Sochain, BitGo, Haskoin, etc.) |
+| [`@xchainjs/xchain-client`](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-client) | Base XChain client interface |
+| [`@xchainjs/xchain-bitcoin`](https://github.com/xchainjs/xchainjs-lib/tree/master/packages/xchain-bitcoin) | Example concrete UTXO client |
+
+## Documentation
+
+More information about XChainJS can be found on [documentation](https://xchainjs.gitbook.io/xchainjs)


### PR DESCRIPTION
## Summary
- Add READMEs for packages that were missing them: `@xchainjs/xchain-dash`, `@xchainjs/xchain-utxo`, and `@xchainjs/xchain-sui`
- Update the root `README.md` package tables:
  - Add **Sui** and **Tron** clients
  - Add **midgard-query** and **mayamidgard-query**
  - Remove dead **binance** package entry
  - Fix broken Monero npm badge
  - Remove stray `</p>`

## Test plan
- [ ] Confirm package README links from the root README resolve to the new files
- [ ] Spot-check install/usage snippets against current package APIs
- [ ] Verify all packages under `packages/` have a `README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the “Client packages” listing with additional supported modules and corrected an npm badge formatting issue.
  * Updated “Protocol packages” to include extra Midgard query entries for Thorchain and Mayachain.
  * Added complete README pages for DASH, SUI, and the shared UTXO client, including installation/peer requirements, configuration defaults, usage examples, supported capabilities, and references to further guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->