### PR TITLE
ci(release): install libusb for Node 22 yarn install

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,14 @@ jobs:
           node --version
           npm --version
 
+      # node-hid (Ledger transports) has no prebuild for Node 22 on some runners and
+      # compiles from source; that needs libusb. Without this, yarn install fails and
+      # changesets/action never refreshes changeset-release/master (stale Version Packages PR).
+      - name: Install native build deps (node-hid / libusb)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libusb-1.0-0-dev libudev-dev
+
       - name: Install dependencies
         run: yarn install --immutable
 


### PR DESCRIPTION
## Summary

Release workflow has been **failing on `yarn install`** since Node 22 / Trusted Publishing, because `node-hid` (Ledger) has no prebuild and needs `libusb` to compile. `changesets/action` never runs, so `changeset-release/master` stays frozen and **Version Packages (#1730)** conflicts with `master`.

## Fix

Install `libusb-1.0-0-dev` and `libudev-dev` before `yarn install` in `.github/workflows/release.yaml`.

## After merge

1. Release workflow should succeed on `master`.
2. Bot regenerates / updates **Version Packages** from current pending changesets (close #1730 only if it stays dirty; usually the action force-updates the same PR).
3. Review that Version Packages PR (versions + changelogs).
4. Merge it → next Release run publishes to npm.

## Test plan

- [ ] Merge this PR
- [ ] Confirm Release workflow on that push is green
- [ ] Confirm Version Packages PR is mergeable (no conflicts with master)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release build reliability by installing required system libraries for native hardware integration dependencies.
  * Ensured releases can compile successfully on Node.js 22 build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->