### PR TITLE
chore(utxo): bump coinselect 3.1.12 → 3.1.13

### DIFF
--- a/.changeset/coinselect-3.1.13.md
+++ b/.changeset/coinselect-3.1.13.md
@@ -1,0 +1,11 @@
+---
+'@xchainjs/xchain-bitcoin': patch
+'@xchainjs/xchain-bitcoincash': patch
+'@xchainjs/xchain-dash': patch
+'@xchainjs/xchain-doge': patch
+'@xchainjs/xchain-litecoin': patch
+---
+
+Bump `coinselect` from 3.1.12 to 3.1.13 across UTXO chain packages.
+
+3.1.13 only changes the `split` algorithm (treat `value: 0` as a fixed output, not a split target). XChain UTXO clients use `coinselect/accumulative.js`, which is identical between 3.1.12 and 3.1.13 — this is a hygiene/alignment bump with no intended selection behavior change for current call sites.

--- a/packages/xchain-bitcoin/package.json
+++ b/packages/xchain-bitcoin/package.json
@@ -42,7 +42,7 @@
     "@xchainjs/xchain-utxo": "workspace:*",
     "@xchainjs/xchain-utxo-providers": "workspace:*",
     "bitcoinjs-lib": "^6.1.7",
-    "coinselect": "3.1.12",
+    "coinselect": "3.1.13",
     "ecpair": "2.1.0"
   },
   "devDependencies": {

--- a/packages/xchain-bitcoincash/package.json
+++ b/packages/xchain-bitcoincash/package.json
@@ -44,7 +44,7 @@
     "bitcore-lib-cash": "11.0.0",
     "bs58check": "^4.0.0",
     "cashaddrjs": "^0.4.4",
-    "coinselect": "3.1.12"
+    "coinselect": "3.1.13"
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.28.6",

--- a/packages/xchain-dash/package.json
+++ b/packages/xchain-dash/package.json
@@ -43,7 +43,7 @@
     "@xchainjs/xchain-utxo": "workspace:*",
     "@xchainjs/xchain-utxo-providers": "workspace:*",
     "bitcoinjs-lib": "^6.1.7",
-    "coinselect": "3.1.12",
+    "coinselect": "3.1.13",
     "ecpair": "2.1.0"
   },
   "devDependencies": {

--- a/packages/xchain-doge/package.json
+++ b/packages/xchain-doge/package.json
@@ -42,7 +42,7 @@
     "@xchainjs/xchain-utxo": "workspace:*",
     "@xchainjs/xchain-utxo-providers": "workspace:*",
     "bitcoinjs-lib": "^6.1.7",
-    "coinselect": "3.1.12",
+    "coinselect": "3.1.13",
     "ecpair": "2.1.0"
   },
   "devDependencies": {

--- a/packages/xchain-litecoin/package.json
+++ b/packages/xchain-litecoin/package.json
@@ -43,7 +43,7 @@
     "@xchainjs/xchain-utxo-providers": "workspace:*",
     "axios": "1.18.1",
     "bitcoinjs-lib": "^6.1.7",
-    "coinselect": "3.1.12",
+    "coinselect": "3.1.13",
     "ecpair": "2.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5339,7 +5339,7 @@ __metadata:
     axios: "npm:1.18.1"
     axios-mock-adapter: "npm:^2.1.0"
     bitcoinjs-lib: "npm:^6.1.7"
-    coinselect: "npm:3.1.12"
+    coinselect: "npm:3.1.13"
     ecpair: "npm:2.1.0"
   languageName: unknown
   linkType: soft
@@ -5363,7 +5363,7 @@ __metadata:
     bitcore-lib-cash: "npm:11.0.0"
     bs58check: "npm:^4.0.0"
     cashaddrjs: "npm:^0.4.4"
-    coinselect: "npm:3.1.12"
+    coinselect: "npm:3.1.13"
   languageName: unknown
   linkType: soft
 
@@ -5477,7 +5477,7 @@ __metadata:
     axios: "npm:1.18.1"
     axios-mock-adapter: "npm:^2.1.0"
     bitcoinjs-lib: "npm:^6.1.7"
-    coinselect: "npm:3.1.12"
+    coinselect: "npm:3.1.13"
     ecpair: "npm:2.1.0"
   languageName: unknown
   linkType: soft
@@ -5498,7 +5498,7 @@ __metadata:
     axios: "npm:1.18.1"
     axios-mock-adapter: "npm:^2.1.0"
     bitcoinjs-lib: "npm:^6.1.7"
-    coinselect: "npm:3.1.12"
+    coinselect: "npm:3.1.13"
     ecpair: "npm:2.1.0"
   languageName: unknown
   linkType: soft
@@ -5582,7 +5582,7 @@ __metadata:
     axios: "npm:1.18.1"
     axios-mock-adapter: "npm:^2.1.0"
     bitcoinjs-lib: "npm:^6.1.7"
-    coinselect: "npm:3.1.12"
+    coinselect: "npm:3.1.13"
     ecpair: "npm:2.1.0"
   languageName: unknown
   linkType: soft
@@ -7581,10 +7581,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"coinselect@npm:3.1.12":
-  version: 3.1.12
-  resolution: "coinselect@npm:3.1.12"
-  checksum: 10c0/d68337aeb47cbf017df27a2ce73a0eca7d8300beee2f32578c039461d7a30d16141f4b229817512723ea55083ad049ac9b29c420d71dfdb5b73444885733864a
+"coinselect@npm:3.1.13":
+  version: 3.1.13
+  resolution: "coinselect@npm:3.1.13"
+  checksum: 10c0/bdab9186e2b735c82a835e7c8fb23f21b5d79538a270e82c079194e865d0bbd90a4cfcf189465cb971992657dfbe4eeb5397e44f42382876c476e6be8b6a3265
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Monorepo-wide `coinselect` bump **3.1.12 → 3.1.13**, replacing closed stale Dependabot [#1506](https://github.com/xchainjs/xchainjs-lib/pull/1506) (dash-only, no lockfile, failed CI).

### Packages

| Package | Why |
|---------|-----|
| `@xchainjs/xchain-bitcoincash` | **Uses** `coinselect/accumulative.js` in `buildTx` |
| `@xchainjs/xchain-dash` | **Uses** `accumulative` in `utils.ts` |
| `@xchainjs/xchain-doge` | **Uses** `accumulative` in `buildTx` |
| `@xchainjs/xchain-litecoin` | **Uses** `accumulative` in `buildTx` |
| `@xchainjs/xchain-bitcoin` | **Declares** dep only — selection moved to `@xchainjs/xchain-utxo` strategies; bump keeps pin aligned (optional follow-up: remove dead dep + `modules.d.ts`) |

Not touched: zcash, utxo base (own selectors), EVM/Cosmos.

### What 3.1.13 actually changes

Upstream [bitcoinjs/coinselect#71](https://github.com/bitcoinjs/coinselect/pull/71): **`split.js` only** — treat `value: 0` as a fixed output (e.g. OP_RETURN), not as a “split” target. `accumulative.js`, `utils.js`, and `index.js` are **byte-identical** to 3.1.12.

### Gotchas / behavior notes

1. **No intended selection behavior change** for current XChain call sites — we never import `coinselect/split` or the default entry.
2. **LTC/DOGE** still pass memo as `{ script, value: 0 }` *into* `accumulative` (fee sizing includes that output). That path is unchanged by this bump. BCH/DASH add memo **after** selection (safer pattern).
3. **Bitcoin** no longer imports coinselect; leaving the pin avoids version skew if something reintroduces it; dead-code removal is out of scope here.
4. Yarn Berry: bump includes **`yarn.lock`** (Dependabot #1506 did not).
5. Patch changesets on all five packages for version coordination.

## Test plan

- [ ] CI build/test green
- [ ] Optional: smoke transfer prep on LTC/DOGE with memo (accumulative path)
- [ ] Confirm `yarn why coinselect` → single 3.1.13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance**
  - Updated transaction selection support for Bitcoin, Bitcoin Cash, Dash, Dogecoin, and Litecoin.
  - Applied a patch-level dependency update with no expected changes to the current selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->