### PR TITLE
fix(sui): migrate off deprecated Foundation JSON-RPC fullnodes

### DIFF
--- a/.changeset/sui-grpc-graphql-migration.md
+++ b/.changeset/sui-grpc-graphql-migration.md
@@ -1,0 +1,9 @@
+---
+'@xchainjs/xchain-sui': minor
+---
+
+Migrate `@xchainjs/xchain-sui` off deprecated Sui Foundation JSON-RPC fullnodes.
+
+Defaults now use **gRPC** (`fullnode.*.sui.io`) for balances, fees, coins, and execution, and **GraphQL** (`graphql.*.sui.io`) for transaction history. Existing `clientUrls` pointing at Foundation fullnodes continue to work as gRPC base URLs.
+
+Optional `transport: 'jsonRpc'` remains for private nodes that still enable JSON-RPC. New optional `grpcUrls` / `graphqlUrls` params allow overriding each endpoint.

--- a/packages/xchain-sui/CHANGELOG.md
+++ b/packages/xchain-sui/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @xchainjs/xchain-sui
 
+## 0.2.0
+
+### Minor Changes
+
+- Migrate off deprecated Sui Foundation JSON-RPC fullnodes.
+  - Default transport is **gRPC** against `fullnode.*.sui.io` (balances, fees, coins, transfer execution).
+  - Transaction history uses **GraphQL** at `graphql.*.sui.io`.
+  - Existing `clientUrls` to Foundation fullnodes remain valid as gRPC base URLs (no consumer URL change required for that case).
+  - Optional `transport: 'jsonRpc'` for private nodes that still enable JSON-RPC.
+  - Optional `grpcUrls` / `graphqlUrls` for explicit endpoint overrides.
+  - See README for Asgardex / `clientUrls` migration notes and [JSON-RPC migration guide](https://docs.sui.io/develop/accessing-data/json-rpc-migration).
+
 ## 0.1.5
 
 ### Patch Changes
@@ -7,6 +19,7 @@
 - Updated dependencies [4ec2e3e]
   - @xchainjs/xchain-crypto@1.0.8
   - @xchainjs/xchain-client@2.0.16
+
 
 ## 0.1.4
 

--- a/packages/xchain-sui/README.md
+++ b/packages/xchain-sui/README.md
@@ -1,0 +1,141 @@
+# `@xchainjs/xchain-sui`
+
+## Modules
+
+- `client` - Custom client for communicating with the [Sui](https://sui.io/) blockchain using [@mysten/sui](https://github.com/MystenLabs/sui/tree/main/sdk/typescript)
+
+## Installation
+
+```sh
+yarn add @xchainjs/xchain-sui
+```
+
+## Network access (JSON-RPC deprecation)
+
+Sui Foundation **disabled JSON-RPC on public fullnodes** (week of 2026-07-27). Full decommission is planned mid-October 2026.
+
+See the [JSON-RPC migration guide](https://docs.sui.io/develop/accessing-data/json-rpc-migration).
+
+This package defaults to:
+
+| Role | Transport | Default mainnet URL |
+| ---- | --------- | ------------------- |
+| Balances, fees, coins, transfer execution | **gRPC** | `https://fullnode.mainnet.sui.io:443` |
+| Transaction history / archival lookups | **GraphQL** | `https://graphql.mainnet.sui.io/graphql` |
+
+`clientUrls` pointing at `fullnode.*.sui.io` still work: those hosts remain valid as **gRPC** base URLs. They no longer serve public JSON-RPC.
+
+### Migration for apps (e.g. Asgardex)
+
+```ts
+// Before: JSON-RPC against Foundation fullnodes (broken on public mainnet)
+clientUrls: {
+  mainnet: 'https://fullnode.mainnet.sui.io',
+  testnet: 'https://fullnode.testnet.sui.io',
+}
+
+// After: same URLs work with the default transport ('grpc').
+// No URL change required if you only used Foundation fullnodes.
+new Client({
+  ...defaultSuiParams,
+  clientUrls, // optional; defaults already use Foundation fullnode gRPC
+  phrase,
+})
+
+// Optional: explicit GraphQL endpoint for history
+new Client({
+  ...defaultSuiParams,
+  graphqlUrls: {
+    mainnet: 'https://graphql.mainnet.sui.io/graphql',
+    testnet: 'https://graphql.testnet.sui.io/graphql',
+    stagenet: 'https://graphql.mainnet.sui.io/graphql',
+  },
+  phrase,
+})
+
+// Optional: private node that still enables JSON-RPC
+new Client({
+  ...defaultSuiParams,
+  transport: 'jsonRpc',
+  clientUrls: {
+    mainnet: 'https://my-private-node.example/json-rpc',
+    // ...
+  },
+  phrase,
+})
+```
+
+Public Foundation endpoints are rate-limited and intended for development. Production apps should use a dedicated provider or self-hosted node.
+
+## Usage
+
+Read-only (no phrase):
+
+```typescript
+import { Client } from '@xchainjs/xchain-sui'
+
+const client = new Client()
+const balances = await client.getBalance('0x...')
+```
+
+Sign and transfer:
+
+```typescript
+import { Client, defaultSuiParams, SUIAsset } from '@xchainjs/xchain-sui'
+import { Network } from '@xchainjs/xchain-client'
+import { assetToBase, assetAmount } from '@xchainjs/xchain-util'
+
+const client = new Client({
+  ...defaultSuiParams,
+  network: Network.Mainnet,
+  phrase: 'your mnemonic phrase',
+})
+
+const address = await client.getAddressAsync()
+const balances = await client.getBalance(address)
+
+const txHash = await client.transfer({
+  asset: SUIAsset,
+  recipient: '0x...',
+  amount: assetToBase(assetAmount('1', 9)), // 1 SUI (9 decimals)
+})
+```
+
+### Default parameters
+
+```typescript
+const defaultSuiParams = {
+  network: Network.Mainnet,
+  transport: 'grpc',
+  rootDerivationPaths: {
+    [Network.Mainnet]: "m/44'/784'/",
+    [Network.Testnet]: "m/44'/784'/",
+    [Network.Stagenet]: "m/44'/784'/",
+  },
+  // clientUrls / grpcUrls → Foundation fullnode gRPC
+  // graphqlUrls → Foundation GraphQL
+}
+```
+
+## Features
+
+- Get native SUI and coin/token balances
+- Generate addresses from a secret phrase (SLIP-10, coin type `784`)
+- Transfer SUI and coins/tokens
+- Get transaction details by digest (GraphQL, with fullnode fallback)
+- Get address transaction history (GraphQL `affectedAddress`)
+- Estimate fees (gas-based model)
+
+**Note:** Memos are not supported for SUI transfers.
+
+## Explorer
+
+| Network  | Explorer |
+| -------- | -------- |
+| Mainnet  | https://suiscan.xyz/mainnet |
+| Testnet  | https://suiscan.xyz/testnet |
+| Stagenet | https://suiscan.xyz/mainnet (uses Mainnet explorer) |
+
+## Documentation
+
+More information about XChainJS clients can be found on [documentation](https://xchainjs.gitbook.io/xchainjs)

--- a/packages/xchain-sui/__tests__/client.test.ts
+++ b/packages/xchain-sui/__tests__/client.test.ts
@@ -1,7 +1,7 @@
 import { Network } from '@xchainjs/xchain-client'
 import { assetToString } from '@xchainjs/xchain-util'
 
-import { Client, defaultSuiParams } from '../src'
+import { Client, defaultSuiParams, getDefaultGraphqlUrl, getDefaultGrpcUrl } from '../src'
 
 describe('Sui client', () => {
   describe('Asset', () => {
@@ -10,6 +10,16 @@ describe('Sui client', () => {
       const assetInfo = client.getAssetInfo()
       expect(assetToString(assetInfo.asset)).toBe('SUI.SUI')
       expect(assetInfo.decimal).toBe(9)
+    })
+  })
+
+  describe('Defaults (post JSON-RPC deprecation)', () => {
+    it('Should default transport to grpc with Foundation fullnode and GraphQL URLs', () => {
+      expect(defaultSuiParams.transport).toBe('grpc')
+      expect(defaultSuiParams.clientUrls?.[Network.Mainnet]).toBe(getDefaultGrpcUrl(Network.Mainnet))
+      expect(defaultSuiParams.graphqlUrls?.[Network.Mainnet]).toBe(getDefaultGraphqlUrl(Network.Mainnet))
+      expect(getDefaultGrpcUrl(Network.Mainnet)).toContain('fullnode.mainnet.sui.io')
+      expect(getDefaultGraphqlUrl(Network.Mainnet)).toContain('graphql.mainnet.sui.io')
     })
   })
 

--- a/packages/xchain-sui/__tests__/client.test.ts
+++ b/packages/xchain-sui/__tests__/client.test.ts
@@ -1,7 +1,14 @@
 import { Network } from '@xchainjs/xchain-client'
 import { assetToString } from '@xchainjs/xchain-util'
 
-import { Client, defaultSuiParams, getDefaultGraphqlUrl, getDefaultGrpcUrl } from '../src'
+import {
+  Client,
+  defaultSuiParams,
+  getDefaultGraphqlUrl,
+  getDefaultGrpcUrl,
+  resolveGraphqlUrl,
+  resolvePrimaryUrl,
+} from '../src'
 
 describe('Sui client', () => {
   describe('Asset', () => {
@@ -16,10 +23,57 @@ describe('Sui client', () => {
   describe('Defaults (post JSON-RPC deprecation)', () => {
     it('Should default transport to grpc with Foundation fullnode and GraphQL URLs', () => {
       expect(defaultSuiParams.transport).toBe('grpc')
-      expect(defaultSuiParams.clientUrls?.[Network.Mainnet]).toBe(getDefaultGrpcUrl(Network.Mainnet))
-      expect(defaultSuiParams.graphqlUrls?.[Network.Mainnet]).toBe(getDefaultGraphqlUrl(Network.Mainnet))
+      // Endpoint maps are resolved in the client (not baked into defaultSuiParams)
+      // so consumer clientUrls are not shadowed by default grpcUrls.
+      expect(defaultSuiParams.clientUrls).toBeUndefined()
+      expect(defaultSuiParams.grpcUrls).toBeUndefined()
       expect(getDefaultGrpcUrl(Network.Mainnet)).toContain('fullnode.mainnet.sui.io')
       expect(getDefaultGraphqlUrl(Network.Mainnet)).toContain('graphql.mainnet.sui.io')
+      expect(resolvePrimaryUrl(Network.Mainnet)).toBe(getDefaultGrpcUrl(Network.Mainnet))
+      expect(resolveGraphqlUrl(Network.Mainnet)).toBe(getDefaultGraphqlUrl(Network.Mainnet))
+    })
+
+    it('Should honor consumer clientUrls over defaults (Asgardex-style spread)', () => {
+      const custom = 'https://my-private-node.example:443'
+      // Typical consumer pattern: spread defaults then set clientUrls
+      const url = resolvePrimaryUrl(Network.Mainnet, {
+        ...defaultSuiParams,
+        clientUrls: {
+          [Network.Mainnet]: custom,
+          [Network.Testnet]: custom,
+          [Network.Stagenet]: custom,
+        },
+      })
+      expect(url).toBe(custom)
+    })
+
+    it('Should prefer grpcUrls over clientUrls when both provided', () => {
+      const url = resolvePrimaryUrl(Network.Mainnet, {
+        grpcUrls: {
+          [Network.Mainnet]: 'https://grpc.example',
+          [Network.Testnet]: 'https://grpc.example',
+          [Network.Stagenet]: 'https://grpc.example',
+        },
+        clientUrls: {
+          [Network.Mainnet]: 'https://client.example',
+          [Network.Testnet]: 'https://client.example',
+          [Network.Stagenet]: 'https://client.example',
+        },
+      })
+      expect(url).toBe('https://grpc.example')
+    })
+
+    it('Should honor graphqlUrls override', () => {
+      const custom = 'https://graphql.example/graphql'
+      expect(
+        resolveGraphqlUrl(Network.Mainnet, {
+          graphqlUrls: {
+            [Network.Mainnet]: custom,
+            [Network.Testnet]: custom,
+            [Network.Stagenet]: custom,
+          },
+        }),
+      ).toBe(custom)
     })
   })
 

--- a/packages/xchain-sui/src/client.ts
+++ b/packages/xchain-sui/src/client.ts
@@ -30,7 +30,7 @@ import slip10 from 'micro-key-producer/slip10.js'
 
 import { DEFAULT_GAS_BUDGET, SUIAsset, SUIChain, SUI_DECIMALS, SUI_TYPE_TAG, defaultSuiParams } from './const'
 import { Balance, SUIClientParams, SuiTransport, Tx, TxFrom, TxParams, TxTo, TxsPage } from './types'
-import { getDefaultGraphqlUrl, getDefaultGrpcUrl, getSuiNetwork } from './utils'
+import { getSuiNetwork, resolveGraphqlUrl, resolvePrimaryUrl } from './utils'
 
 type CoreClient = SuiGrpcClient | SuiJsonRpcClient
 type GasCoinRef = { objectId: string; version: string | number; digest: string }
@@ -74,29 +74,22 @@ export class Client extends BaseXChainClient {
     const mergedParams = { ...defaultSuiParams, ...params }
     super(SUIChain, mergedParams)
     this.explorerProviders = mergedParams.explorerProviders
-    this.transport = mergedParams.transport ?? 'grpc'
+    this.transport = params.transport ?? mergedParams.transport ?? 'grpc'
 
-    const network = this.getNetwork()
+    // Resolve endpoints from caller params only (not shallow-merged defaults),
+    // so consumer `clientUrls` / `graphqlUrls` are not shadowed by baked-in maps.
     this.clientUrls = {
-      [Network.Mainnet]:
-        mergedParams.grpcUrls?.[Network.Mainnet] ||
-        mergedParams.clientUrls?.[Network.Mainnet] ||
-        getDefaultGrpcUrl(Network.Mainnet),
-      [Network.Testnet]:
-        mergedParams.grpcUrls?.[Network.Testnet] ||
-        mergedParams.clientUrls?.[Network.Testnet] ||
-        getDefaultGrpcUrl(Network.Testnet),
-      [Network.Stagenet]:
-        mergedParams.grpcUrls?.[Network.Stagenet] ||
-        mergedParams.clientUrls?.[Network.Stagenet] ||
-        getDefaultGrpcUrl(Network.Stagenet),
+      [Network.Mainnet]: resolvePrimaryUrl(Network.Mainnet, params),
+      [Network.Testnet]: resolvePrimaryUrl(Network.Testnet, params),
+      [Network.Stagenet]: resolvePrimaryUrl(Network.Stagenet, params),
     }
     this.graphqlUrls = {
-      [Network.Mainnet]: mergedParams.graphqlUrls?.[Network.Mainnet] || getDefaultGraphqlUrl(Network.Mainnet),
-      [Network.Testnet]: mergedParams.graphqlUrls?.[Network.Testnet] || getDefaultGraphqlUrl(Network.Testnet),
-      [Network.Stagenet]: mergedParams.graphqlUrls?.[Network.Stagenet] || getDefaultGraphqlUrl(Network.Stagenet),
+      [Network.Mainnet]: resolveGraphqlUrl(Network.Mainnet, params),
+      [Network.Testnet]: resolveGraphqlUrl(Network.Testnet, params),
+      [Network.Stagenet]: resolveGraphqlUrl(Network.Stagenet, params),
     }
 
+    const network = this.getNetwork()
     this.coreClient = this.createCoreClient(network)
     this.graphqlClient = this.createGraphqlClient(network)
   }
@@ -256,11 +249,12 @@ export class Client extends BaseXChainClient {
 
     // GraphQL supports affectedAddress (sent + received). Core API only supports sender.
     const nodes = await this.fetchGraphqlTransactions(address, limit + offset)
+    const decimalsCache = new Map<string, number>()
 
     const txs: Tx[] = []
     for (const node of nodes) {
       try {
-        txs.push(this.parseGraphqlTransactionNode(node))
+        txs.push(await this.parseGraphqlTransactionNode(node, decimalsCache))
       } catch {
         // Skip unparseable transactions
       }
@@ -578,6 +572,7 @@ export class Client extends BaseXChainClient {
       }
       await new Promise((r) => setTimeout(r, 1000))
     }
+    throw Error(`Timed out waiting for transaction ${digest} to be indexed`)
   }
 
   private async getTransactionDataFromGraphql(txId: string): Promise<Tx> {
@@ -655,7 +650,10 @@ export class Client extends BaseXChainClient {
     return nodes.slice(0, maxResults)
   }
 
-  private parseGraphqlTransactionNode(node: GraphqlTxNode): Tx {
+  private async parseGraphqlTransactionNode(
+    node: GraphqlTxNode,
+    decimalsCache: Map<string, number> = new Map(),
+  ): Promise<Tx> {
     const from: TxFrom[] = []
     const to: TxTo[] = []
     const changes = node.effects?.balanceChanges?.nodes || []
@@ -663,7 +661,11 @@ export class Client extends BaseXChainClient {
     for (const change of changes) {
       const coinType = change.coinType?.repr || SUI_TYPE_TAG
       const isSui = this.isSuiCoinType(coinType)
-      const decimals = isSui ? SUI_DECIMALS : SUI_DECIMALS // token decimals unknown in history path; use 9 fallback
+      let decimals = decimalsCache.get(coinType)
+      if (decimals === undefined) {
+        decimals = await this.getCoinDecimals(coinType)
+        decimalsCache.set(coinType, decimals)
+      }
       const asset = isSui ? SUIAsset : (assetFromStringEx(`SUI.${this.coinTypeToSymbol(coinType)}`) as TokenAsset)
       const changeAmount = BigInt(change.amount)
       const ownerAddress = change.owner?.address || ''

--- a/packages/xchain-sui/src/client.ts
+++ b/packages/xchain-sui/src/client.ts
@@ -1,7 +1,9 @@
-import { SuiClient as SuiRpcClient, SuiTransactionBlockResponse } from '@mysten/sui/client'
+import { SuiClient as SuiJsonRpcClient, SuiTransactionBlockResponse } from '@mysten/sui/client'
+import { SuiGraphQLClient } from '@mysten/sui/graphql'
+import { SuiGrpcClient } from '@mysten/sui/grpc'
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519'
 import { Transaction } from '@mysten/sui/transactions'
-import { isValidSuiAddress } from '@mysten/sui/utils'
+import { fromBase64, isValidSuiAddress } from '@mysten/sui/utils'
 import {
   AssetInfo,
   BaseXChainClient,
@@ -26,30 +28,83 @@ import {
 } from '@xchainjs/xchain-util'
 import slip10 from 'micro-key-producer/slip10.js'
 
-import { SUIAsset, SUIChain, SUI_DECIMALS, SUI_TYPE_TAG, defaultSuiParams } from './const'
-import { Balance, SUIClientParams, Tx, TxFrom, TxParams, TxTo, TxsPage } from './types'
-import { getDefaultClientUrl } from './utils'
+import { DEFAULT_GAS_BUDGET, SUIAsset, SUIChain, SUI_DECIMALS, SUI_TYPE_TAG, defaultSuiParams } from './const'
+import { Balance, SUIClientParams, SuiTransport, Tx, TxFrom, TxParams, TxTo, TxsPage } from './types'
+import { getDefaultGraphqlUrl, getDefaultGrpcUrl, getSuiNetwork } from './utils'
 
+type CoreClient = SuiGrpcClient | SuiJsonRpcClient
+type GasCoinRef = { objectId: string; version: string | number; digest: string }
+
+type GraphqlTxNode = {
+  digest: string
+  effects: {
+    timestamp: string | null
+    status: string
+    balanceChanges: {
+      nodes: Array<{
+        amount: string
+        coinType: { repr: string } | null
+        owner: { address: string } | null
+      }>
+    } | null
+  } | null
+}
+
+/**
+ * Sui client for XChainJS.
+ *
+ * Defaults to **gRPC** against Sui Foundation public fullnodes. Foundation JSON-RPC on
+ * `fullnode.*.sui.io` is deprecated (disabled week of 2026-07-27). Historical transaction
+ * queries use GraphQL (`graphql.*.sui.io`).
+ *
+ * Optional `transport: 'jsonRpc'` keeps the legacy JSON-RPC path for private nodes that
+ * still enable it.
+ *
+ * @see https://docs.sui.io/develop/accessing-data/json-rpc-migration
+ */
 export class Client extends BaseXChainClient {
   private explorerProviders: ExplorerProviders
-  private suiClient: SuiRpcClient
-  private clientUrls?: Record<Network, string>
+  private transport: SuiTransport
+  private clientUrls: Record<Network, string>
+  private graphqlUrls: Record<Network, string>
+  private coreClient: CoreClient
+  private graphqlClient: SuiGraphQLClient
 
   constructor(params: SUIClientParams = defaultSuiParams) {
     const mergedParams = { ...defaultSuiParams, ...params }
     super(SUIChain, mergedParams)
     this.explorerProviders = mergedParams.explorerProviders
-    this.clientUrls = mergedParams.clientUrls
-    this.suiClient = new SuiRpcClient({
-      url: this.clientUrls?.[this.getNetwork()] || getDefaultClientUrl(this.getNetwork()),
-    })
+    this.transport = mergedParams.transport ?? 'grpc'
+
+    const network = this.getNetwork()
+    this.clientUrls = {
+      [Network.Mainnet]:
+        mergedParams.grpcUrls?.[Network.Mainnet] ||
+        mergedParams.clientUrls?.[Network.Mainnet] ||
+        getDefaultGrpcUrl(Network.Mainnet),
+      [Network.Testnet]:
+        mergedParams.grpcUrls?.[Network.Testnet] ||
+        mergedParams.clientUrls?.[Network.Testnet] ||
+        getDefaultGrpcUrl(Network.Testnet),
+      [Network.Stagenet]:
+        mergedParams.grpcUrls?.[Network.Stagenet] ||
+        mergedParams.clientUrls?.[Network.Stagenet] ||
+        getDefaultGrpcUrl(Network.Stagenet),
+    }
+    this.graphqlUrls = {
+      [Network.Mainnet]: mergedParams.graphqlUrls?.[Network.Mainnet] || getDefaultGraphqlUrl(Network.Mainnet),
+      [Network.Testnet]: mergedParams.graphqlUrls?.[Network.Testnet] || getDefaultGraphqlUrl(Network.Testnet),
+      [Network.Stagenet]: mergedParams.graphqlUrls?.[Network.Stagenet] || getDefaultGraphqlUrl(Network.Stagenet),
+    }
+
+    this.coreClient = this.createCoreClient(network)
+    this.graphqlClient = this.createGraphqlClient(network)
   }
 
   public setNetwork(network: Network): void {
     super.setNetwork(network)
-    this.suiClient = new SuiRpcClient({
-      url: this.clientUrls?.[this.getNetwork()] || getDefaultClientUrl(this.getNetwork()),
-    })
+    this.coreClient = this.createCoreClient(network)
+    this.graphqlClient = this.createGraphqlClient(network)
   }
 
   public getAssetInfo(): AssetInfo {
@@ -95,39 +150,72 @@ export class Client extends BaseXChainClient {
   public async getBalance(address: Address, assets?: TokenAsset[]): Promise<Balance[]> {
     const balances: Balance[] = []
 
-    // Get native SUI balance
-    const suiBalance = await this.suiClient.getBalance({ owner: address })
+    if (this.isJsonRpc(this.coreClient)) {
+      const suiBalance = await this.coreClient.getBalance({ owner: address })
+      balances.push({
+        asset: SUIAsset,
+        amount: baseAmount(suiBalance.totalBalance, SUI_DECIMALS),
+      })
+
+      const allBalances = await this.coreClient.getAllBalances({ owner: address })
+      for (const coinBalance of allBalances) {
+        if (coinBalance.coinType === SUI_TYPE_TAG || this.isSuiCoinType(coinBalance.coinType)) continue
+
+        const tokenAsset = assetFromStringEx(`SUI.${this.coinTypeToSymbol(coinBalance.coinType)}`) as TokenAsset
+        if (assets && !assets.some((a) => eqAsset(a, tokenAsset))) continue
+
+        const decimals = await this.getCoinDecimals(coinBalance.coinType)
+        balances.push({
+          asset: tokenAsset,
+          amount: baseAmount(coinBalance.totalBalance, decimals),
+        })
+      }
+      return balances
+    }
+
+    const suiBalance = await this.coreClient.core.getBalance({
+      address,
+      coinType: SUI_TYPE_TAG,
+    })
     balances.push({
       asset: SUIAsset,
-      amount: baseAmount(suiBalance.totalBalance, SUI_DECIMALS),
+      amount: baseAmount(suiBalance.balance.balance, SUI_DECIMALS),
     })
 
-    // Get all coin balances if no specific assets requested, or filter by requested assets
-    const allBalances = await this.suiClient.getAllBalances({ owner: address })
-
-    for (const coinBalance of allBalances) {
-      // Skip native SUI (already added)
-      if (coinBalance.coinType === SUI_TYPE_TAG) continue
-
-      const tokenAsset = assetFromStringEx(`SUI.${this.coinTypeToSymbol(coinBalance.coinType)}`) as TokenAsset
-
-      if (assets && !assets.some((a) => eqAsset(a, tokenAsset))) continue
-
-      const decimals = await this.getCoinDecimals(coinBalance.coinType)
-
-      balances.push({
-        asset: tokenAsset,
-        amount: baseAmount(coinBalance.totalBalance, decimals),
+    let cursor: string | null = null
+    const decimalsCache = new Map<string, number>()
+    // Cap pages so pathological addresses cannot hang the client.
+    for (let pageNum = 0; pageNum < 20; pageNum++) {
+      const page = await this.coreClient.core.getAllBalances({
+        address,
+        cursor: cursor ?? undefined,
       })
+      for (const coinBalance of page.balances) {
+        if (this.isSuiCoinType(coinBalance.coinType)) continue
+
+        const tokenAsset = assetFromStringEx(`SUI.${this.coinTypeToSymbol(coinBalance.coinType)}`) as TokenAsset
+        if (assets && !assets.some((a) => eqAsset(a, tokenAsset))) continue
+
+        let decimals = decimalsCache.get(coinBalance.coinType)
+        if (decimals === undefined) {
+          decimals = await this.getCoinDecimals(coinBalance.coinType)
+          decimalsCache.set(coinBalance.coinType, decimals)
+        }
+        balances.push({
+          asset: tokenAsset,
+          amount: baseAmount(coinBalance.balance, decimals),
+        })
+      }
+      if (!page.hasNextPage || !page.cursor || page.cursor === cursor) break
+      cursor = page.cursor
     }
 
     return balances
   }
 
   public async getFees(): Promise<Fees> {
-    // SUI uses a gas-based fee model. Reference gas price from the network.
-    const gasPrice = await this.suiClient.getReferenceGasPrice()
-    const baseFee = BigInt(gasPrice) * BigInt(2000) // Estimate for a simple transfer
+    const gasPrice = await this.getReferenceGasPrice()
+    const baseFee = BigInt(gasPrice) * BigInt(2000)
 
     return {
       type: FeeType.FlatFee,
@@ -138,58 +226,47 @@ export class Client extends BaseXChainClient {
   }
 
   public async getTransactionData(txId: string): Promise<Tx> {
-    const txResponse = await this.suiClient.getTransactionBlock({
-      digest: txId,
-      options: {
-        showInput: true,
-        showEffects: true,
-        showBalanceChanges: true,
-      },
-    })
+    // Prefer GraphQL for history (fullnode gRPC retention is limited).
+    try {
+      return await this.getTransactionDataFromGraphql(txId)
+    } catch {
+      // Fall back to primary transport for very recent txs still in fullnode window.
+    }
 
-    return await this.parseTransaction(txResponse)
+    if (this.isJsonRpc(this.coreClient)) {
+      const txResponse = await this.coreClient.getTransactionBlock({
+        digest: txId,
+        options: {
+          showInput: true,
+          showEffects: true,
+          showBalanceChanges: true,
+        },
+      })
+      return this.parseJsonRpcTransaction(txResponse)
+    }
+
+    const { transaction } = await this.coreClient.core.getTransaction({ digest: txId })
+    return this.parseCoreTransaction(transaction.digest, transaction.balanceChanges, null)
   }
 
   public async getTransactions(params?: TxHistoryParams): Promise<TxsPage> {
     const address = params?.address || (await this.getAddressAsync())
     const limit = params?.limit || 50
+    const offset = params?.offset || 0
 
-    // Fetch all pages for FromAddress
-    const fromResponses = await this.fetchAllTransactionBlocks({ FromAddress: address }, limit)
-
-    // Fetch all pages for ToAddress
-    const toResponses = await this.fetchAllTransactionBlocks({ ToAddress: address }, limit)
-
-    // Merge and deduplicate by digest
-    const seen = new Set<string>()
-    const allTxResponses: SuiTransactionBlockResponse[] = []
-
-    for (const tx of [...fromResponses, ...toResponses]) {
-      if (!seen.has(tx.digest)) {
-        seen.add(tx.digest)
-        allTxResponses.push(tx)
-      }
-    }
-
-    // Sort by timestamp descending
-    allTxResponses.sort((a, b) => {
-      const timeA = Number(a.timestampMs || 0)
-      const timeB = Number(b.timestampMs || 0)
-      return timeB - timeA
-    })
+    // GraphQL supports affectedAddress (sent + received). Core API only supports sender.
+    const nodes = await this.fetchGraphqlTransactions(address, limit + offset)
 
     const txs: Tx[] = []
-    for (const txResponse of allTxResponses) {
+    for (const node of nodes) {
       try {
-        txs.push(await this.parseTransaction(txResponse))
+        txs.push(this.parseGraphqlTransactionNode(node))
       } catch {
         // Skip unparseable transactions
       }
     }
 
-    const offset = params?.offset || 0
     const paged = txs.slice(offset, offset + limit)
-
     return {
       txs: paged,
       total: txs.length,
@@ -200,113 +277,93 @@ export class Client extends BaseXChainClient {
     if (memo) throw Error('Memo is not supported for SUI transfers')
 
     const keypair = this.getKeypair(walletIndex || 0)
-    const tx = new Transaction()
-
-    if (!asset || eqAsset(asset, SUIAsset)) {
-      // Native SUI transfer
-      const [coin] = tx.splitCoins(tx.gas, [amount.amount().toString()])
-      tx.transferObjects([coin], recipient)
-    } else {
-      // Token transfer
-      const coinType = getContractAddressFromAsset(asset as TokenAsset)
-      const coins = await this.suiClient.getCoins({
-        owner: keypair.getPublicKey().toSuiAddress(),
-        coinType,
-      })
-
-      if (coins.data.length === 0) {
-        throw Error('No coins found for the specified asset')
-      }
-
-      // Merge all coins into the first one if there are multiple
-      const primaryCoin = tx.object(coins.data[0].coinObjectId)
-      if (coins.data.length > 1) {
-        tx.mergeCoins(
-          primaryCoin,
-          coins.data.slice(1).map((c) => tx.object(c.coinObjectId)),
-        )
-      }
-
-      const [splitCoin] = tx.splitCoins(primaryCoin, [amount.amount().toString()])
-      tx.transferObjects([splitCoin], recipient)
-    }
-
-    if (gasBudget) {
-      tx.setGasBudget(gasBudget.amount().toNumber())
-    }
-
-    const result = await this.suiClient.signAndExecuteTransaction({
-      signer: keypair,
-      transaction: tx,
-      options: { showEffects: true },
+    const sender = keypair.getPublicKey().toSuiAddress()
+    const { bytes } = await this.buildTransferTransaction({
+      sender,
+      recipient,
+      asset,
+      amount,
+      gasBudget,
     })
 
-    if (result.effects?.status?.status !== 'success') {
-      throw Error(`Transaction failed: ${result.effects?.status?.error || 'unknown error'}`)
+    const { signature } = await keypair.signTransaction(bytes)
+
+    if (this.isJsonRpc(this.coreClient)) {
+      const result = await this.coreClient.executeTransactionBlock({
+        transactionBlock: bytes,
+        signature,
+        options: { showEffects: true },
+      })
+      if (result.effects?.status?.status !== 'success') {
+        throw Error(`Transaction failed: ${result.effects?.status?.error || 'unknown error'}`)
+      }
+      await this.coreClient.waitForTransaction({ digest: result.digest })
+      return result.digest
     }
 
-    await this.suiClient.waitForTransaction({ digest: result.digest })
-
-    return result.digest
+    const execDigest = await this.executeGrpcTransaction(bytes, signature)
+    await this.waitForGraphqlTransaction(execDigest)
+    return execDigest
   }
 
   public async broadcastTx(txHex: string): Promise<TxHash> {
     const txBytes = Uint8Array.from(Buffer.from(txHex, 'hex'))
     const keypair = this.getKeypair(0)
-    const { signature, bytes } = await keypair.signTransaction(txBytes)
+    const { signature } = await keypair.signTransaction(txBytes)
 
-    const result = await this.suiClient.executeTransactionBlock({
-      transactionBlock: bytes,
-      signature,
-      options: { showEffects: true },
-    })
-
-    if (result.effects?.status?.status !== 'success') {
-      throw Error(`Transaction failed: ${result.effects?.status?.error || 'unknown error'}`)
+    if (this.isJsonRpc(this.coreClient)) {
+      const result = await this.coreClient.executeTransactionBlock({
+        transactionBlock: txBytes,
+        signature,
+        options: { showEffects: true },
+      })
+      if (result.effects?.status?.status !== 'success') {
+        throw Error(`Transaction failed: ${result.effects?.status?.error || 'unknown error'}`)
+      }
+      return result.digest
     }
 
-    return result.digest
+    return this.executeGrpcTransaction(txBytes, signature)
   }
 
   public async prepareTx({ walletIndex, memo, recipient, asset, amount, gasBudget }: TxParams): Promise<PreparedTx> {
     if (memo) throw Error('Memo is not supported for SUI transfers')
 
     const sender = await this.getAddressAsync(walletIndex ?? 0)
-    const tx = new Transaction()
-    tx.setSender(sender)
+    const { bytes } = await this.buildTransferTransaction({
+      sender,
+      recipient,
+      asset,
+      amount,
+      gasBudget,
+    })
 
-    if (!asset || eqAsset(asset, SUIAsset)) {
-      const [coin] = tx.splitCoins(tx.gas, [amount.amount().toString()])
-      tx.transferObjects([coin], recipient)
-    } else {
-      const coinType = getContractAddressFromAsset(asset as TokenAsset)
-      const coins = await this.suiClient.getCoins({
-        owner: sender,
-        coinType,
-      })
+    return { rawUnsignedTx: Buffer.from(bytes).toString('hex') }
+  }
 
-      if (coins.data.length === 0) {
-        throw Error('No coins found for the specified asset')
-      }
+  private createCoreClient(network: Network): CoreClient {
+    const url = this.clientUrls[network]
+    const suiNetwork = getSuiNetwork(network)
 
-      const primaryCoin = tx.object(coins.data[0].coinObjectId)
-      if (coins.data.length > 1) {
-        tx.mergeCoins(
-          primaryCoin,
-          coins.data.slice(1).map((c) => tx.object(c.coinObjectId)),
-        )
-      }
-
-      const [splitCoin] = tx.splitCoins(primaryCoin, [amount.amount().toString()])
-      tx.transferObjects([splitCoin], recipient)
+    if (this.transport === 'jsonRpc') {
+      return new SuiJsonRpcClient({ url })
     }
 
-    if (gasBudget) {
-      tx.setGasBudget(gasBudget.amount().toNumber())
-    }
+    return new SuiGrpcClient({
+      baseUrl: url,
+      network: suiNetwork,
+    })
+  }
 
-    const builtTx = await tx.build({ client: this.suiClient })
-    return { rawUnsignedTx: Buffer.from(builtTx).toString('hex') }
+  private createGraphqlClient(network: Network): SuiGraphQLClient {
+    return new SuiGraphQLClient({
+      url: this.graphqlUrls[network],
+      network: getSuiNetwork(network),
+    })
+  }
+
+  private isJsonRpc(client: CoreClient): client is SuiJsonRpcClient {
+    return this.transport === 'jsonRpc' && !(client instanceof SuiGrpcClient)
   }
 
   private getKeypair(index: number): Ed25519Keypair {
@@ -319,52 +376,330 @@ export class Client extends BaseXChainClient {
     return Ed25519Keypair.fromSecretKey(derived.privateKey)
   }
 
+  private async getReferenceGasPrice(): Promise<bigint> {
+    if (this.isJsonRpc(this.coreClient)) {
+      return this.coreClient.getReferenceGasPrice()
+    }
+    const { referenceGasPrice } = await this.coreClient.core.getReferenceGasPrice()
+    return BigInt(referenceGasPrice)
+  }
+
   private async getCoinDecimals(coinType: string): Promise<number> {
-    if (coinType === SUI_TYPE_TAG) return SUI_DECIMALS
+    if (this.isSuiCoinType(coinType)) return SUI_DECIMALS
+
+    if (this.isJsonRpc(this.coreClient)) {
+      try {
+        const metadata = await this.coreClient.getCoinMetadata({ coinType })
+        return metadata?.decimals ?? SUI_DECIMALS
+      } catch {
+        return SUI_DECIMALS
+      }
+    }
+
+    // Prefer a single GraphQL metadata lookup (lighter than full CoinInfo over gRPC).
     try {
-      const metadata = await this.suiClient.getCoinMetadata({ coinType })
-      return metadata?.decimals ?? SUI_DECIMALS
+      const response: { data?: { coinMetadata?: { decimals: number } | null } } = await this.graphqlClient.query({
+        query: `query ($coinType: String!) {
+            coinMetadata(coinType: $coinType) { decimals }
+          }`,
+        variables: { coinType },
+      })
+      if (response.data?.coinMetadata?.decimals != null) {
+        return response.data.coinMetadata.decimals
+      }
+    } catch {
+      // fall through
+    }
+
+    try {
+      const { response } = await this.coreClient.stateService.getCoinInfo({ coinType })
+      return response.metadata?.decimals ?? SUI_DECIMALS
     } catch {
       return SUI_DECIMALS
     }
   }
 
-  private async fetchAllTransactionBlocks(
-    filter: { FromAddress: string } | { ToAddress: string },
-    maxResults: number,
-  ): Promise<SuiTransactionBlockResponse[]> {
-    const results: SuiTransactionBlockResponse[] = []
-    let cursor: string | null | undefined = undefined
-    const pageSize = Math.min(maxResults, 50)
+  private async getCoins(owner: string, coinType: string): Promise<GasCoinRef[]> {
+    if (this.isJsonRpc(this.coreClient)) {
+      const page = await this.coreClient.getCoins({ owner, coinType })
+      return page.data.map((c) => ({
+        objectId: c.coinObjectId,
+        version: c.version,
+        digest: c.digest,
+      }))
+    }
 
-    do {
-      const page = await this.suiClient.queryTransactionBlocks({
-        filter,
-        options: {
-          showInput: true,
-          showEffects: true,
-          showBalanceChanges: true,
-        },
-        limit: pageSize,
-        cursor: cursor ?? undefined,
-      })
-
-      results.push(...page.data)
-      cursor = page.nextCursor
-
-      if (!page.hasNextPage || results.length >= maxResults) break
-    } while (cursor)
-
-    return results.slice(0, maxResults)
+    const page = await this.coreClient.core.getCoins({
+      address: owner,
+      coinType,
+    })
+    return page.objects.map((c) => ({
+      objectId: c.id,
+      version: c.version,
+      digest: c.digest,
+    }))
   }
 
-  private async parseTransaction(txResponse: SuiTransactionBlockResponse): Promise<Tx> {
+  /**
+   * Build a signed-ready transfer PTB with explicit gas payment.
+   * Avoids transaction resolution (unsupported on public gRPC/GraphQL clients).
+   */
+  private async buildTransferTransaction({
+    sender,
+    recipient,
+    asset,
+    amount,
+    gasBudget,
+  }: {
+    sender: string
+    recipient: string
+    asset?: TxParams['asset']
+    amount: TxParams['amount']
+    gasBudget?: TxParams['gasBudget']
+  }): Promise<{ bytes: Uint8Array }> {
+    const budget = gasBudget?.amount().toNumber() ?? DEFAULT_GAS_BUDGET
+    const gasPrice = await this.getReferenceGasPrice()
+    const gasCoins = await this.getCoins(sender, SUI_TYPE_TAG)
+    if (gasCoins.length === 0) {
+      throw Error('No SUI coins available for gas')
+    }
+
+    const tx = new Transaction()
+    tx.setSender(sender)
+    tx.setGasPayment([
+      {
+        objectId: gasCoins[0].objectId,
+        version: gasCoins[0].version,
+        digest: gasCoins[0].digest,
+      },
+    ])
+    tx.setGasBudget(budget)
+    tx.setGasPrice(gasPrice)
+
+    if (!asset || eqAsset(asset, SUIAsset)) {
+      const [coin] = tx.splitCoins(tx.gas, [amount.amount().toString()])
+      tx.transferObjects([coin], recipient)
+    } else {
+      const coinType = getContractAddressFromAsset(asset as TokenAsset)
+      const tokenCoins = await this.getCoins(sender, coinType)
+      if (tokenCoins.length === 0) {
+        throw Error('No coins found for the specified asset')
+      }
+
+      const primary = tx.objectRef({
+        objectId: tokenCoins[0].objectId,
+        version: tokenCoins[0].version,
+        digest: tokenCoins[0].digest,
+      })
+      if (tokenCoins.length > 1) {
+        tx.mergeCoins(
+          primary,
+          tokenCoins.slice(1).map((c) =>
+            tx.objectRef({
+              objectId: c.objectId,
+              version: c.version,
+              digest: c.digest,
+            }),
+          ),
+        )
+      }
+      const [splitCoin] = tx.splitCoins(primary, [amount.amount().toString()])
+      tx.transferObjects([splitCoin], recipient)
+    }
+
+    // Gas payment is set explicitly; no client resolution required.
+    const bytes = await tx.build()
+    return { bytes }
+  }
+
+  /**
+   * Execute via gRPC with a read mask compatible with current fullnodes.
+   * SDK 1.x core client requests invalid paths (`transaction.transaction`).
+   */
+  private async executeGrpcTransaction(transaction: Uint8Array, signature: string): Promise<string> {
+    if (!(this.coreClient instanceof SuiGrpcClient)) {
+      throw Error('gRPC client required for executeGrpcTransaction')
+    }
+
+    const { response } = await this.coreClient.transactionExecutionService.executeTransaction({
+      transaction: {
+        bcs: {
+          value: transaction,
+        },
+      },
+      signatures: [
+        {
+          bcs: {
+            value: fromBase64(signature),
+          },
+          signature: {
+            oneofKind: undefined,
+          },
+        },
+      ],
+      readMask: {
+        // Compatible with fullnode read-mask validation (SDK default paths break).
+        paths: ['digest', 'effects'],
+      },
+    })
+
+    const digest = response.transaction?.digest
+    if (!digest) {
+      throw Error('Transaction execution returned no digest')
+    }
+
+    const status = response.transaction?.effects?.status
+    // status may be enum number or object depending on protobuf version
+    if (status && typeof status === 'object' && 'success' in status && status.success === false) {
+      throw Error(`Transaction failed: ${JSON.stringify(status)}`)
+    }
+
+    return digest
+  }
+
+  private async waitForGraphqlTransaction(digest: string, timeoutMs = 60_000): Promise<void> {
+    const start = Date.now()
+    while (Date.now() - start < timeoutMs) {
+      try {
+        const response: { data?: { transaction?: { digest?: string } } } = await this.graphqlClient.query({
+          query: `query ($digest: String!) {
+            transaction(digest: $digest) {
+              digest
+              effects { status }
+            }
+          }`,
+          variables: { digest },
+        })
+        if (response.data?.transaction?.digest) {
+          return
+        }
+      } catch {
+        // keep polling
+      }
+      await new Promise((r) => setTimeout(r, 1000))
+    }
+  }
+
+  private async getTransactionDataFromGraphql(txId: string): Promise<Tx> {
+    const response: { data?: { transaction?: GraphqlTxNode | null } } = await this.graphqlClient.query({
+      query: `query ($digest: String!) {
+        transaction(digest: $digest) {
+          digest
+          effects {
+            timestamp
+            status
+            balanceChanges {
+              nodes {
+                amount
+                coinType { repr }
+                owner { address }
+              }
+            }
+          }
+        }
+      }`,
+      variables: { digest: txId },
+    })
+
+    const node = response.data?.transaction
+    if (!node) {
+      throw Error(`Transaction ${txId} not found`)
+    }
+    return this.parseGraphqlTransactionNode(node)
+  }
+
+  private async fetchGraphqlTransactions(address: string, maxResults: number): Promise<GraphqlTxNode[]> {
+    const nodes: GraphqlTxNode[] = []
+    let cursor: string | null = null
+    const pageSize = Math.min(maxResults, 50)
+
+    while (nodes.length < maxResults) {
+      const response: {
+        data?: {
+          transactions?: {
+            nodes: GraphqlTxNode[]
+            pageInfo: { hasNextPage: boolean; endCursor: string | null }
+          }
+        }
+      } = await this.graphqlClient.query({
+        query: `query ($address: SuiAddress!, $first: Int!, $after: String) {
+          transactions(first: $first, after: $after, filter: { affectedAddress: $address }) {
+            nodes {
+              digest
+              effects {
+                timestamp
+                status
+                balanceChanges {
+                  nodes {
+                    amount
+                    coinType { repr }
+                    owner { address }
+                  }
+                }
+              }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+        }`,
+        variables: { address, first: pageSize, after: cursor },
+      })
+
+      const page = response.data?.transactions
+      if (!page) break
+
+      nodes.push(...page.nodes)
+      if (!page.pageInfo.hasNextPage || !page.pageInfo.endCursor) break
+      cursor = page.pageInfo.endCursor
+    }
+
+    return nodes.slice(0, maxResults)
+  }
+
+  private parseGraphqlTransactionNode(node: GraphqlTxNode): Tx {
+    const from: TxFrom[] = []
+    const to: TxTo[] = []
+    const changes = node.effects?.balanceChanges?.nodes || []
+
+    for (const change of changes) {
+      const coinType = change.coinType?.repr || SUI_TYPE_TAG
+      const isSui = this.isSuiCoinType(coinType)
+      const decimals = isSui ? SUI_DECIMALS : SUI_DECIMALS // token decimals unknown in history path; use 9 fallback
+      const asset = isSui ? SUIAsset : (assetFromStringEx(`SUI.${this.coinTypeToSymbol(coinType)}`) as TokenAsset)
+      const changeAmount = BigInt(change.amount)
+      const ownerAddress = change.owner?.address || ''
+
+      if (changeAmount < BigInt(0)) {
+        from.push({
+          from: ownerAddress,
+          amount: baseAmount((-changeAmount).toString(), decimals),
+          asset,
+        })
+      } else if (changeAmount > BigInt(0)) {
+        to.push({
+          to: ownerAddress,
+          amount: baseAmount(changeAmount.toString(), decimals),
+          asset,
+        })
+      }
+    }
+
+    return {
+      asset: SUIAsset,
+      date: node.effects?.timestamp ? new Date(node.effects.timestamp) : new Date(0),
+      type: TxType.Transfer,
+      hash: node.digest,
+      from,
+      to,
+    }
+  }
+
+  private async parseJsonRpcTransaction(txResponse: SuiTransactionBlockResponse): Promise<Tx> {
     const from: TxFrom[] = []
     const to: TxTo[] = []
 
     if (txResponse.balanceChanges) {
       for (const change of txResponse.balanceChanges) {
-        const isSui = change.coinType === SUI_TYPE_TAG
+        const isSui = this.isSuiCoinType(change.coinType)
         const decimals = await this.getCoinDecimals(change.coinType)
         const asset = isSui
           ? SUIAsset
@@ -399,6 +734,52 @@ export class Client extends BaseXChainClient {
       from,
       to,
     }
+  }
+
+  private parseCoreTransaction(
+    digest: string,
+    balanceChanges: { coinType: string; address: string; amount: string }[] | undefined,
+    timestamp: string | null,
+  ): Tx {
+    const from: TxFrom[] = []
+    const to: TxTo[] = []
+
+    for (const change of balanceChanges || []) {
+      const isSui = this.isSuiCoinType(change.coinType)
+      const asset = isSui
+        ? SUIAsset
+        : (assetFromStringEx(`SUI.${this.coinTypeToSymbol(change.coinType)}`) as TokenAsset)
+      const changeAmount = BigInt(change.amount)
+
+      if (changeAmount < BigInt(0)) {
+        from.push({
+          from: change.address,
+          amount: baseAmount((-changeAmount).toString(), SUI_DECIMALS),
+          asset,
+        })
+      } else if (changeAmount > BigInt(0)) {
+        to.push({
+          to: change.address,
+          amount: baseAmount(changeAmount.toString(), SUI_DECIMALS),
+          asset,
+        })
+      }
+    }
+
+    return {
+      asset: SUIAsset,
+      date: timestamp ? new Date(timestamp) : new Date(0),
+      type: TxType.Transfer,
+      hash: digest,
+      from,
+      to,
+    }
+  }
+
+  private isSuiCoinType(coinType: string): boolean {
+    // Normalize padded package ids: 0x2 vs 0x000...002
+    const normalized = coinType.replace(/^0x0+/, '0x').toLowerCase()
+    return normalized === '0x2::sui::sui' || coinType === SUI_TYPE_TAG
   }
 
   private coinTypeToSymbol(coinType: string): string {

--- a/packages/xchain-sui/src/const.ts
+++ b/packages/xchain-sui/src/const.ts
@@ -2,7 +2,6 @@ import { ExplorerProvider, Network } from '@xchainjs/xchain-client'
 import { Asset, AssetType } from '@xchainjs/xchain-util'
 
 import { SUIClientParams } from './types'
-import { getDefaultGraphqlUrl, getDefaultGrpcUrl } from './utils'
 
 export const SUIChain = 'SUI' as const
 
@@ -26,6 +25,15 @@ const mainnetExplorer = new ExplorerProvider(
   'https://suiscan.xyz/mainnet/tx/%%TX_ID%%',
 )
 
+/**
+ * Default client params.
+ *
+ * Endpoint URLs are resolved in the Client constructor from caller overrides
+ * (`grpcUrls` / `clientUrls` / `graphqlUrls`) with Foundation public defaults
+ * as fallback. They are intentionally omitted here so spreading
+ * `defaultSuiParams` does not shadow consumer `clientUrls` with baked-in
+ * `grpcUrls` (shallow merge would otherwise ignore custom endpoints).
+ */
 export const defaultSuiParams: SUIClientParams = {
   network: Network.Mainnet,
   transport: 'grpc',
@@ -42,22 +50,5 @@ export const defaultSuiParams: SUIClientParams = {
       'https://suiscan.xyz/testnet/tx/%%TX_ID%%',
     ),
     [Network.Stagenet]: mainnetExplorer,
-  },
-  // Backward-compatible: consumers historically passed fullnode URLs as clientUrls.
-  // Those hosts still work as gRPC base URLs after JSON-RPC deprecation.
-  clientUrls: {
-    [Network.Mainnet]: getDefaultGrpcUrl(Network.Mainnet),
-    [Network.Testnet]: getDefaultGrpcUrl(Network.Testnet),
-    [Network.Stagenet]: getDefaultGrpcUrl(Network.Stagenet),
-  },
-  grpcUrls: {
-    [Network.Mainnet]: getDefaultGrpcUrl(Network.Mainnet),
-    [Network.Testnet]: getDefaultGrpcUrl(Network.Testnet),
-    [Network.Stagenet]: getDefaultGrpcUrl(Network.Stagenet),
-  },
-  graphqlUrls: {
-    [Network.Mainnet]: getDefaultGraphqlUrl(Network.Mainnet),
-    [Network.Testnet]: getDefaultGraphqlUrl(Network.Testnet),
-    [Network.Stagenet]: getDefaultGraphqlUrl(Network.Stagenet),
   },
 }

--- a/packages/xchain-sui/src/const.ts
+++ b/packages/xchain-sui/src/const.ts
@@ -2,6 +2,7 @@ import { ExplorerProvider, Network } from '@xchainjs/xchain-client'
 import { Asset, AssetType } from '@xchainjs/xchain-util'
 
 import { SUIClientParams } from './types'
+import { getDefaultGraphqlUrl, getDefaultGrpcUrl } from './utils'
 
 export const SUIChain = 'SUI' as const
 
@@ -16,6 +17,9 @@ export const SUIAsset: Asset = {
 
 export const SUI_TYPE_TAG = '0x2::sui::SUI'
 
+/** Gas budget estimate for a simple transfer (in MIST). */
+export const DEFAULT_GAS_BUDGET = 10_000_000
+
 const mainnetExplorer = new ExplorerProvider(
   'https://suiscan.xyz/mainnet',
   'https://suiscan.xyz/mainnet/account/%%ADDRESS%%',
@@ -24,6 +28,7 @@ const mainnetExplorer = new ExplorerProvider(
 
 export const defaultSuiParams: SUIClientParams = {
   network: Network.Mainnet,
+  transport: 'grpc',
   rootDerivationPaths: {
     [Network.Mainnet]: "m/44'/784'/",
     [Network.Testnet]: "m/44'/784'/",
@@ -37,5 +42,22 @@ export const defaultSuiParams: SUIClientParams = {
       'https://suiscan.xyz/testnet/tx/%%TX_ID%%',
     ),
     [Network.Stagenet]: mainnetExplorer,
+  },
+  // Backward-compatible: consumers historically passed fullnode URLs as clientUrls.
+  // Those hosts still work as gRPC base URLs after JSON-RPC deprecation.
+  clientUrls: {
+    [Network.Mainnet]: getDefaultGrpcUrl(Network.Mainnet),
+    [Network.Testnet]: getDefaultGrpcUrl(Network.Testnet),
+    [Network.Stagenet]: getDefaultGrpcUrl(Network.Stagenet),
+  },
+  grpcUrls: {
+    [Network.Mainnet]: getDefaultGrpcUrl(Network.Mainnet),
+    [Network.Testnet]: getDefaultGrpcUrl(Network.Testnet),
+    [Network.Stagenet]: getDefaultGrpcUrl(Network.Stagenet),
+  },
+  graphqlUrls: {
+    [Network.Mainnet]: getDefaultGraphqlUrl(Network.Mainnet),
+    [Network.Testnet]: getDefaultGraphqlUrl(Network.Testnet),
+    [Network.Stagenet]: getDefaultGraphqlUrl(Network.Stagenet),
   },
 }

--- a/packages/xchain-sui/src/index.ts
+++ b/packages/xchain-sui/src/index.ts
@@ -2,3 +2,4 @@ export { Client } from './client'
 
 export * from './types'
 export * from './const'
+export { getDefaultClientUrl, getDefaultGraphqlUrl, getDefaultGrpcUrl, getSuiNetwork } from './utils'

--- a/packages/xchain-sui/src/index.ts
+++ b/packages/xchain-sui/src/index.ts
@@ -2,4 +2,11 @@ export { Client } from './client'
 
 export * from './types'
 export * from './const'
-export { getDefaultClientUrl, getDefaultGraphqlUrl, getDefaultGrpcUrl, getSuiNetwork } from './utils'
+export {
+  getDefaultClientUrl,
+  getDefaultGraphqlUrl,
+  getDefaultGrpcUrl,
+  getSuiNetwork,
+  resolveGraphqlUrl,
+  resolvePrimaryUrl,
+} from './utils'

--- a/packages/xchain-sui/src/types.ts
+++ b/packages/xchain-sui/src/types.ts
@@ -11,9 +11,39 @@ import {
 } from '@xchainjs/xchain-client'
 import { Asset, BaseAmount, TokenAsset } from '@xchainjs/xchain-util'
 
+/**
+ * Primary data / execution transport.
+ *
+ * - `grpc` (default): Sui Foundation fullnode gRPC (`fullnode.*.sui.io`). Required for public mainnet after JSON-RPC deprecation.
+ * - `jsonRpc`: legacy JSON-RPC. Only works against private nodes that still enable JSON-RPC.
+ */
+export type SuiTransport = 'grpc' | 'jsonRpc'
+
 export type SUIClientParams = XChainClientParams & {
   explorerProviders: ExplorerProviders
+  /**
+   * Primary node base URLs per network.
+   *
+   * With the default `transport: 'grpc'`, these are **gRPC** base URLs
+   * (e.g. `https://fullnode.mainnet.sui.io:443`). The same host that previously
+   * served JSON-RPC still works for gRPC.
+   *
+   * With `transport: 'jsonRpc'`, these are JSON-RPC URLs for private nodes that
+   * still expose JSON-RPC.
+   *
+   * @deprecated Prefer `grpcUrls` / explicit `transport`. Still supported as the
+   * primary URL map for backward compatibility with Asgardex and other consumers.
+   */
   clientUrls?: Record<Network, string>
+  /** gRPC fullnode base URLs. Defaults to Sui Foundation public fullnodes. */
+  grpcUrls?: Record<Network, string>
+  /** GraphQL RPC URLs used for historical transaction queries. */
+  graphqlUrls?: Record<Network, string>
+  /**
+   * Primary transport. Defaults to `grpc`.
+   * Use `jsonRpc` only for private infrastructure that still enables JSON-RPC.
+   */
+  transport?: SuiTransport
 }
 
 export type CompatibleAsset = Asset | TokenAsset

--- a/packages/xchain-sui/src/utils.ts
+++ b/packages/xchain-sui/src/utils.ts
@@ -9,7 +9,11 @@ export const getSuiNetwork = (network: Network): 'mainnet' | 'testnet' => {
   return networkMap[network]
 }
 
-export const getDefaultClientUrl = (network: Network): string => {
+/**
+ * Default gRPC fullnode base URLs (Sui Foundation public nodes).
+ * JSON-RPC on these hosts is deprecated; use gRPC instead.
+ */
+export const getDefaultGrpcUrl = (network: Network): string => {
   const networkMap: { [key in Network]: string } = {
     [Network.Mainnet]: 'https://fullnode.mainnet.sui.io:443',
     [Network.Stagenet]: 'https://fullnode.mainnet.sui.io:443',
@@ -17,3 +21,22 @@ export const getDefaultClientUrl = (network: Network): string => {
   }
   return networkMap[network]
 }
+
+/**
+ * Default GraphQL RPC URLs (Sui Foundation public GraphQL).
+ * Used for historical transaction queries (fullnode gRPC retention is limited).
+ */
+export const getDefaultGraphqlUrl = (network: Network): string => {
+  const networkMap: { [key in Network]: string } = {
+    [Network.Mainnet]: 'https://graphql.mainnet.sui.io/graphql',
+    [Network.Stagenet]: 'https://graphql.mainnet.sui.io/graphql',
+    [Network.Testnet]: 'https://graphql.testnet.sui.io/graphql',
+  }
+  return networkMap[network]
+}
+
+/**
+ * @deprecated Use {@link getDefaultGrpcUrl}. Kept for callers that still import
+ * the old name; returns the gRPC fullnode URL (not JSON-RPC).
+ */
+export const getDefaultClientUrl = getDefaultGrpcUrl

--- a/packages/xchain-sui/src/utils.ts
+++ b/packages/xchain-sui/src/utils.ts
@@ -1,5 +1,7 @@
 import { Network } from '@xchainjs/xchain-client'
 
+import { SUIClientParams } from './types'
+
 export const getSuiNetwork = (network: Network): 'mainnet' | 'testnet' => {
   const networkMap: { [key in Network]: 'mainnet' | 'testnet' } = {
     [Network.Mainnet]: 'mainnet',
@@ -33,6 +35,28 @@ export const getDefaultGraphqlUrl = (network: Network): string => {
     [Network.Testnet]: 'https://graphql.testnet.sui.io/graphql',
   }
   return networkMap[network]
+}
+
+/**
+ * Resolve primary (gRPC / JSON-RPC) URL for a network.
+ *
+ * Precedence: `grpcUrls` → `clientUrls` → Foundation default.
+ * Pass **caller** params only (not a shallow-merge with defaults) so consumer
+ * `clientUrls` are not shadowed by baked-in default `grpcUrls`.
+ */
+export const resolvePrimaryUrl = (
+  network: Network,
+  params: Pick<SUIClientParams, 'grpcUrls' | 'clientUrls'> = {},
+): string => {
+  return params.grpcUrls?.[network] ?? params.clientUrls?.[network] ?? getDefaultGrpcUrl(network)
+}
+
+/**
+ * Resolve GraphQL URL for a network.
+ * Precedence: `graphqlUrls` → Foundation default.
+ */
+export const resolveGraphqlUrl = (network: Network, params: Pick<SUIClientParams, 'graphqlUrls'> = {}): string => {
+  return params.graphqlUrls?.[network] ?? getDefaultGraphqlUrl(network)
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix [#1732](https://github.com/xchainjs/xchainjs-lib/issues/1732): Sui Foundation disabled JSON-RPC on public fullnodes, breaking `@xchainjs/xchain-sui` defaults.
- Default transport is **gRPC** (`https://fullnode.*.sui.io:443`) for balances, fees, coins, and transfer execution.
- Transaction history / archival lookups use **GraphQL** (`https://graphql.*.sui.io/graphql`).
- Existing `clientUrls` pointing at Foundation fullnodes continue to work (same host, gRPC instead of JSON-RPC) — important for Asgardex Desktop.
- Optional `transport: 'jsonRpc'` for private nodes that still expose JSON-RPC.
- Optional `grpcUrls` / `graphqlUrls` overrides.
- Transfers set gas payment explicitly (transaction resolution is not supported on public gRPC/GraphQL clients).
- README + changeset document the migration.

## Test plan
- [x] Unit tests pass (`yarn workspace @xchainjs/xchain-sui test`)
- [x] Live mainnet smoke: `getBalance` + `getFees` over default gRPC
- [x] Live mainnet smoke: `transport: 'jsonRpc'` against Foundation fullnode fails with deprecation error
- [ ] Asgardex Desktop prerelease: balance + simple transfer on mainnet/testnet
- [ ] Review README migration notes for `clientUrls` consumers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated default Sui transport to gRPC for balances, fees, coins, and transaction execution; transaction history now uses GraphQL by default.
  * Added `DEFAULT_GAS_BUDGET` for simpler transfer estimation.
  * Added endpoint override support via `grpcUrls` and `graphqlUrls`, plus optional `transport: 'jsonRpc'` for compatible private nodes.
  * Re-exported endpoint helper utilities (including GraphQL/primary URL resolvers).

* **Documentation**
  * Updated README (peer dependency callouts) and added changelog/migration notes.

* **Tests**
  * Expanded client tests for transport and endpoint-resolution precedence/overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->