### PR TITLE
feat(suite): Ledger BTC/ETH connect and derivation path testing

### DIFF
--- a/tools/xchain-suite/README.md
+++ b/tools/xchain-suite/README.md
@@ -72,11 +72,22 @@ pnpm preview
 ## Usage
 
 ### Connect Wallet
-1. Click the wallet icon in the header
-2. Enter your BIP-39 mnemonic phrase
-3. Select network (Mainnet/Testnet/Stagenet)
+1. Click **Connect Wallet** in the header
+2. Choose one of:
+   - **Connect Ledger** (BTC + ETH via WebHID) — unlock the device, approve the browser prompt, open the Bitcoin or Ethereum app
+   - **Quick Connect** — temporary keystore or mnemonic (not saved)
+   - **Create / Import** — encrypted keystore stored in browser localStorage
 
-> **Security Note**: This tool stores your mnemonic in memory only. Never use mainnet wallets with significant funds for testing.
+#### Ledger (BTC + ETH)
+- Browser: Chrome / Edge (WebHID)
+- On the Ledger connect screen, pick:
+  - **BTC address format**: native SegWit, Taproot, legacy (`1…`), or nested SegWit (`3…`)
+  - **ETH derivation**: default BIP44 or Ledger Live account path
+  - **Account index**: BIP account slot (e.g. `m/84'/0'/N'/0/…`); ignored for Ledger Live ETH — use wallet index on Get Address
+  - **Custom root path** (optional): full override such as `m/84'/0'/5'/0/` or `m/44'/60'/{index}'/0/0`
+- Only **BTC** and **ETH** chain pages work in Ledger mode; other chains error with a clear message
+
+> **Security Note**: Phrase mode stores your mnemonic in memory only. Never use mainnet wallets with significant funds for testing.
 
 ### Making a Swap
 1. Navigate to **Swap** in the sidebar

--- a/tools/xchain-suite/package.json
+++ b/tools/xchain-suite/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "@chainflip/sdk": "2.2.1",
+    "@ledgerhq/hw-transport": "^6.31.6",
+    "@ledgerhq/hw-transport-webhid": "^6.29.4",
     "@xchainjs/xchain-arbitrum": "workspace:*",
     "@xchainjs/xchain-avax": "workspace:*",
     "@xchainjs/xchain-bitcoin": "workspace:*",

--- a/tools/xchain-suite/src/components/layout/Header.tsx
+++ b/tools/xchain-suite/src/components/layout/Header.tsx
@@ -4,7 +4,7 @@ import { WalletConnect } from '../wallet/WalletConnect'
 import { Wallet } from 'lucide-react'
 
 export function Header() {
-  const { isConnected, activeWalletName, disconnect } = useWallet()
+  const { isConnected, activeWalletName, disconnect, walletType } = useWallet()
   const [showConnectModal, setShowConnectModal] = useState(false)
 
   return (
@@ -23,6 +23,7 @@ export function Header() {
                   <Wallet className="w-4 h-4 text-green-600 dark:text-green-400" />
                   <span className="text-sm font-medium text-green-700 dark:text-green-300">
                     {activeWalletName || 'Connected'}
+                    {walletType === 'ledger' ? ' · Ledger' : ''}
                   </span>
                 </div>
                 <button

--- a/tools/xchain-suite/src/components/wallet/WalletConnect.tsx
+++ b/tools/xchain-suite/src/components/wallet/WalletConnect.tsx
@@ -1,9 +1,23 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, useMemo } from 'react'
 import { useWallet, type SavedWallet } from '../../contexts/WalletContext'
-import { Wallet, Plus, Upload, Key, Trash2, Download, Eye, EyeOff, Zap } from 'lucide-react'
+import { Wallet, Plus, Upload, Key, Trash2, Download, Eye, EyeOff, Zap, Cpu } from 'lucide-react'
 import type { Keystore } from '@xchainjs/xchain-crypto'
+import type { BtcAddressFormatOption, EthDerivationStyle } from '../../lib/ledger/types'
+import { previewRootPath } from '../../lib/ledger/paths'
 
-type ViewMode = 'list' | 'create' | 'import-phrase' | 'import-keystore' | 'unlock' | 'quick-connect'
+const BTC_BASE_ROOT: Record<BtcAddressFormatOption, string> = {
+  p2wpkh: "m/84'/0'/0'/0/",
+  p2tr: "m/86'/0'/0'/0/",
+  p2pkh: "m/44'/0'/0'/0/",
+  'p2sh-p2wpkh': "m/49'/0'/0'/0/",
+}
+
+const ETH_BASE_ROOT: Record<EthDerivationStyle, string> = {
+  default: "m/44'/60'/0'/0/",
+  ledgerLive: "m/44'/60'/{index}'/0/0",
+}
+
+type ViewMode = 'list' | 'create' | 'import-phrase' | 'import-keystore' | 'unlock' | 'quick-connect' | 'ledger'
 
 interface WalletConnectProps {
   onClose: () => void
@@ -14,6 +28,7 @@ export function WalletConnect({ onClose }: WalletConnectProps) {
     savedWallets,
     connect,
     connectWithKeystore,
+    connectLedger,
     createWallet,
     importFromPhrase,
     importFromKeystore,
@@ -34,6 +49,10 @@ export function WalletConnect({ onClose }: WalletConnectProps) {
   const [keystoreFile, setKeystoreFile] = useState<Keystore | null>(null)
   const [keystoreFileName, setKeystoreFileName] = useState('')
   const [quickConnectMode, setQuickConnectMode] = useState<'phrase' | 'keystore'>('keystore')
+  const [btcAddressFormat, setBtcAddressFormat] = useState<BtcAddressFormatOption>('p2wpkh')
+  const [ethDerivationStyle, setEthDerivationStyle] = useState<EthDerivationStyle>('default')
+  const [accountIndex, setAccountIndex] = useState(0)
+  const [customRootPath, setCustomRootPath] = useState('')
 
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
@@ -41,6 +60,19 @@ export function WalletConnect({ onClose }: WalletConnectProps) {
 
   const fileInputRef = useRef<HTMLInputElement>(null)
   const quickConnectFileRef = useRef<HTMLInputElement>(null)
+
+  const pathOverrides = useMemo(
+    () => ({ accountIndex, customRootPath }),
+    [accountIndex, customRootPath],
+  )
+  const btcPathPreview = useMemo(
+    () => previewRootPath(BTC_BASE_ROOT[btcAddressFormat], pathOverrides, 'btc'),
+    [btcAddressFormat, pathOverrides],
+  )
+  const ethPathPreview = useMemo(
+    () => previewRootPath(ETH_BASE_ROOT[ethDerivationStyle], pathOverrides, 'eth'),
+    [ethDerivationStyle, pathOverrides],
+  )
 
   const resetForm = () => {
     setWalletName('')
@@ -51,6 +83,10 @@ export function WalletConnect({ onClose }: WalletConnectProps) {
     setKeystoreFileName('')
     setError(null)
     setGeneratedPhrase(null)
+    setBtcAddressFormat('p2wpkh')
+    setEthDerivationStyle('default')
+    setAccountIndex(0)
+    setCustomRootPath('')
   }
 
   const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -195,6 +231,30 @@ export function WalletConnect({ onClose }: WalletConnectProps) {
     }
   }
 
+  const handleConnectLedger = async () => {
+    setError(null)
+    setIsLoading(true)
+    try {
+      if (accountIndex < 0 || !Number.isInteger(accountIndex)) {
+        setError('Account index must be a non-negative integer')
+        return
+      }
+      const result = await connectLedger({
+        btcAddressFormat,
+        ethDerivationStyle,
+        accountIndex,
+        customRootPath: customRootPath.trim(),
+      })
+      if (result.success) {
+        onClose()
+      } else {
+        setError(result.error || 'Failed to connect Ledger')
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
   const handleQuickConnectPhrase = async () => {
     setError(null)
 
@@ -262,6 +322,24 @@ export function WalletConnect({ onClose }: WalletConnectProps) {
 
   const renderWalletList = () => (
     <>
+      {/* Ledger */}
+      <div className="mb-3">
+        <button
+          onClick={() => { resetForm(); setViewMode('ledger') }}
+          className="w-full flex items-center gap-3 p-3 bg-gradient-to-r from-indigo-50 to-violet-50 dark:from-indigo-900/30 dark:to-violet-900/30 border border-indigo-200 dark:border-indigo-800 rounded-lg hover:from-indigo-100 hover:to-violet-100 dark:hover:from-indigo-900/50 dark:hover:to-violet-900/50 transition-colors"
+        >
+          <div className="p-2 bg-indigo-100 dark:bg-indigo-900/50 rounded-full">
+            <Cpu className="w-5 h-5 text-indigo-600 dark:text-indigo-400" />
+          </div>
+          <div className="text-left">
+            <p className="font-medium text-gray-900 dark:text-gray-100">Connect Ledger</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              BTC + ETH via WebHID — open the chain app on the device
+            </p>
+          </div>
+        </button>
+      </div>
+
       {/* Quick Connect Option */}
       <div className="mb-4">
         <button
@@ -766,6 +844,111 @@ export function WalletConnect({ onClose }: WalletConnectProps) {
     </div>
   )
 
+  const renderLedgerForm = () => (
+    <div className="space-y-4">
+      <div className="p-3 bg-indigo-50 dark:bg-indigo-900/30 border border-indigo-200 dark:border-indigo-800 rounded-md">
+        <p className="text-sm text-indigo-900 dark:text-indigo-200">
+          Unlock your Ledger, enable WebHID when prompted, and open the <strong>Bitcoin</strong> or{' '}
+          <strong>Ethereum</strong> app before running chain operations. Other chains are not supported in Ledger mode.
+        </p>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          BTC address format
+        </label>
+        <select
+          value={btcAddressFormat}
+          onChange={(e) => setBtcAddressFormat(e.target.value as BtcAddressFormatOption)}
+          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+        >
+          <option value="p2wpkh">Native SegWit (P2WPKH / bc1q… / BIP84)</option>
+          <option value="p2tr">Taproot (P2TR / bc1p… / BIP86)</option>
+          <option value="p2pkh">Legacy (P2PKH / 1… / BIP44)</option>
+          <option value="p2sh-p2wpkh">Nested SegWit (P2SH-P2WPKH / 3… / BIP49)</option>
+        </select>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          ETH derivation style
+        </label>
+        <select
+          value={ethDerivationStyle}
+          onChange={(e) => setEthDerivationStyle(e.target.value as EthDerivationStyle)}
+          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+        >
+          <option value="default">Default BIP44 (m/44&apos;/60&apos;/0&apos;/0/index)</option>
+          <option value="ledgerLive">Ledger Live (m/44&apos;/60&apos;/index&apos;/0/0)</option>
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="accountIndex" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Account index
+        </label>
+        <input
+          id="accountIndex"
+          type="number"
+          min={0}
+          step={1}
+          value={accountIndex}
+          onChange={(e) => setAccountIndex(Math.max(0, parseInt(e.target.value, 10) || 0))}
+          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+        />
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          BIP account slot (default 0). Rewrites e.g. m/84&apos;/0&apos;/<strong>{accountIndex}</strong>&apos;/0/.
+          No effect on Ledger Live ETH — use wallet index on Get Address instead.
+        </p>
+      </div>
+
+      <div>
+        <label htmlFor="customRootPath" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Custom root path <span className="font-normal text-gray-500">(optional)</span>
+        </label>
+        <input
+          id="customRootPath"
+          type="text"
+          value={customRootPath}
+          onChange={(e) => setCustomRootPath(e.target.value)}
+          placeholder="e.g. m/84'/0'/5'/0/ or m/44'/60'/{index}'/0/0"
+          spellCheck={false}
+          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm font-mono"
+        />
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          Overrides account index when set. BTC purpose must match the format above (m/84&apos;, m/86&apos;, m/44&apos;, or m/49&apos;).
+          Use <code className="text-[11px]">{'{index}'}</code> for Ledger Live–style ETH paths.
+        </p>
+      </div>
+
+      <div className="p-3 bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 rounded-md space-y-1">
+        <p className="text-xs font-medium text-gray-700 dark:text-gray-300">Effective root (preview)</p>
+        <p className="text-xs font-mono text-gray-600 dark:text-gray-400 break-all">
+          BTC: {btcPathPreview}
+          <span className="text-gray-400 dark:text-gray-500">{'{walletIndex}'}</span>
+        </p>
+        <p className="text-xs font-mono text-gray-600 dark:text-gray-400 break-all">
+          ETH:{' '}
+          {ethPathPreview.includes('{index}')
+            ? ethPathPreview
+            : `${ethPathPreview.replace(/\/$/, '')}/` + '{walletIndex}'}
+        </p>
+      </div>
+
+      <button
+        onClick={handleConnectLedger}
+        disabled={isLoading}
+        className="w-full px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {isLoading ? 'Connecting…' : 'Connect Ledger (WebHID)'}
+      </button>
+
+      <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
+        Requires Chrome, Edge, or another Chromium browser with WebHID.
+      </p>
+    </div>
+  )
+
   const getTitle = () => {
     switch (viewMode) {
       case 'list': return 'Connect Wallet'
@@ -774,6 +957,7 @@ export function WalletConnect({ onClose }: WalletConnectProps) {
       case 'import-keystore': return 'Import Keystore'
       case 'unlock': return 'Unlock Wallet'
       case 'quick-connect': return 'Quick Connect'
+      case 'ledger': return 'Connect Ledger'
     }
   }
 
@@ -812,7 +996,7 @@ export function WalletConnect({ onClose }: WalletConnectProps) {
             </button>
           </div>
 
-          {viewMode !== 'unlock' && viewMode !== 'quick-connect' && (
+          {viewMode !== 'unlock' && viewMode !== 'quick-connect' && viewMode !== 'ledger' && (
             <div className="mb-4 p-3 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800 rounded-md">
               <p className="text-sm text-amber-800 dark:text-amber-300">
                 <strong>Warning:</strong> Testing only. Do not use with significant funds.
@@ -832,6 +1016,7 @@ export function WalletConnect({ onClose }: WalletConnectProps) {
           {viewMode === 'import-keystore' && renderImportKeystoreForm()}
           {viewMode === 'unlock' && renderUnlockForm()}
           {viewMode === 'quick-connect' && renderQuickConnectForm()}
+          {viewMode === 'ledger' && renderLedgerForm()}
         </div>
       </div>
     </div>

--- a/tools/xchain-suite/src/contexts/WalletContext.tsx
+++ b/tools/xchain-suite/src/contexts/WalletContext.tsx
@@ -1,6 +1,14 @@
 import { createContext, useContext, useState, useCallback, useEffect, ReactNode, useMemo } from 'react'
+import type Transport from '@ledgerhq/hw-transport'
 import { validatePhrase, encryptToKeyStore, decryptFromKeystore, generatePhrase, type Keystore } from '@xchainjs/xchain-crypto'
 import { Network } from '@xchainjs/xchain-client'
+
+import { closeLedgerTransport, openLedgerTransport } from '../lib/ledger/transport'
+import type {
+  BtcAddressFormatOption,
+  EthDerivationStyle,
+  SuiteWalletType,
+} from '../lib/ledger/types'
 
 const WALLETS_STORAGE_KEY = 'xchainjs-testing-gui-wallets'
 const ACTIVE_WALLET_KEY = 'xchainjs-testing-gui-active-wallet'
@@ -12,9 +20,24 @@ export interface SavedWallet {
   createdAt: number
 }
 
+export type ConnectLedgerOptions = {
+  btcAddressFormat?: BtcAddressFormatOption
+  ethDerivationStyle?: EthDerivationStyle
+  /** BIP account index (default 0). No effect on Ledger Live ETH `{index}` paths. */
+  accountIndex?: number
+  /** Optional root path override for BTC/ETH, e.g. m/84'/0'/5'/0/ */
+  customRootPath?: string
+}
+
 interface WalletContextValue {
   // Current session
   phrase: string | null
+  walletType: SuiteWalletType
+  transport: Transport | null
+  btcAddressFormat: BtcAddressFormatOption
+  ethDerivationStyle: EthDerivationStyle
+  accountIndex: number
+  customRootPath: string
   isConnected: boolean
   network: Network
   activeWalletId: string | null
@@ -24,7 +47,12 @@ interface WalletContextValue {
   savedWallets: SavedWallet[]
   connect: (phrase: string) => { success: boolean; error?: string }
   connectWithKeystore: (keystore: Keystore, password: string, walletName?: string) => Promise<{ success: boolean; error?: string }>
+  connectLedger: (options?: ConnectLedgerOptions) => Promise<{ success: boolean; error?: string }>
   disconnect: () => void
+  setBtcAddressFormat: (format: BtcAddressFormatOption) => void
+  setEthDerivationStyle: (style: EthDerivationStyle) => void
+  setAccountIndex: (index: number) => void
+  setCustomRootPath: (path: string) => void
 
   // Keystore operations (save to storage)
   createWallet: (name: string, password: string) => Promise<{ success: boolean; error?: string; phrase?: string }>
@@ -67,6 +95,12 @@ function generateWalletId(): string {
 
 export function WalletProvider({ children }: WalletProviderProps) {
   const [phrase, setPhrase] = useState<string | null>(null)
+  const [walletType, setWalletType] = useState<SuiteWalletType>('phrase')
+  const [transport, setTransport] = useState<Transport | null>(null)
+  const [btcAddressFormat, setBtcAddressFormat] = useState<BtcAddressFormatOption>('p2wpkh')
+  const [ethDerivationStyle, setEthDerivationStyle] = useState<EthDerivationStyle>('default')
+  const [accountIndex, setAccountIndex] = useState(0)
+  const [customRootPath, setCustomRootPath] = useState('')
   const [savedWallets, setSavedWallets] = useState<SavedWallet[]>([])
   const [activeWalletId, setActiveWalletId] = useState<string | null>(null)
   const [tempWalletName, setTempWalletName] = useState<string | null>(null) // For non-saved connections
@@ -107,11 +141,15 @@ export function WalletProvider({ children }: WalletProviderProps) {
       return { success: false, error: 'Invalid mnemonic phrase' }
     }
 
+    // Drop any active Ledger session when switching to phrase
+    void closeLedgerTransport(transport)
+    setTransport(null)
+    setWalletType('phrase')
     setPhrase(trimmedPhrase)
     setActiveWalletId(null)
     setTempWalletName(null)
     return { success: true }
-  }, [])
+  }, [transport])
 
   // Connect with keystore file without saving (quick connect)
   const connectWithKeystore = useCallback(async (keystore: Keystore, password: string, walletName?: string): Promise<{ success: boolean; error?: string }> => {
@@ -122,6 +160,9 @@ export function WalletProvider({ children }: WalletProviderProps) {
         return { success: false, error: 'Decrypted data is not a valid mnemonic' }
       }
 
+      void closeLedgerTransport(transport)
+      setTransport(null)
+      setWalletType('phrase')
       setPhrase(decryptedPhrase)
       setActiveWalletId(null)
       setTempWalletName(walletName || 'Keystore Wallet')
@@ -130,14 +171,50 @@ export function WalletProvider({ children }: WalletProviderProps) {
     } catch (e) {
       return { success: false, error: e instanceof Error ? e.message : 'Failed to decrypt keystore. Check your password.' }
     }
-  }, [])
+  }, [transport])
+
+  /**
+   * Connect a Ledger device over WebHID.
+   * Unlock the device, open the Bitcoin or Ethereum app before using those chains.
+   */
+  const connectLedger = useCallback(async (options?: ConnectLedgerOptions): Promise<{ success: boolean; error?: string }> => {
+    try {
+      // Close any previous transport first
+      await closeLedgerTransport(transport)
+
+      const next = await openLedgerTransport()
+      setTransport(next)
+      setWalletType('ledger')
+      setPhrase(null)
+      setActiveWalletId(null)
+      setTempWalletName('Ledger')
+      localStorage.removeItem(ACTIVE_WALLET_KEY)
+
+      if (options?.btcAddressFormat) setBtcAddressFormat(options.btcAddressFormat)
+      if (options?.ethDerivationStyle) setEthDerivationStyle(options.ethDerivationStyle)
+      if (options?.accountIndex !== undefined) setAccountIndex(options.accountIndex)
+      if (options?.customRootPath !== undefined) setCustomRootPath(options.customRootPath)
+
+      return { success: true }
+    } catch (e) {
+      setTransport(null)
+      setWalletType('phrase')
+      return {
+        success: false,
+        error: e instanceof Error ? e.message : 'Failed to connect Ledger. Unlock the device and try again.',
+      }
+    }
+  }, [transport])
 
   const disconnect = useCallback(() => {
+    void closeLedgerTransport(transport)
+    setTransport(null)
+    setWalletType('phrase')
     setPhrase(null)
     setActiveWalletId(null)
     setTempWalletName(null)
     localStorage.removeItem(ACTIVE_WALLET_KEY)
-  }, [])
+  }, [transport])
 
   // Create a new wallet with generated phrase
   const createWallet = useCallback(async (name: string, password: string): Promise<{ success: boolean; error?: string; phrase?: string }> => {
@@ -152,6 +229,9 @@ export function WalletProvider({ children }: WalletProviderProps) {
         createdAt: Date.now(),
       }
 
+      void closeLedgerTransport(transport)
+      setTransport(null)
+      setWalletType('phrase')
       setSavedWallets(prev => [...prev, wallet])
       setPhrase(newPhrase)
       setActiveWalletId(wallet.id)
@@ -161,7 +241,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
     } catch (e) {
       return { success: false, error: e instanceof Error ? e.message : 'Failed to create wallet' }
     }
-  }, [])
+  }, [transport])
 
   // Import wallet from phrase
   const importFromPhrase = useCallback(async (name: string, inputPhrase: string, password: string): Promise<{ success: boolean; error?: string }> => {
@@ -181,6 +261,9 @@ export function WalletProvider({ children }: WalletProviderProps) {
         createdAt: Date.now(),
       }
 
+      void closeLedgerTransport(transport)
+      setTransport(null)
+      setWalletType('phrase')
       setSavedWallets(prev => [...prev, wallet])
       setPhrase(trimmedPhrase)
       setActiveWalletId(wallet.id)
@@ -190,7 +273,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
     } catch (e) {
       return { success: false, error: e instanceof Error ? e.message : 'Failed to import wallet' }
     }
-  }, [])
+  }, [transport])
 
   // Import wallet from keystore file
   const importFromKeystore = useCallback(async (name: string, keystore: Keystore, password: string): Promise<{ success: boolean; error?: string }> => {
@@ -209,6 +292,9 @@ export function WalletProvider({ children }: WalletProviderProps) {
         createdAt: Date.now(),
       }
 
+      void closeLedgerTransport(transport)
+      setTransport(null)
+      setWalletType('phrase')
       setSavedWallets(prev => [...prev, wallet])
       setPhrase(decryptedPhrase)
       setActiveWalletId(wallet.id)
@@ -218,7 +304,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
     } catch (e) {
       return { success: false, error: e instanceof Error ? e.message : 'Failed to decrypt keystore. Check your password.' }
     }
-  }, [])
+  }, [transport])
 
   // Unlock an existing saved wallet
   const unlockWallet = useCallback(async (walletId: string, password: string): Promise<{ success: boolean; error?: string }> => {
@@ -234,6 +320,9 @@ export function WalletProvider({ children }: WalletProviderProps) {
         return { success: false, error: 'Decrypted data is not a valid mnemonic' }
       }
 
+      void closeLedgerTransport(transport)
+      setTransport(null)
+      setWalletType('phrase')
       setPhrase(decryptedPhrase)
       setActiveWalletId(walletId)
       setTempWalletName(null)
@@ -243,17 +332,20 @@ export function WalletProvider({ children }: WalletProviderProps) {
     } catch (e) {
       return { success: false, error: 'Incorrect password' }
     }
-  }, [savedWallets])
+  }, [savedWallets, transport])
 
   // Delete a saved wallet
   const deleteWallet = useCallback((walletId: string) => {
     setSavedWallets(prev => prev.filter(w => w.id !== walletId))
     if (activeWalletId === walletId) {
+      void closeLedgerTransport(transport)
+      setTransport(null)
+      setWalletType('phrase')
       setPhrase(null)
       setActiveWalletId(null)
       localStorage.removeItem(ACTIVE_WALLET_KEY)
     }
-  }, [activeWalletId])
+  }, [activeWalletId, transport])
 
   // Export keystore for download
   const exportKeystore = useCallback((walletId: string): Keystore | null => {
@@ -261,11 +353,17 @@ export function WalletProvider({ children }: WalletProviderProps) {
     return wallet?.keystore || null
   }, [savedWallets])
 
-  const isConnected = phrase !== null
+  const isConnected = walletType === 'ledger' ? transport !== null : phrase !== null
 
   const value = useMemo<WalletContextValue>(
     () => ({
       phrase,
+      walletType,
+      transport,
+      btcAddressFormat,
+      ethDerivationStyle,
+      accountIndex,
+      customRootPath,
       isConnected,
       network,
       activeWalletId,
@@ -273,7 +371,12 @@ export function WalletProvider({ children }: WalletProviderProps) {
       savedWallets,
       connect,
       connectWithKeystore,
+      connectLedger,
       disconnect,
+      setBtcAddressFormat,
+      setEthDerivationStyle,
+      setAccountIndex,
+      setCustomRootPath,
       createWallet,
       importFromPhrase,
       importFromKeystore,
@@ -281,7 +384,30 @@ export function WalletProvider({ children }: WalletProviderProps) {
       deleteWallet,
       exportKeystore,
     }),
-    [phrase, isConnected, network, activeWalletId, activeWalletName, savedWallets, connect, connectWithKeystore, disconnect, createWallet, importFromPhrase, importFromKeystore, unlockWallet, deleteWallet, exportKeystore]
+    [
+      phrase,
+      walletType,
+      transport,
+      btcAddressFormat,
+      ethDerivationStyle,
+      accountIndex,
+      customRootPath,
+      isConnected,
+      network,
+      activeWalletId,
+      activeWalletName,
+      savedWallets,
+      connect,
+      connectWithKeystore,
+      connectLedger,
+      disconnect,
+      createWallet,
+      importFromPhrase,
+      importFromKeystore,
+      unlockWallet,
+      deleteWallet,
+      exportKeystore,
+    ],
   )
 
   return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>

--- a/tools/xchain-suite/src/hooks/useChainClient.ts
+++ b/tools/xchain-suite/src/hooks/useChainClient.ts
@@ -10,18 +10,42 @@ interface UseChainClientResult {
 }
 
 /**
- * Hook that creates a client for the given chain ID using the wallet phrase.
- * The client is recreated when the phrase or chainId changes.
+ * Hook that creates a client for the given chain ID.
+ * Supports phrase/keystore wallets and Ledger (BTC + ETH only).
  */
 export function useChainClient(chainId: string): UseChainClientResult {
-  const { phrase, isConnected, network } = useWallet()
+  const {
+    phrase,
+    isConnected,
+    network,
+    walletType,
+    transport,
+    btcAddressFormat,
+    ethDerivationStyle,
+    accountIndex,
+    customRootPath,
+  } = useWallet()
   const [client, setClient] = useState<XChainClient | null>(null)
   // Start loading if wallet is connected (client will be created in useEffect)
   const [loading, setLoading] = useState(isConnected)
   const [error, setError] = useState<Error | null>(null)
 
   useEffect(() => {
-    if (!isConnected || !phrase) {
+    if (!isConnected) {
+      setClient(null)
+      setError(null)
+      setLoading(false)
+      return
+    }
+
+    if (walletType === 'phrase' && !phrase) {
+      setClient(null)
+      setError(null)
+      setLoading(false)
+      return
+    }
+
+    if (walletType === 'ledger' && !transport) {
       setClient(null)
       setError(null)
       setLoading(false)
@@ -32,8 +56,17 @@ export function useChainClient(chainId: string): UseChainClientResult {
     setError(null)
 
     try {
-      console.log(`[useChainClient] Creating client for ${chainId}...`)
-      const newClient = createClient(chainId, { phrase, network })
+      console.log(`[useChainClient] Creating ${walletType} client for ${chainId}...`)
+      const newClient = createClient(chainId, {
+        network,
+        walletType,
+        phrase: phrase ?? undefined,
+        transport: transport ?? undefined,
+        btcAddressFormat,
+        ethDerivationStyle,
+        accountIndex,
+        customRootPath: customRootPath.trim() || undefined,
+      })
       console.log(`[useChainClient] Client created successfully:`, newClient)
       setClient(newClient)
       setLoading(false)
@@ -43,7 +76,18 @@ export function useChainClient(chainId: string): UseChainClientResult {
       setError(e as Error)
       setLoading(false)
     }
-  }, [phrase, chainId, isConnected, network])
+  }, [
+    phrase,
+    chainId,
+    isConnected,
+    network,
+    walletType,
+    transport,
+    btcAddressFormat,
+    ethDerivationStyle,
+    accountIndex,
+    customRootPath,
+  ])
 
   return { client, loading, error }
 }

--- a/tools/xchain-suite/src/lib/clients/factory.test.ts
+++ b/tools/xchain-suite/src/lib/clients/factory.test.ts
@@ -17,6 +17,145 @@ describe('Client Factory', () => {
     expect(client).toBeDefined()
   })
 
+  it('should derive different BTC addresses for legacy vs native segwit formats', async () => {
+    const native = createClient('BTC', {
+      phrase: TEST_PHRASE,
+      network: Network.Mainnet,
+      btcAddressFormat: 'p2wpkh',
+    })
+    const legacy = createClient('BTC', {
+      phrase: TEST_PHRASE,
+      network: Network.Mainnet,
+      btcAddressFormat: 'p2pkh',
+    })
+    const nested = createClient('BTC', {
+      phrase: TEST_PHRASE,
+      network: Network.Mainnet,
+      btcAddressFormat: 'p2sh-p2wpkh',
+    })
+
+    const [nativeAddr, legacyAddr, nestedAddr] = await Promise.all([
+      native.getAddressAsync(0),
+      legacy.getAddressAsync(0),
+      nested.getAddressAsync(0),
+    ])
+
+    expect(nativeAddr).not.toEqual(legacyAddr)
+    expect(nativeAddr).not.toEqual(nestedAddr)
+    expect(legacyAddr.startsWith('1')).toBe(true)
+    expect(nestedAddr.startsWith('3')).toBe(true)
+    expect(nativeAddr.startsWith('bc1')).toBe(true)
+  })
+
+  it('should derive different ETH addresses for Ledger Live path style', async () => {
+    const defaultClient = createClient('ETH', {
+      phrase: TEST_PHRASE,
+      network: Network.Mainnet,
+      ethDerivationStyle: 'default',
+    })
+    const ledgerLive = createClient('ETH', {
+      phrase: TEST_PHRASE,
+      network: Network.Mainnet,
+      ethDerivationStyle: 'ledgerLive',
+    })
+
+    // Index 1 differs: default uses address index; Ledger Live uses account index
+    const [defaultAddr, liveAddr] = await Promise.all([
+      defaultClient.getAddressAsync(1),
+      ledgerLive.getAddressAsync(1),
+    ])
+    expect(defaultAddr.toLowerCase()).not.toEqual(liveAddr.toLowerCase())
+  })
+
+  it('should derive different BTC addresses for non-zero account index', async () => {
+    const account0 = createClient('BTC', {
+      phrase: TEST_PHRASE,
+      network: Network.Mainnet,
+      btcAddressFormat: 'p2wpkh',
+      accountIndex: 0,
+    })
+    const account1 = createClient('BTC', {
+      phrase: TEST_PHRASE,
+      network: Network.Mainnet,
+      btcAddressFormat: 'p2wpkh',
+      accountIndex: 1,
+    })
+
+    const [addr0, addr1] = await Promise.all([
+      account0.getAddressAsync(0),
+      account1.getAddressAsync(0),
+    ])
+    expect(addr0).not.toEqual(addr1)
+    expect(addr0.startsWith('bc1')).toBe(true)
+    expect(addr1.startsWith('bc1')).toBe(true)
+  })
+
+  it('should honor custom BTC root path', async () => {
+    const defaultAccount = createClient('BTC', {
+      phrase: TEST_PHRASE,
+      network: Network.Mainnet,
+      btcAddressFormat: 'p2wpkh',
+    })
+    const custom = createClient('BTC', {
+      phrase: TEST_PHRASE,
+      network: Network.Mainnet,
+      btcAddressFormat: 'p2wpkh',
+      customRootPath: "m/84'/0'/5'/0/",
+    })
+
+    const [defaultAddr, customAddr] = await Promise.all([
+      defaultAccount.getAddressAsync(0),
+      custom.getAddressAsync(0),
+    ])
+    expect(customAddr).not.toEqual(defaultAddr)
+    expect(customAddr.startsWith('bc1')).toBe(true)
+  })
+
+  it('should honor custom ETH root path with account slot', async () => {
+    const defaultClient = createClient('ETH', {
+      phrase: TEST_PHRASE,
+      network: Network.Mainnet,
+      ethDerivationStyle: 'default',
+    })
+    const custom = createClient('ETH', {
+      phrase: TEST_PHRASE,
+      network: Network.Mainnet,
+      ethDerivationStyle: 'default',
+      customRootPath: "m/44'/60'/3'/0/",
+    })
+
+    const [defaultAddr, customAddr] = await Promise.all([
+      defaultClient.getAddressAsync(0),
+      custom.getAddressAsync(0),
+    ])
+    expect(customAddr.toLowerCase()).not.toEqual(defaultAddr.toLowerCase())
+  })
+
+  it('should throw when custom BTC path purpose mismatches format', () => {
+    expect(() =>
+      createClient('BTC', {
+        phrase: TEST_PHRASE,
+        network: Network.Mainnet,
+        btcAddressFormat: 'p2tr',
+        customRootPath: "m/84'/0'/0'/0/",
+      }),
+    ).toThrow(/Unsupported derivation paths/i)
+  })
+
+  it('should throw for ledger mode without transport', () => {
+    expect(() =>
+      createClient('BTC', { network: Network.Mainnet, walletType: 'ledger' }),
+    ).toThrow(/transport/i)
+  })
+
+  it('should throw for unsupported ledger chain', () => {
+    // Minimal fake transport — only used to pass the presence check
+    const transport = { close: async () => undefined } as never
+    expect(() =>
+      createClient('THOR', { network: Network.Mainnet, walletType: 'ledger', transport }),
+    ).toThrow(/only supported/i)
+  })
+
   it('should throw for unsupported chain', () => {
     expect(() => createClient('UNKNOWN', { phrase: TEST_PHRASE, network: Network.Mainnet })).toThrow(
       'Unsupported chain',

--- a/tools/xchain-suite/src/lib/clients/factory.ts
+++ b/tools/xchain-suite/src/lib/clients/factory.ts
@@ -1,3 +1,4 @@
+import type Transport from '@ledgerhq/hw-transport'
 import { ExplorerProvider, Network } from '@xchainjs/xchain-client'
 import type { XChainClient } from '@xchainjs/xchain-client'
 import { EtherscanProviderV2 } from '@xchainjs/xchain-evm-providers'
@@ -6,7 +7,18 @@ import { JsonRpcProvider } from 'ethers'
 import BigNumber from 'bignumber.js'
 
 // UTXO Chains
-import { Client as BtcClient, defaultBTCParams, AssetBTC, BTC_DECIMAL, BTCChain } from '@xchainjs/xchain-bitcoin'
+import {
+  Client as BtcClient,
+  ClientLedger as BtcClientLedger,
+  defaultBTCParams,
+  AssetBTC,
+  BTC_DECIMAL,
+  BTCChain,
+  AddressFormat,
+  legacyDerivationPaths,
+  nestedSegwitDerivationPaths,
+  tapRootDerivationPaths,
+} from '@xchainjs/xchain-bitcoin'
 import { Client as BchClient, defaultBchParams } from '@xchainjs/xchain-bitcoincash'
 import { Client as LtcClient, defaultLtcParams, AssetLTC, LTC_DECIMAL, LTCChain } from '@xchainjs/xchain-litecoin'
 import { Client as DogeClient, defaultDogeParams, AssetDOGE, DOGE_DECIMAL, DOGEChain } from '@xchainjs/xchain-doge'
@@ -15,13 +27,53 @@ import { Client as ZecClient, defaultZECParams, AssetZEC, ZEC_DECIMAL, zcashExpl
 import { NownodesProvider, BlockcypherProvider, BlockcypherNetwork } from '@xchainjs/xchain-utxo-providers'
 
 // EVM Chains - import only the Client classes, not the default params (they trigger broken module-level code)
-import { Client as EthClient, defaultEthParams, AssetETH, ETHChain, ETH_GAS_ASSET_DECIMAL } from '@xchainjs/xchain-ethereum'
+import {
+  Client as EthClient,
+  ClientLedger as EthClientLedger,
+  defaultEthParams,
+  AssetETH,
+  ETHChain,
+  ETH_GAS_ASSET_DECIMAL,
+  ledgerLiveDerivationPaths,
+} from '@xchainjs/xchain-ethereum'
 import { Client as AvaxClient } from '@xchainjs/xchain-avax'
 import { Client as BscClient } from '@xchainjs/xchain-bsc'
 import { Client as ArbClient, defaultArbParams } from '@xchainjs/xchain-arbitrum'
 
+import {
+  type BtcAddressFormatOption,
+  type EthDerivationStyle,
+  type SuiteWalletType,
+  isLedgerSupportedChain,
+  LEDGER_SUPPORTED_CHAINS,
+} from '../ledger/types'
+import { applyDerivationOverrides, type DerivationPathOverrides } from '../ledger/paths'
+
+function resolveBtcDerivation(format: BtcAddressFormatOption = 'p2wpkh') {
+  switch (format) {
+    case 'p2pkh':
+      return { addressFormat: AddressFormat.P2PKH, rootDerivationPaths: legacyDerivationPaths }
+    case 'p2sh-p2wpkh':
+      return { addressFormat: AddressFormat.P2SH_P2WPKH, rootDerivationPaths: nestedSegwitDerivationPaths }
+    case 'p2tr':
+      return { addressFormat: AddressFormat.P2TR, rootDerivationPaths: tapRootDerivationPaths }
+    case 'p2wpkh':
+    default:
+      return {
+        addressFormat: AddressFormat.P2WPKH,
+        rootDerivationPaths: defaultBTCParams.rootDerivationPaths,
+      }
+  }
+}
+
 // Lazy creation of ETH config to use Vite env var for Etherscan API key
-function createEthParams(network: Network, phrase: string) {
+function createEthParams(
+  network: Network,
+  options: {
+    phrase?: string
+    ethDerivationStyle?: EthDerivationStyle
+  } & DerivationPathOverrides = {},
+) {
   const etherscanApiKey = import.meta.env.VITE_ETHERSCAN_API_KEY || ''
 
   const mainnetProvider = new JsonRpcProvider('https://ethereum.publicnode.com', 'homestead')
@@ -39,12 +91,21 @@ function createEthParams(network: Network, phrase: string) {
     [Network.Stagenet]: new EtherscanProviderV2(mainnetProvider, 'https://api.etherscan.io/v2', etherscanApiKey, ETHChain, AssetETH, ETH_GAS_ASSET_DECIMAL, 1),
   }]
 
+  const baseRoots =
+    options.ethDerivationStyle === 'ledgerLive' ? ledgerLiveDerivationPaths : defaultEthParams.rootDerivationPaths
+  const rootDerivationPaths = applyDerivationOverrides(
+    baseRoots,
+    { accountIndex: options.accountIndex, customRootPath: options.customRootPath },
+    'eth',
+  )
+
   return {
     ...defaultEthParams,
     network,
-    phrase,
+    ...(options.phrase !== undefined ? { phrase: options.phrase } : {}),
     providers,
     dataProviders,
+    rootDerivationPaths,
     feeBounds: { lower: 1_000_000, upper: 1_000_000_000_000 },
   }
 }
@@ -175,12 +236,32 @@ function createZecParams(network: Network, phrase: string) {
 }
 
 // Lazy creation of BTC config to use BlockCypher API key
-function createBtcParams(network: Network, phrase: string) {
+function createBtcParams(
+  network: Network,
+  options: {
+    phrase?: string
+    btcAddressFormat?: BtcAddressFormatOption
+  } & DerivationPathOverrides = {},
+) {
   const blockcypherApiKey = import.meta.env.VITE_BLOCKCYPHER_API_KEY || ''
+  const derivation = resolveBtcDerivation(options.btcAddressFormat)
+  const rootDerivationPaths = applyDerivationOverrides(
+    derivation.rootDerivationPaths,
+    { accountIndex: options.accountIndex, customRootPath: options.customRootPath },
+    'btc',
+  )
 
-  // If no API key, use default params
+  const base = {
+    ...defaultBTCParams,
+    network,
+    ...(options.phrase !== undefined ? { phrase: options.phrase } : {}),
+    addressFormat: derivation.addressFormat,
+    rootDerivationPaths,
+  }
+
+  // If no API key, use default data providers
   if (!blockcypherApiKey) {
-    return { ...defaultBTCParams, network, phrase }
+    return base
   }
 
   const mainnetBlockcypherProvider = new BlockcypherProvider(
@@ -207,9 +288,7 @@ function createBtcParams(network: Network, phrase: string) {
   }]
 
   return {
-    ...defaultBTCParams,
-    network,
-    phrase,
+    ...base,
     dataProviders,
   }
 }
@@ -331,17 +410,78 @@ import { Client as XrpClient, defaultXRPParams } from '@xchainjs/xchain-ripple'
 import { Client as TronClient, defaultTRONParams } from '@xchainjs/xchain-tron'
 
 export interface ClientConfig {
-  phrase: string
+  /** Required for phrase / keystore wallets */
+  phrase?: string
   network: Network
+  /** When set with `walletType: 'ledger'`, builds ClientLedger for BTC/ETH */
+  transport?: Transport
+  walletType?: SuiteWalletType
+  btcAddressFormat?: BtcAddressFormatOption
+  ethDerivationStyle?: EthDerivationStyle
+  /** BIP account index (default 0). No effect on Ledger Live ETH `{index}` paths. */
+  accountIndex?: number
+  /**
+   * Optional root path override for BTC/ETH (applied to all networks).
+   * Must match the selected BTC address format purpose (m/84', m/86', m/44', m/49').
+   */
+  customRootPath?: string
 }
 
+function requirePhrase(config: ClientConfig, chainId: string): string {
+  if (!config.phrase) {
+    throw new Error(`Phrase is required to create a keystore client for ${chainId}`)
+  }
+  return config.phrase
+}
+
+/**
+ * Create a chain client for either a keystore phrase or a Ledger transport.
+ *
+ * Ledger mode currently supports **BTC** and **ETH** only (WebHID).
+ * BTC address format, ETH derivation style, account index, and optional custom
+ * root path are honoured for both wallet types so the suite can exercise path work
+ * without a device.
+ */
 export function createClient(chainId: string, config: ClientConfig): XChainClient {
-  const { phrase, network } = config
+  const {
+    network,
+    walletType = 'phrase',
+    transport,
+    btcAddressFormat,
+    ethDerivationStyle,
+    accountIndex,
+    customRootPath,
+  } = config
+  const pathOverrides = { accountIndex, customRootPath }
+
+  if (walletType === 'ledger') {
+    if (!transport) {
+      throw new Error('Ledger transport is required when walletType is "ledger"')
+    }
+    if (!isLedgerSupportedChain(chainId)) {
+      throw new Error(
+        `Ledger is only supported for ${LEDGER_SUPPORTED_CHAINS.join(' and ')} in xchain-suite (got ${chainId}). Open the Bitcoin or Ethereum app on the device and select that chain.`,
+      )
+    }
+
+    if (chainId === 'BTC') {
+      const params = createBtcParams(network, { btcAddressFormat, ...pathOverrides })
+      return new BtcClientLedger({ ...params, transport })
+    }
+
+    // ETH
+    const params = createEthParams(network, { ethDerivationStyle, ...pathOverrides })
+    // ClientLedger omits phrase/signer and injects LedgerSigner from transport
+    const { phrase: _omitPhrase, ...ledgerEthParams } = params as typeof params & { phrase?: string }
+    return new EthClientLedger({ ...ledgerEthParams, transport })
+  }
+
+  const phrase = requirePhrase(config, chainId)
 
   switch (chainId) {
     // UTXO Chains - use BlockCypher API key if available
     case 'BTC':
-      return new BtcClient(createBtcParams(network, phrase))
+      return new BtcClient(createBtcParams(network, { phrase, btcAddressFormat, ...pathOverrides }))
     case 'BCH':
       return new BchClient({ ...defaultBchParams, network, phrase })
     case 'LTC':
@@ -355,7 +495,7 @@ export function createClient(chainId: string, config: ClientConfig): XChainClien
 
     // EVM Chains - use wide fee bounds to accommodate varying gas prices
     case 'ETH':
-      return new EthClient(createEthParams(network, phrase))
+      return new EthClient(createEthParams(network, { phrase, ethDerivationStyle, ...pathOverrides }))
     case 'AVAX':
       return new AvaxClient(createAvaxParams(network, phrase))
     case 'BSC':

--- a/tools/xchain-suite/src/lib/ledger/index.ts
+++ b/tools/xchain-suite/src/lib/ledger/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './transport'
+export * from './paths'

--- a/tools/xchain-suite/src/lib/ledger/paths.test.ts
+++ b/tools/xchain-suite/src/lib/ledger/paths.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { Network } from '@xchainjs/xchain-client'
+import {
+  withAccountIndex,
+  normalizeBtcRootPath,
+  applyDerivationOverrides,
+  previewRootPath,
+} from './paths'
+
+describe('derivation path helpers', () => {
+  it('rewrites the BIP account slot', () => {
+    expect(withAccountIndex("m/84'/0'/0'/0/", 5)).toBe("m/84'/0'/5'/0/")
+    expect(withAccountIndex("m/44'/60'/0'/0/", 2)).toBe("m/44'/60'/2'/0/")
+    expect(withAccountIndex("m/49'/0'/0'/0/", 1)).toBe("m/49'/0'/1'/0/")
+  })
+
+  it('leaves {index} templates unchanged', () => {
+    expect(withAccountIndex("m/44'/60'/{index}'/0/0", 3)).toBe("m/44'/60'/{index}'/0/0")
+  })
+
+  it('normalizes BTC trailing slash', () => {
+    expect(normalizeBtcRootPath("m/84'/0'/0'/0")).toBe("m/84'/0'/0'/0/")
+    expect(normalizeBtcRootPath("m/84'/0'/0'/0/")).toBe("m/84'/0'/0'/0/")
+  })
+
+  it('applies custom root to all networks', () => {
+    const roots = {
+      [Network.Mainnet]: "m/84'/0'/0'/0/",
+      [Network.Testnet]: "m/84'/1'/0'/0/",
+      [Network.Stagenet]: "m/84'/0'/0'/0/",
+    }
+    const next = applyDerivationOverrides(roots, { customRootPath: "m/84'/0'/7'/0" }, 'btc')
+    expect(next?.[Network.Mainnet]).toBe("m/84'/0'/7'/0/")
+    expect(next?.[Network.Testnet]).toBe("m/84'/0'/7'/0/")
+  })
+
+  it('previews effective path with account index', () => {
+    expect(previewRootPath("m/86'/0'/0'/0/", { accountIndex: 4 }, 'btc')).toBe("m/86'/0'/4'/0/")
+  })
+})

--- a/tools/xchain-suite/src/lib/ledger/paths.ts
+++ b/tools/xchain-suite/src/lib/ledger/paths.ts
@@ -1,0 +1,84 @@
+import { Network, type RootDerivationPaths } from '@xchainjs/xchain-client'
+
+/**
+ * Rewrite the BIP account slot (3rd hardened component).
+ * e.g. m/84'/0'/0'/0/ + account 5 → m/84'/0'/5'/0/
+ *
+ * Paths that use an `{index}` placeholder (Ledger Live ETH) are left unchanged —
+ * the wallet index already fills the account position.
+ */
+export function withAccountIndex(rootPath: string, accountIndex: number): string {
+  if (rootPath.includes('{index}')) return rootPath
+  const match = rootPath.match(/^(m\/\d+'\/\d+')\/\d+'(\/.*)$/)
+  if (!match) return rootPath
+  return `${match[1]}/${accountIndex}'${match[2]}`
+}
+
+/** BTC clients append walletIndex to the root — ensure a trailing slash. */
+export function normalizeBtcRootPath(path: string): string {
+  const trimmed = path.trim()
+  if (!trimmed) return trimmed
+  return trimmed.endsWith('/') ? trimmed : `${trimmed}/`
+}
+
+/**
+ * ETH signer strips a trailing slash then appends `/${walletIndex}`, or substitutes `{index}`.
+ * Keep user input as-is aside from trim.
+ */
+export function normalizeEthRootPath(path: string): string {
+  return path.trim()
+}
+
+export type DerivationPathOverrides = {
+  /** BIP account index (default 0). Ignored when path uses `{index}`. */
+  accountIndex?: number
+  /**
+   * Optional full root path override applied to every network.
+   * BTC examples: m/84'/0'/5'/0/  ·  ETH default: m/44'/60'/2'/0/  ·  ETH Live: m/44'/60'/{index}'/0/0
+   */
+  customRootPath?: string
+}
+
+/**
+ * Apply account-index rewrite and/or a custom root path to a RootDerivationPaths map.
+ */
+export function applyDerivationOverrides(
+  roots: RootDerivationPaths | undefined,
+  overrides: DerivationPathOverrides,
+  kind: 'btc' | 'eth',
+): RootDerivationPaths | undefined {
+  if (!roots) return roots
+
+  const accountIndex = overrides.accountIndex ?? 0
+  const custom = overrides.customRootPath?.trim()
+
+  if (custom) {
+    const normalized = kind === 'btc' ? normalizeBtcRootPath(custom) : normalizeEthRootPath(custom)
+    return {
+      [Network.Mainnet]: normalized,
+      [Network.Testnet]: normalized,
+      [Network.Stagenet]: normalized,
+    }
+  }
+
+  if (accountIndex === 0) return roots
+
+  const next = {} as RootDerivationPaths
+  for (const network of [Network.Mainnet, Network.Testnet, Network.Stagenet] as const) {
+    next[network] = withAccountIndex(roots[network], accountIndex)
+  }
+  return next
+}
+
+/** Preview the effective root path (mainnet) for UI labels. */
+export function previewRootPath(
+  baseRoot: string,
+  overrides: DerivationPathOverrides,
+  kind: 'btc' | 'eth',
+): string {
+  const custom = overrides.customRootPath?.trim()
+  if (custom) {
+    return kind === 'btc' ? normalizeBtcRootPath(custom) : normalizeEthRootPath(custom)
+  }
+  return withAccountIndex(baseRoot, overrides.accountIndex ?? 0)
+}

--- a/tools/xchain-suite/src/lib/ledger/transport.ts
+++ b/tools/xchain-suite/src/lib/ledger/transport.ts
@@ -1,0 +1,38 @@
+import type Transport from '@ledgerhq/hw-transport'
+import TransportWebHID from '@ledgerhq/hw-transport-webhid'
+
+/**
+ * Open a Ledger device over WebHID (Chrome / Chromium / Edge).
+ * Must be called from a user gesture (button click).
+ *
+ * Cast through `unknown` because nested `@ledgerhq/devices` versions under
+ * hw-transport-webhid can diverge from the top-level hw-transport types.
+ */
+export async function openLedgerTransport(): Promise<Transport> {
+  if (typeof navigator === 'undefined' || !('hid' in navigator)) {
+    throw new Error(
+      'WebHID is not available in this browser. Use Chrome, Edge, or another Chromium browser with WebHID support.',
+    )
+  }
+
+  // Prefer an already-authorized device when possible
+  const existing = await TransportWebHID.list()
+  if (existing.length > 0) {
+    try {
+      return (await TransportWebHID.open(existing[0])) as unknown as Transport
+    } catch {
+      // Fall through to request a fresh permission
+    }
+  }
+
+  return (await TransportWebHID.create()) as unknown as Transport
+}
+
+export async function closeLedgerTransport(transport: Transport | null | undefined): Promise<void> {
+  if (!transport) return
+  try {
+    await transport.close()
+  } catch (e) {
+    console.warn('[ledger] Failed to close transport:', e)
+  }
+}

--- a/tools/xchain-suite/src/lib/ledger/types.ts
+++ b/tools/xchain-suite/src/lib/ledger/types.ts
@@ -1,0 +1,31 @@
+import type Transport from '@ledgerhq/hw-transport'
+
+/** Wallet connection mode for the suite */
+export type SuiteWalletType = 'phrase' | 'ledger'
+
+/**
+ * BTC address format options exposed in the suite UI.
+ * Maps onto `@xchainjs/xchain-bitcoin` AddressFormat + matching rootDerivationPaths.
+ */
+export type BtcAddressFormatOption = 'p2wpkh' | 'p2tr' | 'p2pkh' | 'p2sh-p2wpkh'
+
+/**
+ * ETH derivation style:
+ * - default: BIP44 address index `m/44'/60'/0'/0/{index}`
+ * - ledgerLive: account index `m/44'/60'/{index}'/0/0`
+ */
+export type EthDerivationStyle = 'default' | 'ledgerLive'
+
+/** Chains that can be driven by a Ledger transport in the suite */
+export const LEDGER_SUPPORTED_CHAINS = ['BTC', 'ETH'] as const
+export type LedgerSupportedChain = (typeof LEDGER_SUPPORTED_CHAINS)[number]
+
+export function isLedgerSupportedChain(chainId: string): chainId is LedgerSupportedChain {
+  return (LEDGER_SUPPORTED_CHAINS as readonly string[]).includes(chainId)
+}
+
+export type LedgerConnection = {
+  transport: Transport
+  btcAddressFormat: BtcAddressFormatOption
+  ethDerivationStyle: EthDerivationStyle
+}

--- a/tools/xchain-suite/vite.config.ts
+++ b/tools/xchain-suite/vite.config.ts
@@ -24,7 +24,13 @@ export default defineConfig({
     esbuildOptions: {
       define: { global: 'globalThis' },
     },
-    include: ['buffer'],
+    include: [
+      'buffer',
+      '@ledgerhq/hw-transport',
+      '@ledgerhq/hw-transport-webhid',
+      '@ledgerhq/hw-app-btc',
+      '@ledgerhq/hw-app-eth',
+    ],
     exclude: ['@xchainjs/xchain-monero'],
   },
   server: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2513,6 +2513,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ledgerhq/devices@npm:8.16.0":
+  version: 8.16.0
+  resolution: "@ledgerhq/devices@npm:8.16.0"
+  dependencies:
+    semver: "npm:7.7.3"
+  checksum: 10c0/cdd3c5620d980a82193302f185e9adb7644414928d27cb8f0d4184ddceab8413e97536d80b6d4f2496942c4508aa49afba32d4f9a0d2dad0648c57532e6a33e2
+  languageName: node
+  linkType: hard
+
 "@ledgerhq/devices@npm:8.4.6":
   version: 8.4.6
   resolution: "@ledgerhq/devices@npm:8.4.6"
@@ -2589,6 +2598,13 @@ __metadata:
   version: 6.26.0
   resolution: "@ledgerhq/errors@npm:6.26.0"
   checksum: 10c0/27e5a1dda997f3c38105b49c709aaf447e37eb27970150ece98ce81065a3bf4eb5c75d37cb91f9f874da2e69d2093395508fa08d9a293cfa6c6235b33627b983
+  languageName: node
+  linkType: hard
+
+"@ledgerhq/errors@npm:^6.37.0":
+  version: 6.37.0
+  resolution: "@ledgerhq/errors@npm:6.37.0"
+  checksum: 10c0/8943569bec9640d7af14498491fc254857a3ec3bf21e841cf51b8bfe7fe9192838e1c854dad646c5264e020b1411df5fca26fc720dab31de539f2712ce6ed217
   languageName: node
   linkType: hard
 
@@ -2729,6 +2745,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ledgerhq/hw-transport-webhid@npm:^6.29.4":
+  version: 6.36.0
+  resolution: "@ledgerhq/hw-transport-webhid@npm:6.36.0"
+  dependencies:
+    "@ledgerhq/devices": "npm:8.16.0"
+    "@ledgerhq/errors": "npm:^6.37.0"
+    "@ledgerhq/hw-transport": "npm:6.35.5"
+    "@ledgerhq/logs": "npm:^6.17.0"
+  checksum: 10c0/235cbf0159a3960bca70feed90c5cea2451e14d979ba42566fa699bf28e55328d47b8bd196c3521265fc9bd6bef21bb4cfb6de7e02096d491956a1ec2909f9b0
+  languageName: node
+  linkType: hard
+
 "@ledgerhq/hw-transport@npm:6.31.4":
   version: 6.31.4
   resolution: "@ledgerhq/hw-transport@npm:6.31.4"
@@ -2738,6 +2766,18 @@ __metadata:
     "@ledgerhq/logs": "npm:^6.12.0"
     events: "npm:^3.3.0"
   checksum: 10c0/033acb802d991788efcda9223356528d0987a268e94c34cbafde499541722363e7cfa6e2734365ef3282c0a80a69f4964a6d728690ff7494662a650516530b02
+  languageName: node
+  linkType: hard
+
+"@ledgerhq/hw-transport@npm:6.35.5":
+  version: 6.35.5
+  resolution: "@ledgerhq/hw-transport@npm:6.35.5"
+  dependencies:
+    "@ledgerhq/devices": "npm:8.16.0"
+    "@ledgerhq/errors": "npm:^6.37.0"
+    "@ledgerhq/logs": "npm:^6.17.0"
+    events: "npm:^3.3.0"
+  checksum: 10c0/bdf2eb0fabde179de2fe0a82a543bc8e60e7f21e0e7532e1e449e6137d449c79638ebebce371f5da92418349f43cac68c134f0c40a25c29c7d2e9f43e39f8b82
   languageName: node
   linkType: hard
 
@@ -2798,6 +2838,13 @@ __metadata:
   version: 6.13.0
   resolution: "@ledgerhq/logs@npm:6.13.0"
   checksum: 10c0/8b40a7af64a9526b441394e84f05afc42552b4d3d1e45c33dd262d669c77e2351e06bd354929ffdf6cfe0e0404b0042b8b5da610016232a0eb516f1daa73f39f
+  languageName: node
+  linkType: hard
+
+"@ledgerhq/logs@npm:^6.17.0":
+  version: 6.17.0
+  resolution: "@ledgerhq/logs@npm:6.17.0"
+  checksum: 10c0/3f90895048b04dd79a916a87cde6ec4b28d60b059d865697a1429d83af54e17066a113de17c52c91bd638b3d9bf2df0c196ea783119f0d18869923dbc6d973e8
   languageName: node
   linkType: hard
 
@@ -14448,6 +14495,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:7.7.3":
+  version: 7.7.3
+  resolution: "semver@npm:7.7.3"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/4afe5c986567db82f44c8c6faef8fe9df2a9b1d98098fc1721f57c696c4c21cebd572f297fc21002f81889492345b8470473bc6f4aff5fb032a6ea59ea2bc45e
+  languageName: node
+  linkType: hard
+
 "semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
@@ -16833,6 +16889,8 @@ __metadata:
   resolution: "xchain-suite@workspace:tools/xchain-suite"
   dependencies:
     "@chainflip/sdk": "npm:2.2.1"
+    "@ledgerhq/hw-transport": "npm:^6.31.6"
+    "@ledgerhq/hw-transport-webhid": "npm:^6.29.4"
     "@testing-library/jest-dom": "npm:^6.2.0"
     "@testing-library/react": "npm:^14.1.0"
     "@types/react": "npm:^18.2.0"


### PR DESCRIPTION
## Summary

Suite-only follow-up to #1738. Wires WebHID Ledger clients for **BTC** and **ETH** in `tools/xchain-suite` so the new address formats and Ledger Live derivation paths can be exercised end-to-end.

- Ledger connect for BTC + ETH (WebHID transport)
- BTC address formats: legacy / nested SegWit / native SegWit / Taproot
- ETH derivation styles: default + Ledger Live (+ custom root path)
- Account index + optional custom derivation path on the connect form
- Factory coverage for phrase-mode path resolution

**Depends on:** #1738 (`feat/ledger-legacy-derivation-paths`) — this PR is stacked on that branch.

## Test plan

- [ ] Land #1738 first (or keep this PR stacked until then)
- [ ] Suite unit tests for factory / path helpers
- [ ] Manually: connect Ledger BTC with each address format and confirm address matches device
- [ ] Manually: connect Ledger ETH with Ledger Live path + account index
- [ ] Phrase mode still derives expected paths for BTC formats / ETH styles

## Notes

- No published package API surface in this PR — suite/tooling only
- No changeset required (`tools/` only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ledger wallet connectivity for Bitcoin and Ethereum.
  * Supports Bitcoin legacy, nested SegWit, native SegWit, and Taproot addresses.
  * Added configurable Bitcoin address formats, Ethereum derivation styles, account selection, custom paths, and live previews.
  * Added Ledger wallet identification and support for browser-based device connections.
* **Bug Fixes**
  * Improved transaction signing and derivation-path validation across supported formats.
* **Documentation**
  * Updated wallet connection and Ledger setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->