### PR TITLE
fix(sui): avoid BigInt TypeError on failed gRPC execute

### DIFF
--- a/.changeset/sui-safe-grpc-status-stringify.md
+++ b/.changeset/sui-safe-grpc-status-stringify.md
@@ -1,0 +1,5 @@
+---
+'@xchainjs/xchain-sui': patch
+---
+
+Fix production TypeError when reporting failed Sui gRPC executes: protobuf `ExecutionStatus` can include BigInt fields (e.g. `error.command`), and `JSON.stringify` throws "Do not know how to serialize a BigInt". Failure messages now prefer `error.description` and otherwise use a BigInt-safe stringify so callers see the on-chain error instead of a serialization crash.

--- a/.changeset/sui-safe-grpc-status-stringify.md
+++ b/.changeset/sui-safe-grpc-status-stringify.md
@@ -3,3 +3,5 @@
 ---
 
 Fix production TypeError when reporting failed Sui gRPC executes: protobuf `ExecutionStatus` can include BigInt fields (e.g. `error.command`), and `JSON.stringify` throws "Do not know how to serialize a BigInt". Failure messages now prefer `error.description` and otherwise use a BigInt-safe stringify so callers see the on-chain error instead of a serialization crash.
+
+Also fix native SUI transfers that only set the first coin object as gas payment: amounts larger than that single coin failed with `InsufficientCoinBalance` even when total wallet SUI was sufficient. All SUI coins are now passed to `setGasPayment` so the PTB can merge them and `splitCoins(tx.gas, …)` can use the full balance (minus gas).

--- a/packages/xchain-sui/__tests__/client.test.ts
+++ b/packages/xchain-sui/__tests__/client.test.ts
@@ -4,10 +4,13 @@ import { assetToString } from '@xchainjs/xchain-util'
 import {
   Client,
   defaultSuiParams,
+  formatGrpcExecutionFailure,
   getDefaultGraphqlUrl,
   getDefaultGrpcUrl,
+  isGrpcExecutionFailure,
   resolveGraphqlUrl,
   resolvePrimaryUrl,
+  safeJsonStringify,
 } from '../src'
 
 describe('Sui client', () => {
@@ -74,6 +77,59 @@ describe('Sui client', () => {
           },
         }),
       ).toBe(custom)
+    })
+  })
+
+  describe('gRPC execution status error reporting', () => {
+    it('Should stringify objects that contain BigInt without throwing', () => {
+      const status = {
+        success: false,
+        error: {
+          description: 'InsufficientGas',
+          command: 2n,
+        },
+      }
+      expect(() => JSON.stringify(status)).toThrow(/BigInt/)
+      expect(safeJsonStringify(status)).toContain('2')
+      expect(safeJsonStringify(status)).toContain('InsufficientGas')
+    })
+
+    it('Should treat only object success:false as failure', () => {
+      expect(isGrpcExecutionFailure({ success: false })).toBe(true)
+      expect(isGrpcExecutionFailure({ success: true })).toBe(false)
+      expect(isGrpcExecutionFailure(undefined)).toBe(false)
+      // enum-style number — leave as non-failure (same as pre-fix behavior)
+      expect(isGrpcExecutionFailure(0)).toBe(false)
+      expect(isGrpcExecutionFailure(1)).toBe(false)
+    })
+
+    it('Should format failure using description and BigInt command without TypeError', () => {
+      const status = {
+        success: false,
+        error: {
+          description: 'InsufficientCoinBalance',
+          command: 0n,
+        },
+      }
+      const message = formatGrpcExecutionFailure(status)
+      expect(message).toContain('Transaction failed')
+      expect(message).toContain('InsufficientCoinBalance')
+      expect(message).toContain('command 0')
+      expect(() => {
+        if (isGrpcExecutionFailure(status)) {
+          throw Error(formatGrpcExecutionFailure(status))
+        }
+      }).toThrow(/InsufficientCoinBalance/)
+    })
+
+    it('Should fall back to safe stringify when description is missing', () => {
+      const status = { success: false, error: { command: 7n, kind: 3 } }
+      const message = formatGrpcExecutionFailure(status)
+      expect(message.startsWith('Transaction failed:')).toBe(true)
+      expect(message).toContain('7')
+      expect(() => {
+        throw Error(formatGrpcExecutionFailure(status))
+      }).not.toThrow(/serialize a BigInt/)
     })
   })
 

--- a/packages/xchain-sui/__tests__/client.test.ts
+++ b/packages/xchain-sui/__tests__/client.test.ts
@@ -122,6 +122,17 @@ describe('Sui client', () => {
       }).toThrow(/InsufficientCoinBalance/)
     })
 
+    it('Should not duplicate command id when description already includes it', () => {
+      const message = formatGrpcExecutionFailure({
+        success: false,
+        error: {
+          description: 'InsufficientCoinBalance in command 0',
+          command: 0n,
+        },
+      })
+      expect(message).toBe('Transaction failed: InsufficientCoinBalance in command 0')
+    })
+
     it('Should fall back to safe stringify when description is missing', () => {
       const status = { success: false, error: { command: 7n, kind: 3 } }
       const message = formatGrpcExecutionFailure(status)

--- a/packages/xchain-sui/src/client.ts
+++ b/packages/xchain-sui/src/client.ts
@@ -466,13 +466,17 @@ export class Client extends BaseXChainClient {
 
     const tx = new Transaction()
     tx.setSender(sender)
-    tx.setGasPayment([
-      {
-        objectId: gasCoins[0].objectId,
-        version: gasCoins[0].version,
-        digest: gasCoins[0].digest,
-      },
-    ])
+    // Use ALL SUI coin objects as gas payment. Native transfers split the send
+    // amount from `tx.gas`; if only the first coin is set, fragmented balances
+    // fail with InsufficientCoinBalance even when total SUI is enough (common
+    // after many receives / swaps). Multiple gas inputs are merged by the PTB.
+    tx.setGasPayment(
+      gasCoins.map((c) => ({
+        objectId: c.objectId,
+        version: c.version,
+        digest: c.digest,
+      })),
+    )
     tx.setGasBudget(budget)
     tx.setGasPrice(gasPrice)
 

--- a/packages/xchain-sui/src/client.ts
+++ b/packages/xchain-sui/src/client.ts
@@ -30,7 +30,13 @@ import slip10 from 'micro-key-producer/slip10.js'
 
 import { DEFAULT_GAS_BUDGET, SUIAsset, SUIChain, SUI_DECIMALS, SUI_TYPE_TAG, defaultSuiParams } from './const'
 import { Balance, SUIClientParams, SuiTransport, Tx, TxFrom, TxParams, TxTo, TxsPage } from './types'
-import { getSuiNetwork, resolveGraphqlUrl, resolvePrimaryUrl } from './utils'
+import {
+  formatGrpcExecutionFailure,
+  getSuiNetwork,
+  isGrpcExecutionFailure,
+  resolveGraphqlUrl,
+  resolvePrimaryUrl,
+} from './utils'
 
 type CoreClient = SuiGrpcClient | SuiJsonRpcClient
 type GasCoinRef = { objectId: string; version: string | number; digest: string }
@@ -544,8 +550,9 @@ export class Client extends BaseXChainClient {
 
     const status = response.transaction?.effects?.status
     // status may be enum number or object depending on protobuf version
-    if (status && typeof status === 'object' && 'success' in status && status.success === false) {
-      throw Error(`Transaction failed: ${JSON.stringify(status)}`)
+    if (isGrpcExecutionFailure(status)) {
+      // Prefer description; never JSON.stringify raw protobuf (BigInt throws).
+      throw Error(formatGrpcExecutionFailure(status))
     }
 
     return digest

--- a/packages/xchain-sui/src/index.ts
+++ b/packages/xchain-sui/src/index.ts
@@ -3,10 +3,13 @@ export { Client } from './client'
 export * from './types'
 export * from './const'
 export {
+  formatGrpcExecutionFailure,
   getDefaultClientUrl,
   getDefaultGraphqlUrl,
   getDefaultGrpcUrl,
   getSuiNetwork,
+  isGrpcExecutionFailure,
   resolveGraphqlUrl,
   resolvePrimaryUrl,
+  safeJsonStringify,
 } from './utils'

--- a/packages/xchain-sui/src/utils.ts
+++ b/packages/xchain-sui/src/utils.ts
@@ -98,8 +98,12 @@ export const formatGrpcExecutionFailure = (status: unknown): string => {
   if (status && typeof status === 'object') {
     const error = (status as { error?: { description?: string; command?: bigint | number | string } }).error
     if (error?.description) {
+      // Descriptions often already include "in command N" — avoid "… (command N)".
+      const alreadyHasCommand = /command\s+\d+/i.test(error.description)
       const command =
-        error.command !== undefined && error.command !== null ? ` (command ${error.command.toString()})` : ''
+        !alreadyHasCommand && error.command !== undefined && error.command !== null
+          ? ` (command ${error.command.toString()})`
+          : ''
       return `Transaction failed: ${error.description}${command}`
     }
   }

--- a/packages/xchain-sui/src/utils.ts
+++ b/packages/xchain-sui/src/utils.ts
@@ -64,3 +64,44 @@ export const resolveGraphqlUrl = (network: Network, params: Pick<SUIClientParams
  * the old name; returns the gRPC fullnode URL (not JSON-RPC).
  */
 export const getDefaultClientUrl = getDefaultGrpcUrl
+
+/**
+ * JSON.stringify that never throws on BigInt (common in Sui gRPC/protobuf).
+ * BigInts are converted to decimal strings.
+ */
+export const safeJsonStringify = (value: unknown): string => {
+  try {
+    return JSON.stringify(value, (_key, v) => (typeof v === 'bigint' ? v.toString() : v))
+  } catch {
+    // Circular refs or other exotic values — fall back without throwing.
+    return String(value)
+  }
+}
+
+/**
+ * gRPC `ExecutionStatus` may be a protobuf object (`{ success, error }`) or an
+ * enum number depending on decoder path. Only treat object `{ success: false }`
+ * as failure (same rule as before).
+ */
+export const isGrpcExecutionFailure = (status: unknown): boolean => {
+  return Boolean(
+    status && typeof status === 'object' && 'success' in status && (status as { success?: boolean }).success === false,
+  )
+}
+
+/**
+ * Build a human-readable message for a failed gRPC execution status.
+ * Prefers `error.description` when present; otherwise safe-stringifies the
+ * whole status (handles BigInt fields such as `error.command`).
+ */
+export const formatGrpcExecutionFailure = (status: unknown): string => {
+  if (status && typeof status === 'object') {
+    const error = (status as { error?: { description?: string; command?: bigint | number | string } }).error
+    if (error?.description) {
+      const command =
+        error.command !== undefined && error.command !== null ? ` (command ${error.command.toString()})` : ''
+      return `Transaction failed: ${error.description}${command}`
+    }
+  }
+  return `Transaction failed: ${safeJsonStringify(status)}`
+}

--- a/tools/xchain-suite/src/pages/SwapPage.tsx
+++ b/tools/xchain-suite/src/pages/SwapPage.tsx
@@ -197,6 +197,8 @@ export default function SwapPage() {
     MAYA: 0.02,
     KUJI: 0.01,
     TRON: 2,
+    // Matches xchain-sui DEFAULT_GAS_BUDGET (10_000_000 MIST = 0.01 SUI)
+    SUI: 0.01,
   }
 
   // Set amount to percentage of balance


### PR DESCRIPTION
## Summary

Production bug in `@xchainjs/xchain-sui@0.2.0`: failed gRPC transaction execute throws:

```text
TypeError: Do not know how to serialize a BigInt
```

instead of the on-chain failure reason. Reproduced on Asgardex Desktop (SUI → BTC via NEAR Intents / 1Click); the throw is in `executeGrpcTransaction` when building the error message.

### Cause

```ts
throw Error(\`Transaction failed: \${JSON.stringify(status)}\`)
```

Sui gRPC `ExecutionStatus.error.command` is a `bigint`. Native `JSON.stringify` throws on BigInt.

### Fix

- Prefer `status.error.description` (+ command id) when present
- Otherwise `JSON.stringify` with a BigInt → string replacer (`safeJsonStringify`)
- Never throw while constructing the failure `Error`
- Success path unchanged (`success: false` object check only; enum numbers not treated as failure)

### Tests

- BigInt status stringifies without TypeError
- Failure messages include description / safe fallback
- Existing client tests still pass

## Test plan

- [x] `yarn turbo run test build --filter='@xchainjs/xchain-sui'`
- [ ] Asgardex: retry SUI → BTC OneClick after package bump; failed txs should show on-chain reason (e.g. gas/balance), not BigInt TypeError
- [ ] Successful SUI transfer still returns digest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sui transaction failure reporting for gRPC executions involving large numeric values.
  * Error messages now avoid serialization crashes and provide clearer descriptions, including command details when available.
  * Added fallback formatting when detailed failure descriptions are unavailable.
  * Native SUI transfers now use all available wallet coins for gas, helping larger transfers succeed.
  * Added a SUI fee reserve to swap transactions for more reliable fee handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->