### PR TITLE
fix(cosmos-sdk): preserve real errors in round-robin RPC failover

### DIFF
--- a/.changeset/cosmos-round-robin-error-fidelity.md
+++ b/.changeset/cosmos-round-robin-error-fidelity.md
@@ -1,0 +1,9 @@
+---
+'@xchainjs/xchain-cosmos-sdk': patch
+'@xchainjs/xchain-thorchain': patch
+'@xchainjs/xchain-mayachain': patch
+'@xchainjs/xchain-cosmos': patch
+'@xchainjs/xchain-kujira': patch
+---
+
+Preserve real RPC/chain errors in Cosmos round-robin helpers instead of always throwing a generic "No clients available" message. Non-retryable failures (e.g. insufficient funds) rethrow immediately; exhausted failover includes the last error as message + cause. `getTransaction` uses `TxNotFoundError` when the tx is missing on reachable nodes.

--- a/packages/xchain-cosmos-sdk/__tests__/roundRobin.test.ts
+++ b/packages/xchain-cosmos-sdk/__tests__/roundRobin.test.ts
@@ -1,0 +1,80 @@
+import {
+  TxNotFoundError,
+  createRoundRobinExhaustedError,
+  isRetryableRpcError,
+  roundRobinTry,
+} from '../src/roundRobin'
+
+describe('isRetryableRpcError', () => {
+  it('treats connection / gateway failures as retryable', () => {
+    expect(isRetryableRpcError(new Error('Failed to fetch'))).toBe(true)
+    expect(isRetryableRpcError(new Error('connect ECONNREFUSED 127.0.0.1:26657'))).toBe(true)
+    expect(isRetryableRpcError(new Error('Bad status on response: 500'))).toBe(true)
+    expect(isRetryableRpcError(new Error('Bad status on response: 503'))).toBe(true)
+    expect(isRetryableRpcError(new Error('request timed out'))).toBe(true)
+  })
+
+  it('treats chain rejection messages as non-retryable', () => {
+    expect(isRetryableRpcError(new Error('insufficient funds: insufficient account funds'))).toBe(false)
+    expect(isRetryableRpcError(new Error('account sequence mismatch, expected 5, got 4'))).toBe(false)
+    expect(isRetryableRpcError(new Error('out of gas in location: WritePerByte'))).toBe(false)
+    expect(isRetryableRpcError(new Error('failed to execute message; message index: 0'))).toBe(false)
+  })
+})
+
+describe('createRoundRobinExhaustedError', () => {
+  it('includes last error message and cause', () => {
+    const cause = new Error('Bad status on response: 500')
+    const err = createRoundRobinExhaustedError('broadcast transaction', cause)
+    expect(err.message).toContain('No clients available. Can not broadcast transaction')
+    expect(err.message).toContain('Last error: Bad status on response: 500')
+    expect((err as Error & { cause?: unknown }).cause).toBe(cause)
+  })
+
+  it('works without a last error', () => {
+    const err = createRoundRobinExhaustedError('get chain id')
+    expect(err.message).toBe('No clients available. Can not get chain id')
+  })
+})
+
+describe('roundRobinTry', () => {
+  it('returns the first successful result', async () => {
+    const result = await roundRobinTry([1, 2, 3], 'test', async (n) => {
+      if (n < 3) throw new Error('Failed to fetch')
+      return n * 10
+    })
+    expect(result).toBe(30)
+  })
+
+  it('rethrows non-retryable errors immediately', async () => {
+    await expect(
+      roundRobinTry([1, 2], 'broadcast transaction', async () => {
+        throw new Error('insufficient funds')
+      }),
+    ).rejects.toThrow('insufficient funds')
+  })
+
+  it('surfaces last retryable error when all endpoints fail', async () => {
+    await expect(
+      roundRobinTry(['a', 'b'], 'broadcast transaction', async (url) => {
+        throw new Error(`Bad status on response: 500 from ${url}`)
+      }),
+    ).rejects.toThrow(/Last error: Bad status on response: 500 from b/)
+  })
+
+  it('throws exhausted error when item list is empty', async () => {
+    await expect(roundRobinTry([], 'get chain id', async () => 1)).rejects.toThrow(
+      'No clients available. Can not get chain id',
+    )
+  })
+})
+
+describe('TxNotFoundError', () => {
+  it('names and message are stable for status pollers', () => {
+    const err = new TxNotFoundError('ABC')
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('TxNotFoundError')
+    expect(err.txId).toBe('ABC')
+    expect(err.message).toBe('Can not find transaction ABC')
+  })
+})

--- a/packages/xchain-cosmos-sdk/__tests__/roundRobin.test.ts
+++ b/packages/xchain-cosmos-sdk/__tests__/roundRobin.test.ts
@@ -2,23 +2,35 @@ import {
   TxNotFoundError,
   createRoundRobinExhaustedError,
   isRetryableRpcError,
+  roundRobinGetTx,
   roundRobinTry,
 } from '../src/roundRobin'
 
 describe('isRetryableRpcError', () => {
-  it('treats connection / gateway failures as retryable', () => {
+  it('treats connection / gateway 5xx failures as retryable', () => {
     expect(isRetryableRpcError(new Error('Failed to fetch'))).toBe(true)
+    expect(isRetryableRpcError(new Error('fetch failed'))).toBe(true)
     expect(isRetryableRpcError(new Error('connect ECONNREFUSED 127.0.0.1:26657'))).toBe(true)
+    expect(isRetryableRpcError(new Error('getaddrinfo ENOTFOUND rpc.example.com'))).toBe(true)
+    expect(isRetryableRpcError(new Error('socket hang up'))).toBe(true)
+    expect(isRetryableRpcError(new Error('request timed out'))).toBe(true)
     expect(isRetryableRpcError(new Error('Bad status on response: 500'))).toBe(true)
     expect(isRetryableRpcError(new Error('Bad status on response: 503'))).toBe(true)
-    expect(isRetryableRpcError(new Error('request timed out'))).toBe(true)
+    expect(isRetryableRpcError(new Error('Bad status on response: 429'))).toBe(true)
   })
 
-  it('treats chain rejection messages as non-retryable', () => {
+  it('does not retry HTTP 4xx (except 429)', () => {
+    expect(isRetryableRpcError(new Error('Bad status on response: 400'))).toBe(false)
+    expect(isRetryableRpcError(new Error('Bad status on response: 404'))).toBe(false)
+    expect(isRetryableRpcError(new Error('invalid request'))).toBe(false)
+  })
+
+  it('treats chain rejection and unknown messages as non-retryable', () => {
     expect(isRetryableRpcError(new Error('insufficient funds: insufficient account funds'))).toBe(false)
     expect(isRetryableRpcError(new Error('account sequence mismatch, expected 5, got 4'))).toBe(false)
     expect(isRetryableRpcError(new Error('out of gas in location: WritePerByte'))).toBe(false)
     expect(isRetryableRpcError(new Error('failed to execute message; message index: 0'))).toBe(false)
+    expect(isRetryableRpcError(new Error('something completely unexpected from cosmjs'))).toBe(false)
   })
 })
 
@@ -66,6 +78,49 @@ describe('roundRobinTry', () => {
     await expect(roundRobinTry([], 'get chain id', async () => 1)).rejects.toThrow(
       'No clients available. Can not get chain id',
     )
+  })
+})
+
+describe('roundRobinGetTx', () => {
+  type FakeClient = { id: string }
+
+  it('returns the first non-null tx', async () => {
+    const clients: FakeClient[] = [{ id: 'a' }, { id: 'b' }]
+    const tx = await roundRobinGetTx(clients, 'HASH', async (c) => (c.id === 'b' ? ({ height: 1 } as never) : null))
+    expect(tx).toEqual({ height: 1 })
+  })
+
+  it('throws TxNotFoundError only when every client returns null', async () => {
+    const clients: FakeClient[] = [{ id: 'a' }, { id: 'b' }]
+    await expect(roundRobinGetTx(clients, 'HASH', async () => null)).rejects.toBeInstanceOf(TxNotFoundError)
+  })
+
+  it('null then retryable error → exhausted with last error (not TxNotFound)', async () => {
+    const clients: FakeClient[] = [{ id: 'a' }, { id: 'b' }]
+    await expect(
+      roundRobinGetTx(clients, 'HASH', async (c) => {
+        if (c.id === 'a') return null
+        throw new Error('Bad status on response: 500')
+      }),
+    ).rejects.toThrow(/Last error: Bad status on response: 500/)
+  })
+
+  it('retryable error then null → exhausted with last error (not TxNotFound)', async () => {
+    const clients: FakeClient[] = [{ id: 'a' }, { id: 'b' }]
+    await expect(
+      roundRobinGetTx(clients, 'HASH', async (c) => {
+        if (c.id === 'a') throw new Error('Failed to fetch')
+        return null
+      }),
+    ).rejects.toThrow(/Last error: Failed to fetch/)
+  })
+
+  it('rethrows non-retryable errors immediately', async () => {
+    await expect(
+      roundRobinGetTx([{ id: 'a' }, { id: 'b' }], 'HASH', async () => {
+        throw new Error('insufficient funds')
+      }),
+    ).rejects.toThrow('insufficient funds')
   })
 })
 

--- a/packages/xchain-cosmos-sdk/src/client.ts
+++ b/packages/xchain-cosmos-sdk/src/client.ts
@@ -33,6 +33,12 @@ import {
   eqAsset,
 } from '@xchainjs/xchain-util'
 
+import {
+  TxNotFoundError,
+  createRoundRobinExhaustedError,
+  isRetryableRpcError,
+  roundRobinTry,
+} from './roundRobin'
 import { Balance, CompatibleAsset, Tx, TxFrom, TxParams, TxTo, TxsPage } from './types'
 
 /**
@@ -463,14 +469,7 @@ export default abstract class Client extends BaseXChainClient implements XChainC
    */
   private async roundRobinGetBalance(address: Address): Promise<readonly Coin[]> {
     const clients = await this.stargateClients.getValue()
-
-    for (const client of clients) {
-      try {
-        return await client.getAllBalances(address)
-      } catch {}
-    }
-
-    throw Error(`No clients available. Can not retrieve balances for ${address}`)
+    return roundRobinTry(clients, `retrieve balances for ${address}`, (client) => client.getAllBalances(address))
   }
 
   /**
@@ -481,36 +480,52 @@ export default abstract class Client extends BaseXChainClient implements XChainC
    */
   private async roundRobinGetBlock(height: number): Promise<Block> {
     const clients = await this.stargateClients.getValue()
-
-    for (const client of clients) {
-      try {
-        return await client.getBlock(height)
-      } catch (e) {
+    return roundRobinTry(clients, `retrieve block ${height}`, (client) => client.getBlock(height), {
+      onRetryableError: (e) => {
         console.warn(`Failed to get block ${height}:`, e instanceof Error ? e.message : e)
-      }
-    }
-
-    throw Error(`No clients available. Can not retrieve block ${height}`)
+      },
+    })
   }
 
   /**
    * Retrieve a transaction making a round robin over the clients urls provided to the client
    * @param {string} txId The hash of the transaction to be retrieved.
    * @returns {IndexedTx} The transaction linked to the hash provided
-   * @throws {Error} if the transaction can not be retrieved
+   * @throws {TxNotFoundError} if no client returns the tx (distinct from RPC unavailability)
+   * @throws {Error} if no client is reachable
    */
   private async roundRobinGetTransaction(txId: string): Promise<IndexedTx> {
     const clients = await this.stargateClients.getValue()
+    let lastError: unknown
+    let notFoundCount = 0
+
+    if (clients.length === 0) {
+      throw createRoundRobinExhaustedError(`retrieve transaction ${txId}`)
+    }
 
     for (const client of clients) {
       try {
         const tx = await client.getTx(txId)
-        if (!tx) throw Error(`Can not find transaction ${txId}`)
+        if (!tx) {
+          notFoundCount++
+          continue
+        }
         return tx
-      } catch {}
+      } catch (error) {
+        lastError = error
+        if (!isRetryableRpcError(error)) {
+          throw error
+        }
+      }
     }
 
-    throw Error(`No clients available. Can not retrieve transaction ${txId}`)
+    // Prefer a distinct not-found error so status pollers can retry without treating
+    // this as "no RPC clients configured / all dead".
+    if (notFoundCount > 0) {
+      throw new TxNotFoundError(txId)
+    }
+
+    throw createRoundRobinExhaustedError(`retrieve transaction ${txId}`, lastError)
   }
 
   /**
@@ -521,14 +536,7 @@ export default abstract class Client extends BaseXChainClient implements XChainC
    */
   private async roundRobinBroadcast(txHex: Uint8Array): Promise<DeliverTxResponse> {
     const clients = await this.stargateClients.getValue()
-
-    for (const client of clients) {
-      try {
-        return await client.broadcastTx(txHex)
-      } catch {}
-    }
-
-    throw Error(`No clients available. Can not broadcast transaction`)
+    return roundRobinTry(clients, 'broadcast transaction', (client) => client.broadcastTx(txHex))
   }
 
   /**
@@ -539,14 +547,7 @@ export default abstract class Client extends BaseXChainClient implements XChainC
    */
   private async roundRobinSearchTx(filters: { key: string; value: string }[]): Promise<IndexedTx[]> {
     const clients = await this.stargateClients.getValue()
-
-    for (const client of clients) {
-      try {
-        return await client.searchTx(filters)
-      } catch {}
-    }
-
-    throw Error(`No clients available. Can not search transaction`)
+    return roundRobinTry(clients, 'search transaction', (client) => client.searchTx(filters))
   }
 
   /**
@@ -557,13 +558,7 @@ export default abstract class Client extends BaseXChainClient implements XChainC
    */
   private async roundRobinGetAccount(address: Address): Promise<Account | null> {
     const clients = await this.stargateClients.getValue()
-
-    for (const client of clients) {
-      try {
-        return await client.getAccount(address)
-      } catch {}
-    }
-    throw Error('No clients available. Can not get address account')
+    return roundRobinTry(clients, 'get address account', (client) => client.getAccount(address))
   }
 
   /**
@@ -574,14 +569,7 @@ export default abstract class Client extends BaseXChainClient implements XChainC
    */
   private async roundRobinGetChainId(): Promise<string> {
     const clients = await this.stargateClients.getValue()
-
-    for (const client of clients) {
-      try {
-        return await client.getChainId()
-      } catch {}
-    }
-
-    throw Error(`No clients available. Can not get chain id`)
+    return roundRobinTry(clients, 'get chain id', (client) => client.getChainId())
   }
 
   public abstract prepareTx({

--- a/packages/xchain-cosmos-sdk/src/client.ts
+++ b/packages/xchain-cosmos-sdk/src/client.ts
@@ -33,12 +33,7 @@ import {
   eqAsset,
 } from '@xchainjs/xchain-util'
 
-import {
-  TxNotFoundError,
-  createRoundRobinExhaustedError,
-  isRetryableRpcError,
-  roundRobinTry,
-} from './roundRobin'
+import { roundRobinGetTx, roundRobinTry } from './roundRobin'
 import { Balance, CompatibleAsset, Tx, TxFrom, TxParams, TxTo, TxsPage } from './types'
 
 /**
@@ -496,36 +491,7 @@ export default abstract class Client extends BaseXChainClient implements XChainC
    */
   private async roundRobinGetTransaction(txId: string): Promise<IndexedTx> {
     const clients = await this.stargateClients.getValue()
-    let lastError: unknown
-    let notFoundCount = 0
-
-    if (clients.length === 0) {
-      throw createRoundRobinExhaustedError(`retrieve transaction ${txId}`)
-    }
-
-    for (const client of clients) {
-      try {
-        const tx = await client.getTx(txId)
-        if (!tx) {
-          notFoundCount++
-          continue
-        }
-        return tx
-      } catch (error) {
-        lastError = error
-        if (!isRetryableRpcError(error)) {
-          throw error
-        }
-      }
-    }
-
-    // Prefer a distinct not-found error so status pollers can retry without treating
-    // this as "no RPC clients configured / all dead".
-    if (notFoundCount > 0) {
-      throw new TxNotFoundError(txId)
-    }
-
-    throw createRoundRobinExhaustedError(`retrieve transaction ${txId}`, lastError)
+    return roundRobinGetTx(clients, txId, (client) => client.getTx(txId))
   }
 
   /**

--- a/packages/xchain-cosmos-sdk/src/index.ts
+++ b/packages/xchain-cosmos-sdk/src/index.ts
@@ -8,6 +8,16 @@ export * from './client'
  * Export specific utility functions from the 'utils' file.
  * This includes 'base64ToBech32', 'bech32ToBase64', and 'makeClientPath'.
  */
-export { base64ToBech32, bech32ToBase64, makeClientPath } from './utils'
+export {
+  base64ToBech32,
+  bech32ToBase64,
+  makeClientPath,
+  TxNotFoundError,
+  createRoundRobinExhaustedError,
+  errorMessage,
+  isRetryableRpcError,
+  roundRobinTry,
+} from './utils'
+export type { RoundRobinTryOptions } from './utils'
 
 export type { Balance, Tx, TxFrom, TxTo, TxsPage, CompatibleAsset, TxParams } from './types'

--- a/packages/xchain-cosmos-sdk/src/index.ts
+++ b/packages/xchain-cosmos-sdk/src/index.ts
@@ -16,6 +16,7 @@ export {
   createRoundRobinExhaustedError,
   errorMessage,
   isRetryableRpcError,
+  roundRobinGetTx,
   roundRobinTry,
 } from './utils'
 export type { RoundRobinTryOptions } from './utils'

--- a/packages/xchain-cosmos-sdk/src/roundRobin.ts
+++ b/packages/xchain-cosmos-sdk/src/roundRobin.ts
@@ -2,9 +2,9 @@
  * Round-robin RPC error handling for Cosmos SDK clients.
  *
  * Goal: only treat connection/transport failures as "try next endpoint".
- * Chain / application failures (insufficient funds, bad sequence, etc.) rethrow
- * immediately. When every endpoint fails, surface the last real error so UIs
- * do not only show a generic "No clients available" string.
+ * Chain / application failures rethrow immediately. When every endpoint fails,
+ * surface the last real error so UIs do not only show a generic
+ * "No clients available" string.
  *
  * @see https://github.com/xchainjs/xchainjs-lib/issues/1727
  */
@@ -26,47 +26,39 @@ export function errorMessage(error: unknown): string {
 }
 
 /**
- * Chain / application errors that should not fail over to the next RPC URL.
- * Connection and most HTTP gateway failures remain retryable so multi-URL
- * configs still work.
+ * Positive allowlist: only these transport / gateway failures fail over to the
+ * next RPC URL. Everything else (4xx, chain rejections, unknown) is non-retryable.
  */
-const NON_RETRYABLE_SUBSTRINGS = [
-  'insufficient funds',
-  'insufficient fee',
-  'account sequence mismatch',
-  'signature verification failed',
-  'unauthorized',
-  'invalid coins',
-  'invalid address',
-  'tx parse error',
-  'out of gas',
-  'failed to execute message',
-  'panic message redacted',
-  'incorrect account sequence',
-  'pubkey type not supported',
-  'signature could not be verified',
+const RETRYABLE_RPC_ERROR_PATTERNS: RegExp[] = [
+  /failed to fetch/i,
+  /fetch failed/i,
+  /networkerror/i,
+  /network request failed/i,
+  /econnrefused/i,
+  /econnreset/i,
+  /enotfound/i,
+  /eai_again/i,
+  /etimedout/i,
+  /socket hang up/i,
+  /socket closed/i,
+  /request timed out/i,
+  /timeout/i,
+  /aborted/i,
+  /ehostunreach/i,
+  /enetunreach/i,
+  // CosmJS Tendermint HTTP gateway errors — only 5xx (and 429) are retryable
+  /bad status on response:\s*(429|5\d\d)\b/i,
+  /status code\s*(429|5\d\d)\b/i,
+  /http (429|5\d\d)\b/i,
 ]
 
 /**
- * @returns true if the error is likely transport/provider related and the next
- * endpoint should be tried; false if the error is a definitive chain rejection.
+ * @returns true if the error is a known transport/gateway failure and the next
+ * endpoint should be tried; false for chain/application errors and unknowns.
  */
 export function isRetryableRpcError(error: unknown): boolean {
-  const msg = errorMessage(error).toLowerCase()
-
-  if (NON_RETRYABLE_SUBSTRINGS.some((s) => msg.includes(s))) {
-    return false
-  }
-
-  // Explicit codespace-style deliver tx failures (CosmJS often embeds these)
-  if (msg.includes('codespace:') && msg.includes('code:')) {
-    // Connection errors rarely include both codespace and code
-    if (!msg.includes('bad status on response')) {
-      return false
-    }
-  }
-
-  return true
+  const msg = errorMessage(error)
+  return RETRYABLE_RPC_ERROR_PATTERNS.some((pattern) => pattern.test(msg))
 }
 
 /**
@@ -125,4 +117,49 @@ export async function roundRobinTry<TItem, TResult>(
   }
 
   throw createRoundRobinExhaustedError(operation, lastError)
+}
+
+/**
+ * Fetch a tx across multiple clients.
+ * - Returns the first non-null tx.
+ * - `null` from a client counts as not-found for that endpoint (try next).
+ * - Retryable RPC errors try the next client.
+ * - Non-retryable errors rethrow immediately.
+ * - If **every** client returns null → `TxNotFoundError`.
+ * - If mixed null + provider failures → exhausted error with last error (not TxNotFound).
+ */
+export async function roundRobinGetTx<TClient, TTx>(
+  clients: readonly TClient[],
+  txId: string,
+  getTx: (client: TClient) => Promise<TTx | null>,
+): Promise<TTx> {
+  let lastError: unknown
+  let notFoundCount = 0
+
+  if (clients.length === 0) {
+    throw createRoundRobinExhaustedError(`retrieve transaction ${txId}`)
+  }
+
+  for (const client of clients) {
+    try {
+      const tx = await getTx(client)
+      if (!tx) {
+        notFoundCount++
+        continue
+      }
+      return tx
+    } catch (error) {
+      lastError = error
+      if (!isRetryableRpcError(error)) {
+        throw error
+      }
+    }
+  }
+
+  // Only when every client successfully reported "missing" — not when providers failed.
+  if (notFoundCount === clients.length) {
+    throw new TxNotFoundError(txId)
+  }
+
+  throw createRoundRobinExhaustedError(`retrieve transaction ${txId}`, lastError)
 }

--- a/packages/xchain-cosmos-sdk/src/roundRobin.ts
+++ b/packages/xchain-cosmos-sdk/src/roundRobin.ts
@@ -1,0 +1,128 @@
+/**
+ * Round-robin RPC error handling for Cosmos SDK clients.
+ *
+ * Goal: only treat connection/transport failures as "try next endpoint".
+ * Chain / application failures (insufficient funds, bad sequence, etc.) rethrow
+ * immediately. When every endpoint fails, surface the last real error so UIs
+ * do not only show a generic "No clients available" string.
+ *
+ * @see https://github.com/xchainjs/xchainjs-lib/issues/1727
+ */
+
+/** Tx was not found on any reachable node (distinct from RPC unavailability). */
+export class TxNotFoundError extends Error {
+  readonly txId: string
+
+  constructor(txId: string) {
+    super(`Can not find transaction ${txId}`)
+    this.name = 'TxNotFoundError'
+    this.txId = txId
+  }
+}
+
+export function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return String(error)
+}
+
+/**
+ * Chain / application errors that should not fail over to the next RPC URL.
+ * Connection and most HTTP gateway failures remain retryable so multi-URL
+ * configs still work.
+ */
+const NON_RETRYABLE_SUBSTRINGS = [
+  'insufficient funds',
+  'insufficient fee',
+  'account sequence mismatch',
+  'signature verification failed',
+  'unauthorized',
+  'invalid coins',
+  'invalid address',
+  'tx parse error',
+  'out of gas',
+  'failed to execute message',
+  'panic message redacted',
+  'incorrect account sequence',
+  'pubkey type not supported',
+  'signature could not be verified',
+]
+
+/**
+ * @returns true if the error is likely transport/provider related and the next
+ * endpoint should be tried; false if the error is a definitive chain rejection.
+ */
+export function isRetryableRpcError(error: unknown): boolean {
+  const msg = errorMessage(error).toLowerCase()
+
+  if (NON_RETRYABLE_SUBSTRINGS.some((s) => msg.includes(s))) {
+    return false
+  }
+
+  // Explicit codespace-style deliver tx failures (CosmJS often embeds these)
+  if (msg.includes('codespace:') && msg.includes('code:')) {
+    // Connection errors rarely include both codespace and code
+    if (!msg.includes('bad status on response')) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * Build the exhausted-round-robin error, attaching the last underlying failure.
+ */
+export function createRoundRobinExhaustedError(operation: string, lastError?: unknown): Error {
+  const last = lastError !== undefined ? errorMessage(lastError) : undefined
+  const message = last
+    ? `No clients available. Can not ${operation}. Last error: ${last}`
+    : `No clients available. Can not ${operation}`
+
+  const err = new Error(message)
+  err.name = 'RoundRobinExhaustedError'
+  if (lastError !== undefined) {
+    // ES2022 Error cause — useful for programmatic consumers
+    ;(err as Error & { cause?: unknown }).cause = lastError
+  }
+  return err
+}
+
+export type RoundRobinTryOptions = {
+  /** Override retry classification (default: isRetryableRpcError). */
+  isRetryable?: (error: unknown) => boolean
+  /** Optional warn hook for skipped retryable failures. */
+  onRetryableError?: (error: unknown, index: number) => void
+}
+
+/**
+ * Run `fn` against each item until one succeeds.
+ * Non-retryable errors rethrow immediately; retryable errors continue.
+ * If all fail, throws with the last error attached.
+ */
+export async function roundRobinTry<TItem, TResult>(
+  items: readonly TItem[],
+  operation: string,
+  fn: (item: TItem, index: number) => Promise<TResult>,
+  options: RoundRobinTryOptions = {},
+): Promise<TResult> {
+  const isRetryable = options.isRetryable ?? isRetryableRpcError
+  let lastError: unknown
+
+  if (items.length === 0) {
+    throw createRoundRobinExhaustedError(operation)
+  }
+
+  for (let i = 0; i < items.length; i++) {
+    try {
+      return await fn(items[i], i)
+    } catch (error) {
+      lastError = error
+      if (!isRetryable(error)) {
+        throw error
+      }
+      options.onRetryableError?.(error, i)
+    }
+  }
+
+  throw createRoundRobinExhaustedError(operation, lastError)
+}

--- a/packages/xchain-cosmos-sdk/src/utils.ts
+++ b/packages/xchain-cosmos-sdk/src/utils.ts
@@ -37,6 +37,7 @@ export {
   createRoundRobinExhaustedError,
   errorMessage,
   isRetryableRpcError,
+  roundRobinGetTx,
   roundRobinTry,
 } from './roundRobin'
 export type { RoundRobinTryOptions } from './roundRobin'

--- a/packages/xchain-cosmos-sdk/src/utils.ts
+++ b/packages/xchain-cosmos-sdk/src/utils.ts
@@ -31,3 +31,12 @@ export const bech32ToBase64 = (address: string): string =>
  * @returns {string} The address in Bech32 format.
  */
 export const base64ToBech32 = (address: string, prefix: string): string => toBech32(prefix, base64.decode(address))
+
+export {
+  TxNotFoundError,
+  createRoundRobinExhaustedError,
+  errorMessage,
+  isRetryableRpcError,
+  roundRobinTry,
+} from './roundRobin'
+export type { RoundRobinTryOptions } from './roundRobin'

--- a/packages/xchain-cosmos/src/client.ts
+++ b/packages/xchain-cosmos/src/client.ts
@@ -9,7 +9,13 @@ import {
 } from '@cosmjs/proto-signing'
 import { GasPrice, SigningStargateClient, calculateFee } from '@cosmjs/stargate'
 import { AssetInfo, FeeType, Fees, PreparedTx, singleFee } from '@xchainjs/xchain-client'
-import { Client as CosmosSDKClient, CosmosSdkClientParams, MsgTypes, makeClientPath } from '@xchainjs/xchain-cosmos-sdk'
+import {
+  Client as CosmosSDKClient,
+  CosmosSdkClientParams,
+  MsgTypes,
+  makeClientPath,
+  roundRobinTry,
+} from '@xchainjs/xchain-cosmos-sdk'
 import { Address, Asset, AssetType, baseAmount, eqAsset } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx.js'
@@ -269,28 +275,24 @@ export abstract class Client extends CosmosSDKClient {
     signer: DirectSecp256k1HdWallet,
     gasLimit: BigNumber,
   ): Promise<TxRaw> {
-    for (const url of this.clientUrls[this.network]) {
-      try {
-        const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
-          registry: this.registry,
-        })
+    return roundRobinTry(this.clientUrls[this.network], 'sign transaction', async (url) => {
+      const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
+        registry: this.registry,
+      })
 
-        const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
-          return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
-        })
+      const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
+        return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
+      })
 
-        return await signingClient.sign(
-          sender,
-          messages,
-          {
-            amount: [],
-            gas: gasLimit.toString(),
-          },
-          unsignedTx.body.memo,
-        )
-      } catch {}
-    }
-
-    throw Error('No clients available. Can not sign transaction')
+      return signingClient.sign(
+        sender,
+        messages,
+        {
+          amount: [],
+          gas: gasLimit.toString(),
+        },
+        unsignedTx.body.memo,
+      )
+    })
   }
 }

--- a/packages/xchain-cosmos/src/clientKeystore.ts
+++ b/packages/xchain-cosmos/src/clientKeystore.ts
@@ -1,7 +1,7 @@
 import { fromBase64 } from '@cosmjs/encoding'
 import { DecodedTxRaw, DirectSecp256k1HdWallet, EncodeObject, decodeTxRaw } from '@cosmjs/proto-signing'
 import { DeliverTxResponse, SigningStargateClient } from '@cosmjs/stargate'
-import { MsgTypes, makeClientPath } from '@xchainjs/xchain-cosmos-sdk'
+import { MsgTypes, makeClientPath, roundRobinTry } from '@xchainjs/xchain-cosmos-sdk'
 import { getSeed } from '@xchainjs/xchain-crypto'
 import { bech32 } from '@scure/base'
 import { HDKey } from '@scure/bip32'
@@ -96,27 +96,21 @@ export class ClientKeystore extends Client {
     unsignedTx: DecodedTxRaw,
     signer: DirectSecp256k1HdWallet,
   ): Promise<DeliverTxResponse> {
-    for (const url of this.clientUrls[this.network]) {
-      try {
-        const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
-          registry: this.registry,
-        })
+    return roundRobinTry(this.clientUrls[this.network], 'sign and broadcast transaction', async (url) => {
+      const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
+        registry: this.registry,
+      })
 
-        const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
-          return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
-        })
+      const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
+        return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
+      })
 
-        const tx = await signingClient.signAndBroadcast(
-          sender,
-          messages,
-          this.getStandardFee(this.getAssetInfo().asset),
-          unsignedTx.body.memo,
-        )
-
-        return tx
-      } catch {}
-    }
-
-    throw Error('No clients available. Can not sign and broadcast transaction')
+      return signingClient.signAndBroadcast(
+        sender,
+        messages,
+        this.getStandardFee(this.getAssetInfo().asset),
+        unsignedTx.body.memo,
+      )
+    })
   }
 }

--- a/packages/xchain-cosmos/src/clientLedger.ts
+++ b/packages/xchain-cosmos/src/clientLedger.ts
@@ -6,7 +6,7 @@ import { DeliverTxResponse, SigningStargateClient } from '@cosmjs/stargate'
 import CosmosApp from '@ledgerhq/hw-app-cosmos'
 import type Transport from '@ledgerhq/hw-transport'
 import { TxHash } from '@xchainjs/xchain-client'
-import { MsgTypes } from '@xchainjs/xchain-cosmos-sdk'
+import { MsgTypes, roundRobinTry } from '@xchainjs/xchain-cosmos-sdk'
 import { Address } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 
@@ -79,27 +79,21 @@ export class ClientLedger extends Client {
     unsignedTx: DecodedTxRaw,
     signer: OfflineAminoSigner,
   ): Promise<DeliverTxResponse> {
-    for (const url of this.clientUrls[this.network]) {
-      try {
-        const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
-          registry: this.registry,
-        })
+    return roundRobinTry(this.clientUrls[this.network], 'sign and broadcast transaction', async (url) => {
+      const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
+        registry: this.registry,
+      })
 
-        const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
-          return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
-        })
+      const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
+        return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
+      })
 
-        const tx = await signingClient.signAndBroadcast(
-          sender,
-          messages,
-          this.getStandardFee(this.getAssetInfo().asset),
-          unsignedTx.body.memo,
-        )
-
-        return tx
-      } catch {}
-    }
-
-    throw Error('No clients available. Can not sign and broadcast transaction')
+      return signingClient.signAndBroadcast(
+        sender,
+        messages,
+        this.getStandardFee(this.getAssetInfo().asset),
+        unsignedTx.body.memo,
+      )
+    })
   }
 }

--- a/packages/xchain-kujira/src/client.ts
+++ b/packages/xchain-kujira/src/client.ts
@@ -9,7 +9,13 @@ import {
 } from '@cosmjs/proto-signing'
 import { DeliverTxResponse, GasPrice, SigningStargateClient, calculateFee } from '@cosmjs/stargate'
 import { AssetInfo, PreparedTx } from '@xchainjs/xchain-client'
-import { Client as CosmosSdkClient, CosmosSdkClientParams, MsgTypes, makeClientPath } from '@xchainjs/xchain-cosmos-sdk'
+import {
+  Client as CosmosSdkClient,
+  CosmosSdkClientParams,
+  MsgTypes,
+  makeClientPath,
+  roundRobinTry,
+} from '@xchainjs/xchain-cosmos-sdk'
 import { getSeed } from '@xchainjs/xchain-crypto'
 import { Address, AssetType, eqAsset } from '@xchainjs/xchain-util'
 import { bech32 } from '@scure/base'
@@ -266,27 +272,21 @@ export class Client extends CosmosSdkClient {
     unsignedTx: DecodedTxRaw,
     signer: DirectSecp256k1HdWallet,
   ): Promise<DeliverTxResponse> {
-    for (const url of this.clientUrls[this.network]) {
-      try {
-        const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
-          registry: this.registry,
-        })
+    return roundRobinTry(this.clientUrls[this.network], 'sign and broadcast transaction', async (url) => {
+      const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
+        registry: this.registry,
+      })
 
-        const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
-          return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
-        })
+      const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
+        return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
+      })
 
-        const tx = await signingClient.signAndBroadcast(
-          sender,
-          messages,
-          this.getStandardFee(this.getAssetInfo().asset),
-          unsignedTx.body.memo,
-        )
-
-        return tx
-      } catch {}
-    }
-
-    throw Error('No clients available. Can not sign and broadcast transaction')
+      return signingClient.signAndBroadcast(
+        sender,
+        messages,
+        this.getStandardFee(this.getAssetInfo().asset),
+        unsignedTx.body.memo,
+      )
+    })
   }
 }

--- a/packages/xchain-mayachain/src/client.ts
+++ b/packages/xchain-mayachain/src/client.ts
@@ -16,6 +16,7 @@ import {
   MsgTypes,
   bech32ToBase64,
   makeClientPath,
+  roundRobinTry,
 } from '@xchainjs/xchain-cosmos-sdk'
 import { getSeed } from '@xchainjs/xchain-crypto'
 import { Address, BaseAmount, assetFromString, eqAsset, isSynthAsset } from '@xchainjs/xchain-util'
@@ -457,28 +458,24 @@ export class Client extends CosmosSDKClient implements MayachainClient {
     signer: DirectSecp256k1HdWallet,
     gasLimit: BigNumber,
   ): Promise<TxRaw> {
-    for (const url of this.clientUrls[this.network]) {
-      try {
-        const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
-          registry: this.registry,
-        })
-        // Map messages and sign the transaction
-        const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
-          return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
-        })
+    return roundRobinTry(this.clientUrls[this.network], 'sign transaction', async (url) => {
+      const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
+        registry: this.registry,
+      })
+      const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
+        return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
+      })
 
-        return await signingClient.sign(
-          sender,
-          messages,
-          {
-            amount: [],
-            gas: gasLimit.toString(),
-          },
-          unsignedTx.body.memo,
-        )
-      } catch {}
-    }
-    throw Error('No clients available. Can not sign transaction')
+      return signingClient.sign(
+        sender,
+        messages,
+        {
+          amount: [],
+          gas: gasLimit.toString(),
+        },
+        unsignedTx.body.memo,
+      )
+    })
   }
 
   /**
@@ -494,20 +491,17 @@ export class Client extends CosmosSDKClient implements MayachainClient {
     unsignedTx: DecodedTxRaw,
     signer: DirectSecp256k1HdWallet,
   ): Promise<DeliverTxResponse> {
-    for (const url of this.clientUrls[this.network]) {
-      try {
-        const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
-          registry: this.registry,
-        })
+    return roundRobinTry(this.clientUrls[this.network], 'sign and broadcast transaction', async (url) => {
+      const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
+        registry: this.registry,
+      })
 
-        const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
-          return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
-        })
+      const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
+        return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
+      })
 
-        return await signingClient.signAndBroadcast(sender, messages, this.getStandardFee(), unsignedTx.body.memo)
-      } catch {}
-    }
-    throw Error('No clients available. Can not sign and broadcast transaction')
+      return signingClient.signAndBroadcast(sender, messages, this.getStandardFee(), unsignedTx.body.memo)
+    })
   }
 
   /**
@@ -529,37 +523,33 @@ export class Client extends CosmosSDKClient implements MayachainClient {
     memo: string,
     asset: CompatibleAsset,
   ): Promise<DeliverTxResponse> {
-    for (const url of this.clientUrls[this.network]) {
-      try {
-        const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
-          registry: this.registry,
-        })
-        // Sign and broadcast the deposit transaction
-        return await signingClient.signAndBroadcast(
-          sender,
-          [
-            {
-              typeUrl: MSG_DEPOSIT_TYPE_URL,
-              value: {
-                signer: bech32ToBase64(sender),
-                memo,
-                coins: [
-                  {
-                    amount: amount.amount().toString(),
-                    asset: parseAssetToMayanodeAsset(asset),
-                  },
-                ],
-              },
-            },
-          ],
+    return roundRobinTry(this.clientUrls[this.network], 'sign and broadcast deposit transaction', async (url) => {
+      const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
+        registry: this.registry,
+      })
+      return signingClient.signAndBroadcast(
+        sender,
+        [
           {
-            amount: [],
-            gas: gasLimit.toString(),
+            typeUrl: MSG_DEPOSIT_TYPE_URL,
+            value: {
+              signer: bech32ToBase64(sender),
+              memo,
+              coins: [
+                {
+                  amount: amount.amount().toString(),
+                  asset: parseAssetToMayanodeAsset(asset),
+                },
+              ],
+            },
           },
-          memo,
-        )
-      } catch {}
-    }
-    throw Error('No clients available. Can not sign and broadcast deposit transaction')
+        ],
+        {
+          amount: [],
+          gas: gasLimit.toString(),
+        },
+        memo,
+      )
+    })
   }
 }

--- a/packages/xchain-thorchain/src/clientKeystore.ts
+++ b/packages/xchain-thorchain/src/clientKeystore.ts
@@ -7,6 +7,7 @@ import {
   MsgTypes,
   bech32ToBase64,
   makeClientPath,
+  roundRobinTry,
 } from '@xchainjs/xchain-cosmos-sdk'
 import { getSeed } from '@xchainjs/xchain-crypto'
 import { BaseAmount } from '@xchainjs/xchain-util'
@@ -234,31 +235,25 @@ export class ClientKeystore extends Client {
     signer: DirectSecp256k1HdWallet,
     gasLimit: BigNumber,
   ): Promise<TxRaw> {
-    // Connect to signing client
-    for (const url of this.clientUrls[this.network]) {
-      try {
-        const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
-          registry: this.registry,
-        })
+    return roundRobinTry(this.clientUrls[this.network], 'sign transaction', async (url) => {
+      const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
+        registry: this.registry,
+      })
 
-        // Prepare messages
-        const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
-          return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
-        })
+      const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
+        return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
+      })
 
-        // Sign transaction
-        return await signingClient.sign(
-          sender,
-          messages,
-          {
-            amount: [],
-            gas: gasLimit.toString(),
-          },
-          unsignedTx.body.memo,
-        )
-      } catch {}
-    }
-    throw Error('No clients available. Can not sign transaction')
+      return signingClient.sign(
+        sender,
+        messages,
+        {
+          amount: [],
+          gas: gasLimit.toString(),
+        },
+        unsignedTx.body.memo,
+      )
+    })
   }
 
   /**
@@ -274,7 +269,7 @@ export class ClientKeystore extends Client {
     unsignedTx: DecodedTxRaw,
     signer: DirectSecp256k1HdWallet,
   ): Promise<DeliverTxResponse> {
-    for (const url of this.clientUrls[this.network]) {
+    return roundRobinTry(this.clientUrls[this.network], 'sign and broadcast transaction', async (url) => {
       const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
         registry: this.registry,
       })
@@ -283,9 +278,8 @@ export class ClientKeystore extends Client {
         return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
       })
 
-      return await signingClient.signAndBroadcast(sender, messages, this.getStandardFee(), unsignedTx.body.memo)
-    }
-    throw Error('No clients available. Can not sign and broadcast transaction')
+      return signingClient.signAndBroadcast(sender, messages, this.getStandardFee(), unsignedTx.body.memo)
+    })
   }
 
   /**
@@ -307,14 +301,15 @@ export class ClientKeystore extends Client {
     memo: string,
     asset: CompatibleAsset,
   ): Promise<DeliverTxResponse> {
-    for (const url of this.clientUrls[this.network]) {
-      try {
+    return roundRobinTry(
+      this.clientUrls[this.network],
+      'sign and broadcast deposit transaction',
+      async (url) => {
         const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
           registry: this.registry,
         })
 
-        // Sign and broadcast transaction
-        return await signingClient.signAndBroadcast(
+        return signingClient.signAndBroadcast(
           sender,
           [
             {
@@ -337,10 +332,12 @@ export class ClientKeystore extends Client {
           },
           memo,
         )
-      } catch (e: unknown) {
-        console.warn(e instanceof Error ? e.message : String(e))
-      }
-    }
-    throw Error('No clients available. Can not sign and broadcast deposit transaction')
+      },
+      {
+        onRetryableError: (e) => {
+          console.warn(e instanceof Error ? e.message : String(e))
+        },
+      },
+    )
   }
 }


### PR DESCRIPTION
## Summary

Fixes #1727 — Cosmos/THOR/MAYA round-robin helpers no longer collapse every failure into a generic **“No clients available”** message.

- Add shared `roundRobinTry`, `isRetryableRpcError`, `TxNotFoundError`, and exhausted-error helpers in `@xchainjs/xchain-cosmos-sdk`
- **Non-retryable** chain errors (e.g. insufficient funds, sequence mismatch) rethrow immediately
- **Retryable** transport/gateway failures still try the next URL
- When all endpoints fail, the final error includes **Last error: …** and `error.cause`
- `getTransaction` throws **`TxNotFoundError`** when reachable nodes report the tx as missing (distinct from RPC unavailability)

Applied consistently in cosmos-sdk, thorchain, mayachain, cosmos (keystore + ledger), and kujira.

## Test plan

- [x] Unit tests: `packages/xchain-cosmos-sdk/__tests__/roundRobin.test.ts` (9 tests)
- [x] Build affected packages
- [ ] Asgardex / suite: insufficient-funds deposit shows real CosmJS message
- [ ] All RPCs returning 500 surfaces last error in the exhausted message
- [ ] Tx status poll: missing tx is `TxNotFoundError`, not “no clients”

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent automatic failover across available RPC endpoints for Cosmos transactions and queries.
  - Improved handling of retryable and non-retryable RPC errors.
  - Clearer errors are now reported when all endpoints fail, including the underlying cause.
  - Missing transactions now return a specific transaction-not-found error.
  - Exposed reusable round-robin retry and error-handling utilities.

- **Bug Fixes**
  - Prevented chain and application errors from being incorrectly retried or silently discarded.
  - Improved retry behavior for signing, broadcasting, and deposit operations across Cosmos-based chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->