### PR TITLE
feat(monero): balance, history, and transfer via local wallet-rpc

### DIFF
--- a/packages/xchain-monero/README.md
+++ b/packages/xchain-monero/README.md
@@ -2,16 +2,20 @@
 
 Monero (XMR) client for XChainJS — a pure JavaScript implementation with no WASM dependencies.
 
+## Status
+
+Address derivation, **balance**, **history**, and **transfer** against a local `monerod` work via `monero-wallet-rpc`. Fee estimates still come from the daemon (per-byte; the suite Fees tab is not a full tx fee). The JS RingCT builder + LWS path remains as a fallback and is not what xchain-suite uses.
+
 ## Overview
 
-This package provides a Monero client that implements the standard XChainJS `XChainClient` interface. It supports address derivation, balance queries, transaction history, fee estimation, and transaction building/broadcasting.
+This package implements the standard XChainJS `XChainClient` interface.
 
 Key design decisions:
 
-- **Pure JS** — Uses `@noble/curves`, `@noble/hashes`, and `micro-key-producer` for all cryptographic operations. No native modules or WASM, so it works in both Node.js and browser environments.
-- **MyMonero LWS** — Balance and UTXO queries go through a Light Wallet Server (LWS) API, defaulting to `api.mymonero.com`.
-- **Monero Daemon RPC** — Fee estimation and transaction broadcasting use a standard Monero daemon node.
-- **SLIP-10 key derivation** — Derives Monero spend/view keys from a BIP-39 mnemonic via SLIP-10 (`m/44'/128'/account'`).
+- **Pure JS** — `@noble/curves`, `@noble/hashes`, and `micro-key-producer`. No native modules or WASM, so it runs in Node.js and the browser.
+- **SLIP-10 key derivation** — spend/view keys come from a BIP-39 mnemonic at `m/44'/128'/account'`. This is **not** a Monero 25-word seed. A `monero-wallet-cli` wallet created with the official seed will not share this address.
+- **`monerod` has no wallet state.** The daemon will not return a balance. You need wallet-rpc (preferred for a local node), LWS, or a short client-side scan.
+- **Balance lookup order** — `walletRpcUrls` → `lwsUrls` → JSON daemon scan (only if the range is ≤ 5,000 blocks).
 
 ## Installation
 
@@ -19,7 +23,7 @@ Key design decisions:
 yarn add @xchainjs/xchain-monero
 ```
 
-## Usage
+## Usage (local node)
 
 ```typescript
 import { Client, defaultXMRParams } from '@xchainjs/xchain-monero'
@@ -29,20 +33,79 @@ const client = new Client({
   ...defaultXMRParams,
   network: Network.Mainnet,
   phrase: 'your mnemonic phrase here',
+  restoreHeight: 3626700, // wallet creation height; do not start at 0
+  daemonUrls: {
+    ...defaultXMRParams.daemonUrls,
+    [Network.Mainnet]: ['http://127.0.0.1:18081'],
+  },
+  walletRpcUrls: {
+    [Network.Mainnet]: ['http://127.0.0.1:18088'],
+    [Network.Testnet]: [],
+    [Network.Stagenet]: [],
+  },
 })
 
-// Get address
 const address = await client.getAddressAsync()
-
-// Get balance
 const balances = await client.getBalance(address)
 
-// Transfer
 const txHash = await client.transfer({
-  recipient: '4...',
+  recipient: '8... or 4...',
   amount: baseAmount(1000000000000, 12), // 1 XMR
 })
 ```
+
+On first `getBalance`, the client calls wallet-rpc `generate_from_keys` (or `open_wallet` if that file already exists), waits until the wallet height catches `monerod`, then reads `get_balance`. The first sync from `restoreHeight` to tip can take several minutes; later calls are fast.
+
+## Running a local node
+
+You need **two** processes: `monerod` (chain) and `monero-wallet-rpc` (wallet). Official binaries: [getmonero.org/downloads](https://www.getmonero.org/downloads/).
+
+### 1. `monerod`
+
+A pruned node is enough. Bind RPC to localhost only.
+
+```bash
+monerod \
+  --prune-blockchain \
+  --rpc-bind-ip 127.0.0.1 \
+  --rpc-bind-port 18081 \
+  --restricted-rpc 0 \
+  --non-interactive
+```
+
+Wait until it is synced (`get_info.synchronized === true`). Unrestricted RPC is required for wallet restore.
+
+### 2. `monero-wallet-rpc`
+
+Leave this with `--wallet-dir` and no wallet preloaded. The client creates/opens a wallet from the BIP-39 keys over RPC.
+
+```bash
+mkdir -p /path/to/xchain-wallets
+
+monero-wallet-rpc \
+  --daemon-address 127.0.0.1:18081 \
+  --trusted-daemon \
+  --rpc-bind-ip 127.0.0.1 \
+  --rpc-bind-port 18088 \
+  --disable-rpc-login \
+  --rpc-ssl disabled \
+  --wallet-dir /path/to/xchain-wallets \
+  --disable-rpc-ban \
+  --no-initial-sync
+```
+
+Do not point this at an existing official-seed wallet if you are testing the XChainJS client. That wallet is a different key scheme.
+
+### Browser / xchain-suite
+
+Browsers cannot call `127.0.0.1:18081` / `18088` directly (CORS). xchain-suite proxies:
+
+| Browser path | Upstream |
+|---|---|
+| `/xmr-daemon` | `http://127.0.0.1:18081` |
+| `/xmr-wallet` | `http://127.0.0.1:18088` |
+
+See [tools/xchain-suite/README.md](../../tools/xchain-suite/README.md#monero-local-node).
 
 ## Architecture
 
@@ -52,8 +115,10 @@ src/
 ├── const.ts           # Chain constants, default params
 ├── types.ts           # Client parameter types
 ├── utils.ts           # Address derivation, key helpers
-├── lws.ts             # MyMonero Light Wallet Server API
+├── walletRpc.ts       # monero-wallet-rpc (balance against a local node)
+├── lws.ts             # MyMonero-compatible Light Wallet Server API
 ├── daemon.ts          # Monero daemon RPC client
+├── scanner.ts         # Bounded JSON daemon scan fallback
 └── tx/
     ├── builder.ts     # Transaction construction
     ├── serialize.ts   # Binary serialization

--- a/packages/xchain-monero/__tests__/client.test.ts
+++ b/packages/xchain-monero/__tests__/client.test.ts
@@ -235,6 +235,215 @@ describe('Monero client (pure JS)', () => {
       await expect(client.getBalance('someAddress')).rejects.toThrow('No daemon URLs configured')
     })
 
+    it('Should return balance from wallet RPC without falling back to daemon scan', async () => {
+      const client = new Client({
+        ...defaultXMRParams,
+        phrase: TEST_PHRASE,
+        walletRpcUrls: { [Network.Mainnet]: ['https://wallet.test'], [Network.Testnet]: [], [Network.Stagenet]: [] },
+        daemonUrls: { [Network.Mainnet]: ['https://daemon.test'], [Network.Testnet]: [], [Network.Stagenet]: [] },
+        lwsUrls: { [Network.Mainnet]: [], [Network.Testnet]: [], [Network.Stagenet]: [] },
+        restoreHeight: 3626700,
+      })
+
+      const address = await client.getAddressAsync()
+      let created = false
+
+      mockFetch.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+        const rawBody = typeof init?.body === 'string' ? init.body : '{}'
+        const body = JSON.parse(rawBody) as { method?: string }
+        if (url.includes('daemon.test')) {
+          return {
+            ok: true,
+            json: async () => ({ result: { count: 3626705, status: 'OK' } }),
+          }
+        }
+        switch (body.method) {
+          case 'get_version':
+            return { ok: true, json: async () => ({ result: { version: 65536 } }) }
+          case 'get_address':
+            if (!created) {
+              return {
+                ok: true,
+                json: async () => ({
+                  error: { code: -13, message: 'No wallet file' },
+                }),
+              }
+            }
+            return { ok: true, json: async () => ({ result: { address } }) }
+          case 'open_wallet':
+            return {
+              ok: true,
+              json: async () => ({
+                error: { code: -1, message: 'Failed to open wallet' },
+              }),
+            }
+          case 'generate_from_keys':
+            created = true
+            return {
+              ok: true,
+              json: async () => ({ result: { address, info: 'Wallet has been generated successfully.' } }),
+            }
+          case 'refresh':
+            return { ok: true, json: async () => ({ result: { blocks_fetched: 5, received_money: false } }) }
+          case 'get_height':
+            return { ok: true, json: async () => ({ result: { height: 3626705 } }) }
+          case 'get_balance':
+            return {
+              ok: true,
+              json: async () => ({ result: { balance: 1500000000000, unlocked_balance: 1500000000000 } }),
+            }
+          default:
+            return { ok: false, status: 500, statusText: `unexpected ${body.method}` }
+        }
+      })
+
+      const balances = await client.getBalance(address)
+
+      expect(balances).toHaveLength(1)
+      expect(balances[0].amount.amount().toString()).toBe('1500000000000')
+      const walletCalls = mockFetch.mock.calls.filter((call) => String(call[0]).includes('wallet.test'))
+      expect(walletCalls.length).toBeGreaterThan(0)
+    })
+
+    it('Should reject foreign addresses on the wallet RPC balance path', async () => {
+      const client = new Client({
+        ...defaultXMRParams,
+        phrase: TEST_PHRASE,
+        walletRpcUrls: { [Network.Mainnet]: ['https://wallet.test'], [Network.Testnet]: [], [Network.Stagenet]: [] },
+        daemonUrls: { [Network.Mainnet]: [], [Network.Testnet]: [], [Network.Stagenet]: [] },
+        lwsUrls: { [Network.Mainnet]: [], [Network.Testnet]: [], [Network.Stagenet]: [] },
+      })
+
+      await expect(client.getBalance('someAddress')).rejects.toThrow(
+        /can only return the balance for the unlocked wallet address/,
+      )
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('Should throw wallet RPC error without daemon fallback when wallet RPC is configured', async () => {
+      const client = new Client({
+        ...defaultXMRParams,
+        phrase: TEST_PHRASE,
+        walletRpcUrls: { [Network.Mainnet]: ['https://wallet.test'], [Network.Testnet]: [], [Network.Stagenet]: [] },
+        daemonUrls: { [Network.Mainnet]: [], [Network.Testnet]: [], [Network.Stagenet]: [] },
+        lwsUrls: { [Network.Mainnet]: [], [Network.Testnet]: [], [Network.Stagenet]: [] },
+      })
+
+      const address = await client.getAddressAsync()
+      mockFetch.mockResolvedValue({ ok: false, status: 502, statusText: 'Bad Gateway' })
+
+      await expect(client.getBalance(address)).rejects.toThrow(/Wallet RPC error: 502/)
+    })
+
+    it('Should reject foreign addresses on the wallet RPC history path', async () => {
+      const client = new Client({
+        ...defaultXMRParams,
+        phrase: TEST_PHRASE,
+        walletRpcUrls: { [Network.Mainnet]: ['https://wallet.test'], [Network.Testnet]: [], [Network.Stagenet]: [] },
+        daemonUrls: { [Network.Mainnet]: [], [Network.Testnet]: [], [Network.Stagenet]: [] },
+        lwsUrls: { [Network.Mainnet]: [], [Network.Testnet]: [], [Network.Stagenet]: [] },
+      })
+
+      await expect(client.getTransactions({ address: 'someAddress' })).rejects.toThrow(
+        /can only return history for the unlocked wallet address/,
+      )
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('Should return history from wallet RPC without falling back to daemon scan', async () => {
+      const client = new Client({
+        ...defaultXMRParams,
+        phrase: TEST_PHRASE,
+        walletRpcUrls: { [Network.Mainnet]: ['https://wallet.test'], [Network.Testnet]: [], [Network.Stagenet]: [] },
+        daemonUrls: { [Network.Mainnet]: ['https://daemon.test'], [Network.Testnet]: [], [Network.Stagenet]: [] },
+        lwsUrls: { [Network.Mainnet]: [], [Network.Testnet]: [], [Network.Stagenet]: [] },
+        restoreHeight: 3626700,
+      })
+
+      mockFetch.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+        const rawBody = typeof init?.body === 'string' ? init.body : '{}'
+        const body = JSON.parse(rawBody) as { method?: string }
+        if (url.includes('daemon.test')) {
+          return {
+            ok: true,
+            json: async () => ({ result: { count: 3626705, status: 'OK' } }),
+          }
+        }
+        switch (body.method) {
+          case 'get_version':
+            return { ok: true, json: async () => ({ result: { version: 65536 } }) }
+          case 'get_address':
+            return {
+              ok: true,
+              json: async () => ({
+                result: {
+                  address:
+                    '44jKQv6ZKMd5ecLLmkNJGi7azgSptEq8ki7TFiat1TfLfdDQ1tQ7ZYa3cRh7X2uRwvLDjddWh97ajeyhR2seKSECQeDx1WR',
+                },
+              }),
+            }
+          case 'refresh':
+            return { ok: true, json: async () => ({ result: { blocks_fetched: 0, received_money: false } }) }
+          case 'get_height':
+            return { ok: true, json: async () => ({ result: { height: 3626705 } }) }
+          case 'get_transfers':
+            return {
+              ok: true,
+              json: async () => ({
+                result: {
+                  in: [
+                    {
+                      txid: 'in_old',
+                      timestamp: 1700000000,
+                      height: 3626701,
+                      amount: 1000000000000,
+                      fee: 0,
+                      type: 'in',
+                      address: '4in',
+                    },
+                    {
+                      txid: 'in_new',
+                      timestamp: 1700001000,
+                      height: 3626704,
+                      amount: 2000000000000,
+                      fee: 0,
+                      type: 'in',
+                      address: '4in',
+                    },
+                  ],
+                  out: [
+                    {
+                      txid: 'out_mid',
+                      timestamp: 1700000500,
+                      height: 3626703,
+                      amount: 500000000000,
+                      fee: 20000,
+                      type: 'out',
+                      address: '4out',
+                      destinations: [{ address: '4dest', amount: 500000000000 }],
+                    },
+                  ],
+                },
+              }),
+            }
+          default:
+            return { ok: false, status: 500, statusText: `unexpected ${body.method}` }
+        }
+      })
+
+      const address = await client.getAddressAsync()
+      const result = await client.getTransactions({ address, limit: 10 })
+
+      expect(result.total).toBe(3)
+      expect(result.txs).toHaveLength(3)
+      expect(result.txs.map((tx) => tx.hash)).toEqual(['in_new', 'out_mid', 'in_old'])
+      expect(result.txs[0].to[0]?.amount.amount().toString()).toBe('2000000000000')
+      expect(result.txs[1].from[0]?.from).toBe(address)
+      expect(result.txs[1].to[0]?.to).toBe('4dest')
+    })
+
     it('Should try next LWS URL on failure', async () => {
       const client = new Client({
         ...defaultXMRParams,
@@ -485,6 +694,77 @@ describe('Monero client (pure JS)', () => {
       })
 
       await expect(client.getTransactions()).rejects.toThrow('No daemon URLs configured')
+    })
+  })
+
+  describe('Transfer (wallet RPC)', () => {
+    const dest = '888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H'
+
+    beforeEach(() => {
+      mockFetch.mockReset()
+    })
+
+    it('Should transfer via wallet RPC without LWS', async () => {
+      const client = new Client({
+        ...defaultXMRParams,
+        phrase: TEST_PHRASE,
+        walletRpcUrls: { [Network.Mainnet]: ['https://wallet.test'], [Network.Testnet]: [], [Network.Stagenet]: [] },
+        daemonUrls: { [Network.Mainnet]: ['https://daemon.test'], [Network.Testnet]: [], [Network.Stagenet]: [] },
+        lwsUrls: { [Network.Mainnet]: [], [Network.Testnet]: [], [Network.Stagenet]: [] },
+        restoreHeight: 3626700,
+      })
+
+      const ownAddress = await client.getAddressAsync()
+
+      mockFetch.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+        const rawBody = typeof init?.body === 'string' ? init.body : '{}'
+        const body = JSON.parse(rawBody) as { method?: string }
+        if (url.includes('daemon.test')) {
+          return { ok: true, json: async () => ({ result: { count: 3626705, status: 'OK' } }) }
+        }
+        switch (body.method) {
+          case 'get_version':
+            return { ok: true, json: async () => ({ result: { version: 65536 } }) }
+          case 'get_address':
+            return { ok: true, json: async () => ({ result: { address: ownAddress } }) }
+          case 'refresh':
+            return { ok: true, json: async () => ({ result: { blocks_fetched: 0, received_money: false } }) }
+          case 'get_height':
+            return { ok: true, json: async () => ({ result: { height: 3626705 } }) }
+          case 'transfer':
+            return { ok: true, json: async () => ({ result: { tx_hash: 'ef12'.repeat(16) } }) }
+          default:
+            return { ok: false, status: 500, statusText: `unexpected ${body.method}` }
+        }
+      })
+
+      const txHash = await client.transfer({ recipient: dest, amount: baseAmount(1000000000000, 12) })
+      expect(txHash).toBe('ef12'.repeat(16))
+
+      const transferCall = mockFetch.mock.calls.find((call) => {
+        const raw = call[1]?.body
+        return typeof raw === 'string' && raw.includes('"transfer"')
+      })
+      expect(transferCall).toBeDefined()
+      const payload = JSON.parse(String(transferCall?.[1]?.body)) as {
+        params: { destinations: { amount: number; address: string }[] }
+      }
+      expect(payload.params.destinations[0]).toEqual({ amount: 1000000000000, address: dest })
+    })
+
+    it('Should reject an invalid recipient before calling wallet RPC', async () => {
+      const client = new Client({
+        ...defaultXMRParams,
+        phrase: TEST_PHRASE,
+        walletRpcUrls: { [Network.Mainnet]: ['https://wallet.test'], [Network.Testnet]: [], [Network.Stagenet]: [] },
+        lwsUrls: { [Network.Mainnet]: [], [Network.Testnet]: [], [Network.Stagenet]: [] },
+      })
+
+      await expect(client.transfer({ recipient: 'not-an-address', amount: baseAmount(1, 12) })).rejects.toThrow(
+        'Invalid Monero recipient address',
+      )
+      expect(mockFetch).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/xchain-monero/__tests__/walletRpc.test.ts
+++ b/packages/xchain-monero/__tests__/walletRpc.test.ts
@@ -23,16 +23,32 @@ describe('wallet RPC client', () => {
     )
   })
 
-  it('Should surface AbortError as a wallet RPC timeout', async () => {
-    mockFetch.mockImplementationOnce(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      const err = new Error('aborted')
-      err.name = 'AbortError'
-      // Mimic fetch rejecting when the AbortSignal fires.
-      if (init?.signal?.aborted) throw err
-      throw err
-    })
+  it('Should time out when the AbortSignal fires', async () => {
+    jest.useFakeTimers()
+    try {
+      mockFetch.mockImplementationOnce((_input: RequestInfo | URL, init?: RequestInit) => {
+        return new Promise((_, reject) => {
+          init?.signal?.addEventListener(
+            'abort',
+            () => {
+              const err = new Error('aborted')
+              err.name = 'AbortError'
+              reject(err)
+            },
+            { once: true },
+          )
+        })
+      })
 
-    await expect(walletRpc.getVersion(url)).rejects.toThrow(/Wallet RPC timeout/)
+      // Attach the rejection matcher before the timer fires so the abort is not unhandled.
+      const assertion = expect(walletRpc.getVersion(url)).rejects.toThrow(
+        /Wallet RPC timeout after 30000ms calling get_version/,
+      )
+      await jest.advanceTimersByTimeAsync(30_000)
+      await assertion
+    } finally {
+      jest.useRealTimers()
+    }
   })
 
   it('Should parse get_balance integers as strings', async () => {
@@ -94,22 +110,30 @@ describe('wallet RPC client', () => {
     expect(methods).toContain('generate_from_keys')
   })
 
-  it('Should flatten in/out/block transfers and drop unconfirmed', async () => {
+  it('Should flatten in/out transfers and drop height-0 entries', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
         result: {
-          in: [{ txid: 'aaa', timestamp: 1, height: 10, amount: 1, type: 'in' }],
+          in: [
+            { txid: 'aaa', timestamp: 1, height: 10, amount: 1, type: 'in' },
+            { txid: 'unconfirmed', timestamp: 4, height: 0, amount: 4, type: 'in' },
+          ],
           out: [{ txid: 'bbb', timestamp: 2, height: 11, amount: 2, type: 'out' }],
-          block: [{ txid: 'ccc', timestamp: 3, height: 12, amount: 3, type: 'block' }],
-          pool: [{ txid: 'ddd', timestamp: 4, height: 0, amount: 4, type: 'pool' }],
         },
       }),
     })
 
     const transfers = await walletRpc.getTransfers(url)
-    expect(transfers.map((tx) => tx.txid)).toEqual(['aaa', 'bbb', 'ccc'])
+    expect(transfers.map((tx) => tx.txid)).toEqual(['aaa', 'bbb'])
     expect(transfers[1].amount).toBe('2')
+
+    const body = JSON.parse(String(mockFetch.mock.calls[0][1]?.body)) as {
+      params: { in?: boolean; out?: boolean; block?: boolean }
+    }
+    expect(body.params.block).toBeUndefined()
+    expect(body.params.in).toBe(true)
+    expect(body.params.out).toBe(true)
   })
 
   it('Should send transfer destinations in piconero', async () => {

--- a/packages/xchain-monero/__tests__/walletRpc.test.ts
+++ b/packages/xchain-monero/__tests__/walletRpc.test.ts
@@ -1,0 +1,133 @@
+import * as walletRpc from '../src/walletRpc'
+
+const mockFetch = jest.fn()
+global.fetch = mockFetch
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+describe('wallet RPC client', () => {
+  const url = 'http://127.0.0.1:18088'
+
+  it('Should ping get_version', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: { version: 65536 } }),
+    })
+
+    await expect(walletRpc.getVersion(url)).resolves.toBe(65536)
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${url}/json_rpc`,
+      expect.objectContaining({ method: 'POST', signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it('Should surface AbortError as a wallet RPC timeout', async () => {
+    mockFetch.mockImplementationOnce(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const err = new Error('aborted')
+      err.name = 'AbortError'
+      // Mimic fetch rejecting when the AbortSignal fires.
+      if (init?.signal?.aborted) throw err
+      throw err
+    })
+
+    await expect(walletRpc.getVersion(url)).rejects.toThrow(/Wallet RPC timeout/)
+  })
+
+  it('Should parse get_balance integers as strings', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: { balance: 1000000000000, unlocked_balance: 500000000000 } }),
+    })
+
+    const result = await walletRpc.getBalance(url)
+    expect(result.balance).toBe('1000000000000')
+    expect(result.unlockedBalance).toBe('500000000000')
+  })
+
+  it('Should throw WalletRpcError on RPC error payload', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ error: { code: -13, message: 'No wallet file' } }),
+    })
+
+    await expect(walletRpc.getAddress(url)).rejects.toThrow('No wallet file')
+  })
+
+  it('Should create a wallet when none is open', async () => {
+    let created = false
+    mockFetch.mockImplementation(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const rawBody = typeof init?.body === 'string' ? init.body : '{}'
+      const body = JSON.parse(rawBody) as { method?: string }
+      switch (body.method) {
+        case 'get_version':
+          return { ok: true, json: async () => ({ result: { version: 1 } }) }
+        case 'get_address':
+          if (!created) {
+            return { ok: true, json: async () => ({ error: { code: -13, message: 'No wallet file' } }) }
+          }
+          return { ok: true, json: async () => ({ result: { address: '4abc' } }) }
+        case 'open_wallet':
+          return { ok: true, json: async () => ({ error: { code: -1, message: 'Failed to open wallet' } }) }
+        case 'generate_from_keys':
+          created = true
+          return { ok: true, json: async () => ({ result: { address: '4abc', info: 'ok' } }) }
+        default:
+          return { ok: false, status: 500, statusText: body.method }
+      }
+    })
+
+    await walletRpc.ensureWallet(url, {
+      filename: 'xchain-test',
+      address: '4abc',
+      spendKey: 'aa'.repeat(32),
+      viewKey: 'bb'.repeat(32),
+      password: 'secret',
+      restoreHeight: 3626700,
+    })
+
+    const methods = mockFetch.mock.calls.map((call) => {
+      const raw = call[1]?.body
+      return JSON.parse(typeof raw === 'string' ? raw : '{}').method
+    })
+    expect(methods).toContain('generate_from_keys')
+  })
+
+  it('Should flatten in/out/block transfers and drop unconfirmed', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        result: {
+          in: [{ txid: 'aaa', timestamp: 1, height: 10, amount: 1, type: 'in' }],
+          out: [{ txid: 'bbb', timestamp: 2, height: 11, amount: 2, type: 'out' }],
+          block: [{ txid: 'ccc', timestamp: 3, height: 12, amount: 3, type: 'block' }],
+          pool: [{ txid: 'ddd', timestamp: 4, height: 0, amount: 4, type: 'pool' }],
+        },
+      }),
+    })
+
+    const transfers = await walletRpc.getTransfers(url)
+    expect(transfers.map((tx) => tx.txid)).toEqual(['aaa', 'bbb', 'ccc'])
+    expect(transfers[1].amount).toBe('2')
+  })
+
+  it('Should send transfer destinations in piconero', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: { tx_hash: 'abcd'.repeat(16) } }),
+    })
+
+    const dest = '44jKQv6ZKMd5ecLLmkNJGi7azgSptEq8ki7TFiat1TfLfdDQ1tQ7ZYa3cRh7X2uRwvLDjddWh97ajeyhR2seKSECQeDx1WR'
+    const hash = await walletRpc.transfer(url, { address: dest, amountPiconero: '1000000000000' })
+    expect(hash).toBe('abcd'.repeat(16))
+
+    const body = JSON.parse(String(mockFetch.mock.calls[0][1]?.body)) as {
+      method: string
+      params: { destinations: { amount: number; address: string }[]; priority: number }
+    }
+    expect(body.method).toBe('transfer')
+    expect(body.params.destinations).toEqual([{ amount: 1000000000000, address: dest }])
+    expect(body.params.priority).toBe(2)
+  })
+})

--- a/packages/xchain-monero/src/client.ts
+++ b/packages/xchain-monero/src/client.ts
@@ -21,6 +21,7 @@ import { encodeAddress, decodeAddress } from './crypto/address'
 import { deriveKeyPairs } from './crypto/keys'
 import * as daemon from './daemon'
 import * as lws from './lws'
+import * as walletRpc from './walletRpc'
 import { buildTransaction } from './tx/builder'
 import type { SpendableOutput, Destination } from './tx/builder'
 import { scanBlocks, computeBalance, OwnedOutput } from './scanner'
@@ -31,8 +32,10 @@ export class Client extends BaseXChainClient {
   private explorerProviders: ExplorerProviders
   private daemonUrls: Record<Network, string[]>
   private lwsUrls: Record<Network, string[]>
+  private walletRpcUrls: Record<Network, string[]>
   private lwsLoggedIn = false
   private restoreHeight: number
+  private walletRpcLock: Promise<unknown> = Promise.resolve()
 
   /** Cached scan state for daemon fallback */
   private scanCache: {
@@ -49,6 +52,7 @@ export class Client extends BaseXChainClient {
     this.explorerProviders = params.explorerProviders ?? defaultXMRParams.explorerProviders
     this.daemonUrls = params.daemonUrls ?? defaultXMRParams.daemonUrls!
     this.lwsUrls = params.lwsUrls ?? defaultXMRParams.lwsUrls!
+    this.walletRpcUrls = params.walletRpcUrls ?? defaultXMRParams.walletRpcUrls!
     this.restoreHeight = params.restoreHeight ?? 0
   }
 
@@ -101,10 +105,29 @@ export class Client extends BaseXChainClient {
   }
 
   /**
-   * Get balance via LWS, falling back to daemon scanning if LWS is unavailable.
+   * Get balance via wallet-rpc (local monerod), then LWS, then a bounded daemon scan.
    */
   public async getBalance(address: Address): Promise<Balance[]> {
-    // Try LWS first
+    const walletRpcUrls = this.walletRpcUrls[this.getNetwork()]
+    if (walletRpcUrls && walletRpcUrls.length > 0) {
+      const ownAddress = await this.getAddressAsync(0)
+      if (address !== ownAddress) {
+        throw new Error('Monero wallet RPC can only return the balance for the unlocked wallet address')
+      }
+      let lastError: unknown
+      for (const url of walletRpcUrls) {
+        try {
+          const amount = await this.getBalanceFromWalletRpc(url)
+          return [{ asset: AssetXMR, amount: baseAmount(amount.toString(), XMR_DECIMALS) }]
+        } catch (error) {
+          lastError = error
+          console.warn(`Wallet RPC ${url} failed for getBalance:`, (error as Error).message)
+        }
+      }
+      throw lastError instanceof Error ? lastError : new Error('All Monero wallet RPC endpoints failed for getBalance')
+    }
+
+    // Try LWS next
     const urls = this.lwsUrls[this.getNetwork()]
     if (urls && urls.length > 0) {
       const viewKeyHex = this.getViewKeyHex(0)
@@ -190,16 +213,36 @@ export class Client extends BaseXChainClient {
   }
 
   /**
-   * Get transaction history via LWS, falling back to daemon scanning.
-   * Due to Monero privacy, counterparty addresses are unavailable;
-   * the own address is used with net amount for from/to.
+   * Get transaction history via wallet-rpc, then LWS, then a bounded daemon scan.
+   * Incoming counterparties are unknown (Monero privacy). Outgoing destinations
+   * are available when the tx was created by this wallet.
    */
   public async getTransactions(params?: TxHistoryParams): Promise<TxsPage> {
     const address = params?.address || (await this.getAddressAsync(0))
     const offset = params?.offset ?? 0
     const limit = params?.limit ?? 10
 
-    // Try LWS first
+    const walletRpcUrls = this.walletRpcUrls[this.getNetwork()]
+    if (walletRpcUrls && walletRpcUrls.length > 0) {
+      const ownAddress = await this.getAddressAsync(0)
+      if (address !== ownAddress) {
+        throw new Error('Monero wallet RPC can only return history for the unlocked wallet address')
+      }
+      let lastError: unknown
+      for (const url of walletRpcUrls) {
+        try {
+          return await this.getTransactionsFromWalletRpc(url, address, offset, limit)
+        } catch (error) {
+          lastError = error
+          console.warn(`Wallet RPC ${url} failed for getTransactions:`, (error as Error).message)
+        }
+      }
+      throw lastError instanceof Error
+        ? lastError
+        : new Error('All Monero wallet RPC endpoints failed for getTransactions')
+    }
+
+    // Try LWS next
     const urls = this.lwsUrls[this.getNetwork()]
     if (urls && urls.length > 0) {
       const viewKeyHex = this.getViewKeyHex(0)
@@ -265,12 +308,29 @@ export class Client extends BaseXChainClient {
 
   /**
    * Transfer XMR to a recipient address.
-   * Builds a complete RingCT transaction with CLSAG signatures and Bulletproofs+ range proof.
+   * Prefers monero-wallet-rpc (local monerod). Falls back to LWS + local RingCT builder.
    */
   public async transfer(params: TxParams): Promise<string> {
     const { recipient, amount } = params
     if (!recipient) throw new Error('Recipient address is required')
     if (!amount) throw new Error('Amount is required')
+
+    const walletRpcUrls = this.walletRpcUrls[this.getNetwork()]
+    if (walletRpcUrls && walletRpcUrls.length > 0) {
+      if (!this.validateAddress(recipient)) {
+        throw new Error('Invalid Monero recipient address')
+      }
+      let lastError: unknown
+      for (const url of walletRpcUrls) {
+        try {
+          return await this.transferViaWalletRpc(url, params)
+        } catch (error) {
+          lastError = error
+          console.warn(`Wallet RPC ${url} failed for transfer:`, (error as Error).message)
+        }
+      }
+      throw lastError instanceof Error ? lastError : new Error('All Monero wallet RPC endpoints failed for transfer')
+    }
 
     const recipientKeys = decodeAddress(recipient)
     const spendKey = this.getPrivateSpendKey(params.walletIndex ?? 0)
@@ -434,6 +494,16 @@ export class Client extends BaseXChainClient {
       return this.scanCache
     }
 
+    // JSON daemon scanning is only viable for a short range. A local node still
+    // cannot answer "what is my balance?" without wallet-rpc or LWS.
+    const MAX_DAEMON_SCAN_BLOCKS = 5_000
+    if (currentHeight - fromHeight > MAX_DAEMON_SCAN_BLOCKS) {
+      throw new Error(
+        `Daemon scan range too large (${currentHeight - fromHeight} blocks from height ${fromHeight}). ` +
+          'Configure walletRpcUrls or lwsUrls, or set a more recent restoreHeight.',
+      )
+    }
+
     const spendKey = this.getPrivateSpendKey(walletIndex)
     const keys = deriveKeyPairs(spendKey)
 
@@ -460,5 +530,138 @@ export class Client extends BaseXChainClient {
     }
 
     return this.scanCache
+  }
+
+  private async withWalletRpcLock<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.walletRpcLock.then(fn, fn)
+    this.walletRpcLock = run.then(
+      () => undefined,
+      () => undefined,
+    )
+    return run
+  }
+
+  /**
+   * Restore or open a wallet-rpc wallet from the BIP-39 derived keys and wait
+   * until it has caught the local daemon. Returns the derived primary address.
+   */
+  private async prepareWalletRpc(url: string, walletIndex = 0): Promise<string> {
+    const spendKey = this.getPrivateSpendKey(walletIndex)
+    const keys = deriveKeyPairs(spendKey)
+    const address = encodeAddress(keys.publicSpendKey, keys.publicViewKey, getMoneroNetworkType(this.getNetwork()))
+    const filename = `xchain-${address.slice(0, 16)}`
+    const password = bytesToHex(keccak_256(spendKey))
+
+    await walletRpc.ensureWallet(url, {
+      filename,
+      address,
+      spendKey: bytesToHex(spendKey),
+      viewKey: bytesToHex(keys.privateViewKey),
+      password,
+      restoreHeight: this.restoreHeight,
+    })
+
+    await this.waitForWalletSync(url)
+    return address
+  }
+
+  private async getBalanceFromWalletRpc(url: string): Promise<bigint> {
+    return this.withWalletRpcLock(async () => {
+      await this.prepareWalletRpc(url)
+      const result = await walletRpc.callWithBusyRetry(() => walletRpc.getBalance(url))
+      return BigInt(result.balance)
+    })
+  }
+
+  private async transferViaWalletRpc(url: string, params: TxParams): Promise<string> {
+    return this.withWalletRpcLock(async () => {
+      await this.prepareWalletRpc(url, params.walletIndex ?? 0)
+      return walletRpc.callWithBusyRetry(() =>
+        walletRpc.transfer(url, {
+          address: params.recipient,
+          amountPiconero: params.amount.amount().toFixed(0).toString(),
+        }),
+      )
+    })
+  }
+
+  private async getTransactionsFromWalletRpc(
+    url: string,
+    address: string,
+    offset: number,
+    limit: number,
+  ): Promise<TxsPage> {
+    const { ownAddress, transfers } = await this.withWalletRpcLock(async () => {
+      const prepared = await this.prepareWalletRpc(url)
+      const txs = await walletRpc.callWithBusyRetry(() => walletRpc.getTransfers(url))
+      return { ownAddress: prepared, transfers: txs }
+    })
+
+    const confirmed = transfers.sort((a, b) => b.height - a.height || b.timestamp - a.timestamp)
+    const paginated = confirmed.slice(offset, offset + limit)
+
+    const txs: Tx[] = paginated.map((tx) => {
+      const amount = baseAmount(tx.amount, XMR_DECIMALS)
+      const isIncoming = tx.type !== 'out'
+
+      return {
+        asset: AssetXMR,
+        date: new Date(tx.timestamp * 1000),
+        type: TxType.Transfer,
+        hash: tx.txid,
+        from: isIncoming ? [] : [{ from: address || ownAddress, amount }],
+        to: isIncoming
+          ? [{ to: address || ownAddress, amount }]
+          : tx.destinations.map((dest) => ({
+              to: dest.address,
+              amount: baseAmount(dest.amount, XMR_DECIMALS),
+            })),
+      }
+    })
+
+    return { total: confirmed.length, txs }
+  }
+
+  private async waitForWalletSync(walletUrl: string): Promise<void> {
+    const daemonUrl = this.daemonUrls[this.getNetwork()]?.[0]
+    let target: number | null = null
+    if (daemonUrl) {
+      try {
+        target = await daemon.getHeight(daemonUrl)
+      } catch (error) {
+        console.warn('Could not read daemon height while waiting for wallet sync:', (error as Error).message)
+      }
+    }
+
+    // Without a daemon tip there is nothing to wait for — refresh once and continue.
+    if (target == null) {
+      try {
+        await walletRpc.refresh(walletUrl)
+      } catch (error) {
+        if (!walletRpc.isBusyError(error)) throw error
+      }
+      return
+    }
+
+    const started = Date.now()
+    const timeoutMs = 15 * 60 * 1000
+    let lastLogged = 0
+
+    while (Date.now() - started < timeoutMs) {
+      try {
+        await walletRpc.refresh(walletUrl)
+        const { height } = await walletRpc.getHeight(walletUrl)
+        if (height !== lastLogged) {
+          console.log(`[XMR] wallet sync ${height} / ${target}`)
+          lastLogged = height
+        }
+        if (height + 2 >= target) return
+      } catch (error) {
+        if (!walletRpc.isBusyError(error)) throw error
+      }
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+    }
+
+    throw new Error('Timed out waiting for Monero wallet RPC to sync with the local node')
   }
 }

--- a/packages/xchain-monero/src/const.ts
+++ b/packages/xchain-monero/src/const.ts
@@ -55,4 +55,9 @@ export const defaultXMRParams: XMRClientParams = {
     [Network.Testnet]: [],
     [Network.Stagenet]: [],
   },
+  walletRpcUrls: {
+    [Network.Mainnet]: [],
+    [Network.Testnet]: [],
+    [Network.Stagenet]: [],
+  },
 }

--- a/packages/xchain-monero/src/index.ts
+++ b/packages/xchain-monero/src/index.ts
@@ -14,3 +14,4 @@ export type { MoneroTransaction, TxInput, TxOutput, ClsagSig, BPPlusProof, RctSi
 export type { SpendableOutput, Destination, BuiltTransaction } from './tx/builder'
 export type { OwnedOutput } from './scanner'
 export { scanBlocks, computeBalance, getUnspentOutputs } from './scanner'
+export type { WalletBalance, WalletTransfer, EnsureWalletOptions } from './walletRpc'

--- a/packages/xchain-monero/src/types.ts
+++ b/packages/xchain-monero/src/types.ts
@@ -16,6 +16,8 @@ export type XMRClientParams = XChainClientParams & {
   explorerProviders: ExplorerProviders
   daemonUrls?: Record<Network, string[]>
   lwsUrls?: Record<Network, string[]>
+  /** monero-wallet-rpc endpoints. Preferred for getBalance against a local monerod. */
+  walletRpcUrls?: Record<Network, string[]>
   /** Block height to start scanning from when using daemon fallback (no LWS). Set to wallet creation height to avoid full chain scan. */
   restoreHeight?: number
 }

--- a/packages/xchain-monero/src/walletRpc.ts
+++ b/packages/xchain-monero/src/walletRpc.ts
@@ -1,0 +1,336 @@
+/**
+ * monero-wallet-rpc JSON-RPC client.
+ *
+ * monerod has no wallet state. Balance queries against a local node go through
+ * wallet-rpc, which scans with the view key and keeps the result on disk.
+ */
+
+interface JsonRpcResponse<T> {
+  id: string
+  jsonrpc: string
+  result: T
+}
+
+export class WalletRpcError extends Error {
+  constructor(message: string, readonly code: number) {
+    super(message)
+    this.name = 'WalletRpcError'
+  }
+}
+
+export interface EnsureWalletOptions {
+  filename: string
+  address: string
+  spendKey: string
+  viewKey: string
+  password: string
+  restoreHeight: number
+}
+
+export interface WalletBalance {
+  balance: string
+  unlockedBalance: string
+}
+
+export interface WalletHeight {
+  height: number
+}
+
+export interface WalletTransferDestination {
+  address: string
+  amount: string
+}
+
+export interface WalletTransfer {
+  txid: string
+  timestamp: number
+  height: number
+  amount: string
+  fee: string
+  type: string
+  address: string
+  destinations: WalletTransferDestination[]
+}
+
+interface RawTransfer {
+  txid?: string
+  timestamp?: number
+  height?: number
+  amount?: number | string
+  fee?: number | string
+  type?: string
+  address?: string
+  destinations?: { address?: string; amount?: number | string }[]
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+export const isBusyError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message.toLowerCase() : ''
+  return message.includes('busy') || message.includes('refreshing')
+}
+
+const isAlreadyOpenError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message.toLowerCase() : ''
+  return message.includes('already open') || message.includes('already opened')
+}
+
+const isNoWalletError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message.toLowerCase() : ''
+  return (
+    message.includes('no wallet file') ||
+    message.includes('no wallet') ||
+    message.includes('wallet does not exist') ||
+    message.includes('failed to open') ||
+    message.includes('file not found') ||
+    message.includes("doesn't exist") ||
+    message.includes('does not exist')
+  )
+}
+
+const isConnectionError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message.toLowerCase() : ''
+  return (
+    message.includes('failed to fetch') ||
+    message.includes('fetch failed') ||
+    message.includes('econnrefused') ||
+    message.includes('networkerror') ||
+    message.includes('network request failed')
+  )
+}
+
+const DEFAULT_RPC_TIMEOUT_MS = 30_000
+/** Cold wallet refresh against a local node can take several minutes. */
+const REFRESH_RPC_TIMEOUT_MS = 10 * 60 * 1000
+
+async function jsonRpc<T>(url: string, method: string, params?: Record<string, unknown>): Promise<T> {
+  const timeoutMs = method === 'refresh' ? REFRESH_RPC_TIMEOUT_MS : DEFAULT_RPC_TIMEOUT_MS
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+  let response: Response
+  try {
+    response = await fetch(`${url}/json_rpc`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: '0',
+        method,
+        params: params ?? {},
+      }),
+      signal: controller.signal,
+    })
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Wallet RPC timeout after ${timeoutMs}ms calling ${method}`)
+    }
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Wallet RPC unreachable: ${message}`)
+  } finally {
+    clearTimeout(timer)
+  }
+
+  if (!response.ok) {
+    throw new Error(`Wallet RPC error: ${response.status} ${response.statusText}`)
+  }
+
+  const data = (await response.json()) as JsonRpcResponse<T> & { error?: { code: number; message: string } }
+  if (data.error) {
+    throw new WalletRpcError(data.error.message, data.error.code)
+  }
+  return data.result
+}
+
+export async function getVersion(url: string): Promise<number> {
+  const result = await jsonRpc<{ version: number }>(url, 'get_version')
+  return result.version
+}
+
+export async function getAddress(url: string, accountIndex = 0): Promise<string> {
+  const result = await jsonRpc<{ address: string }>(url, 'get_address', { account_index: accountIndex })
+  return result.address
+}
+
+export async function openWallet(url: string, filename: string, password: string): Promise<void> {
+  await jsonRpc(url, 'open_wallet', { filename, password })
+}
+
+export async function closeWallet(url: string): Promise<void> {
+  await jsonRpc(url, 'close_wallet')
+}
+
+export async function transfer(
+  url: string,
+  params: { address: string; amountPiconero: string; priority?: number },
+): Promise<string> {
+  const amount = BigInt(params.amountPiconero)
+  if (amount <= BigInt(0)) throw new Error('Transfer amount must be positive')
+  if (amount > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error('Transfer amount exceeds wallet-rpc JSON integer precision')
+  }
+
+  const result = await jsonRpc<{ tx_hash?: string }>(url, 'transfer', {
+    destinations: [{ amount: Number(amount), address: params.address }],
+    account_index: 0,
+    priority: params.priority ?? 2,
+    get_tx_key: true,
+  })
+
+  if (!result.tx_hash) throw new Error('Wallet RPC transfer returned no tx_hash')
+  return result.tx_hash
+}
+
+export async function generateFromKeys(url: string, options: EnsureWalletOptions): Promise<void> {
+  await jsonRpc(url, 'generate_from_keys', {
+    filename: options.filename,
+    address: options.address,
+    spendkey: options.spendKey,
+    viewkey: options.viewKey,
+    password: options.password,
+    restore_height: options.restoreHeight,
+    autosave_current: true,
+  })
+}
+
+export async function refresh(url: string, startHeight?: number): Promise<void> {
+  await jsonRpc(url, 'refresh', startHeight !== undefined ? { start_height: startHeight } : {})
+}
+
+export async function getHeight(url: string): Promise<WalletHeight> {
+  return jsonRpc<WalletHeight>(url, 'get_height')
+}
+
+function normalizeTransfer(raw: RawTransfer): WalletTransfer {
+  return {
+    txid: raw.txid ?? '',
+    timestamp: raw.timestamp ?? 0,
+    height: raw.height ?? 0,
+    amount: String(raw.amount ?? 0),
+    fee: String(raw.fee ?? 0),
+    type: raw.type ?? '',
+    address: raw.address ?? '',
+    destinations: (raw.destinations ?? [])
+      .filter((dest): dest is { address: string; amount: number | string } => Boolean(dest.address))
+      .map((dest) => ({ address: dest.address, amount: String(dest.amount ?? 0) })),
+  }
+}
+
+export async function getTransfers(url: string, accountIndex = 0): Promise<WalletTransfer[]> {
+  const result = await jsonRpc<{
+    in?: RawTransfer[]
+    out?: RawTransfer[]
+    block?: RawTransfer[]
+  }>(url, 'get_transfers', {
+    in: true,
+    out: true,
+    pending: false,
+    failed: false,
+    pool: false,
+    block: true,
+    account_index: accountIndex,
+  })
+
+  return [...(result.in ?? []), ...(result.out ?? []), ...(result.block ?? [])]
+    .map(normalizeTransfer)
+    .filter((tx) => tx.txid && tx.height > 0)
+}
+
+export async function getBalance(url: string, accountIndex = 0): Promise<WalletBalance> {
+  const result = await jsonRpc<{ balance: number | string; unlocked_balance: number | string }>(url, 'get_balance', {
+    account_index: accountIndex,
+  })
+  return {
+    balance: String(result.balance),
+    unlockedBalance: String(result.unlocked_balance),
+  }
+}
+
+export async function waitUntilReachable(url: string, timeoutMs = 30_000): Promise<void> {
+  const started = Date.now()
+  let lastError: unknown
+  while (Date.now() - started < timeoutMs) {
+    try {
+      await getVersion(url)
+      return
+    } catch (error) {
+      lastError = error
+      if (isConnectionError(error) || isBusyError(error)) {
+        await sleep(500)
+        continue
+      }
+      // HTTP/RPC answered. get_version is available, or the process rejected
+      // the call for a non-transport reason — either way we can proceed.
+      if (error instanceof WalletRpcError) return
+      throw error
+    }
+  }
+  const message = lastError instanceof Error ? lastError.message : String(lastError)
+  throw new Error(`Monero wallet RPC is not reachable at ${url}: ${message}`)
+}
+
+async function assertOpenAddress(url: string, expected: string): Promise<void> {
+  const current = await getAddress(url)
+  if (current !== expected) {
+    throw new Error('Wallet RPC has a different wallet open than the derived suite address')
+  }
+}
+
+export async function ensureWallet(url: string, options: EnsureWalletOptions): Promise<void> {
+  await waitUntilReachable(url)
+
+  try {
+    const current = await getAddress(url)
+    if (current === options.address) return
+  } catch {
+    // No wallet open yet.
+  }
+
+  try {
+    await openWallet(url, options.filename, options.password)
+    await assertOpenAddress(url, options.address)
+    return
+  } catch (error) {
+    if (isAlreadyOpenError(error)) {
+      try {
+        await assertOpenAddress(url, options.address)
+        return
+      } catch {
+        await closeWallet(url)
+      }
+    } else if (!isNoWalletError(error) && !(error instanceof WalletRpcError)) {
+      throw error
+    }
+  }
+
+  try {
+    await generateFromKeys(url, options)
+    await assertOpenAddress(url, options.address)
+  } catch (error) {
+    if (isAlreadyOpenError(error)) {
+      await assertOpenAddress(url, options.address)
+      return
+    }
+    const message = error instanceof Error ? error.message.toLowerCase() : ''
+    if (message.includes('already exists') || message.includes('exists')) {
+      await openWallet(url, options.filename, options.password)
+      await assertOpenAddress(url, options.address)
+      return
+    }
+    throw error
+  }
+}
+
+export async function callWithBusyRetry<T>(fn: () => Promise<T>, attempts = 40, delayMs = 1500): Promise<T> {
+  let lastError: unknown
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn()
+    } catch (error) {
+      lastError = error
+      if (!isBusyError(error) || i === attempts - 1) throw error
+      await sleep(delayMs)
+    }
+  }
+  throw lastError
+}

--- a/packages/xchain-monero/src/walletRpc.ts
+++ b/packages/xchain-monero/src/walletRpc.ts
@@ -220,18 +220,16 @@ export async function getTransfers(url: string, accountIndex = 0): Promise<Walle
   const result = await jsonRpc<{
     in?: RawTransfer[]
     out?: RawTransfer[]
-    block?: RawTransfer[]
   }>(url, 'get_transfers', {
     in: true,
     out: true,
     pending: false,
     failed: false,
     pool: false,
-    block: true,
     account_index: accountIndex,
   })
 
-  return [...(result.in ?? []), ...(result.out ?? []), ...(result.block ?? [])]
+  return [...(result.in ?? []), ...(result.out ?? [])]
     .map(normalizeTransfer)
     .filter((tx) => tx.txid && tx.height > 0)
 }
@@ -312,7 +310,7 @@ export async function ensureWallet(url: string, options: EnsureWalletOptions): P
       return
     }
     const message = error instanceof Error ? error.message.toLowerCase() : ''
-    if (message.includes('already exists') || message.includes('exists')) {
+    if (message.includes('already exists')) {
       await openWallet(url, options.filename, options.password)
       await assertOpenAddress(url, options.address)
       return

--- a/tools/xchain-suite/.env.example
+++ b/tools/xchain-suite/.env.example
@@ -28,3 +28,12 @@ VITE_COVALENT_API_KEY=
 
 #ADA
 VITE_ADA_API_KEY=
+
+# Monero — local monerod + monero-wallet-rpc (see vite.config.ts proxies)
+# Scan from this height when creating the wallet-rpc wallet. Use wallet creation height.
+VITE_XMR_RESTORE_HEIGHT=3626700
+# Optional: absolute path to monero-wallet-rpc (defaults to `monero-wallet-rpc` on PATH)
+# MONERO_WALLET_RPC=/path/to/monero-wallet-rpc
+# Optional: wallet + log directory (defaults to ~/.cache/xchain-suite/monero-wallets)
+# MONERO_WALLET_DIR=/path/to/xchain-wallets
+# MONERO_WALLET_RPC_LOG=/path/to/xchain-wallet-rpc.log

--- a/tools/xchain-suite/.env.example
+++ b/tools/xchain-suite/.env.example
@@ -34,6 +34,7 @@ VITE_ADA_API_KEY=
 VITE_XMR_RESTORE_HEIGHT=3626700
 # Optional: absolute path to monero-wallet-rpc (defaults to `monero-wallet-rpc` on PATH)
 # MONERO_WALLET_RPC=/path/to/monero-wallet-rpc
-# Optional: wallet + log directory (defaults to ~/.cache/xchain-suite/monero-wallets)
+# Optional: wallet directory (defaults to ~/.cache/xchain-suite/monero-wallets)
 # MONERO_WALLET_DIR=/path/to/xchain-wallets
+# Optional: wallet-rpc log file (defaults to <MONERO_WALLET_DIR>/xchain-wallet-rpc.log)
 # MONERO_WALLET_RPC_LOG=/path/to/xchain-wallet-rpc.log

--- a/tools/xchain-suite/README.md
+++ b/tools/xchain-suite/README.md
@@ -39,34 +39,34 @@ A browser-based developer suite for XChainJS packages. Test chain clients, execu
 | **UTXO** | Bitcoin (BTC), Bitcoin Cash (BCH), Litecoin (LTC), Dogecoin (DOGE), Dash (DASH), Zcash (ZEC) |
 | **EVM** | Ethereum (ETH), Avalanche (AVAX), BNB Smart Chain (BSC), Arbitrum (ARB) |
 | **Cosmos** | Cosmos Hub (GAIA), THORChain (THOR), MAYAChain (MAYA), Kujira (KUJI) |
-| **Other** | Solana (SOL), Radix (XRD), Cardano (ADA), Ripple (XRP) |
+| **Other** | Monero (XMR), Solana (SOL), Radix (XRD), Cardano (ADA), Ripple (XRP) |
 
 ## Getting Started
 
 ### Prerequisites
 - Node.js 18+
-- pnpm (recommended) or npm
+- Yarn 4 (this monorepo uses `packageManager: yarn@4.9.2`)
 
 ### Installation
 
 ```bash
 # From the xchainjs-lib root directory
-pnpm install
+yarn install
 
 # Navigate to xchain-suite
 cd tools/xchain-suite
 
 # Start development server
-pnpm dev
+yarn dev
 ```
 
-The app will be available at `http://localhost:5173`
+The app will be available at `http://localhost:3000`
 
 ### Build for Production
 
 ```bash
-pnpm build
-pnpm preview
+yarn build
+yarn preview
 ```
 
 ## Usage
@@ -88,6 +88,94 @@ pnpm preview
 - Only **BTC** and **ETH** chain pages work in Ledger mode; other chains error with a clear message
 
 > **Security Note**: Phrase mode stores your mnemonic in memory only. Never use mainnet wallets with significant funds for testing.
+
+## Monero (local node)
+
+`monerod` stores the chain, not wallets. The suite shows an XMR balance by talking to **`monero-wallet-rpc`**, which scans with the BIP-39 view key against your local daemon.
+
+That address is **not** a `monero-wallet-cli` wallet. Official Monero seeds are 25 words; the suite derives XMR via SLIP-10 `m/44'/128'/0'` from the same BIP-39 phrase as every other chain.
+
+Full client notes: [`packages/xchain-monero/README.md`](../../packages/xchain-monero/README.md).
+
+### 1. Run `monerod`
+
+Pruned is fine. Bind RPC to localhost. Wait until it is synced.
+
+```bash
+monerod \
+  --prune-blockchain \
+  --rpc-bind-ip 127.0.0.1 \
+  --rpc-bind-port 18081 \
+  --restricted-rpc 0 \
+  --non-interactive
+```
+
+Check:
+
+```bash
+curl -s http://127.0.0.1:18081/json_rpc \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":"0","method":"get_info"}'
+```
+
+You want `"synchronized": true` and `"restricted": false`.
+
+### 2. Run `monero-wallet-rpc`
+
+`yarn dev` starts this automatically if it finds the binary (`MONERO_WALLET_RPC`, or `monero-wallet-rpc` on `PATH`). Wallet files default to `~/.cache/xchain-suite/monero-wallets` (`MONERO_WALLET_DIR`). Otherwise start it yourself:
+
+```bash
+export MONERO_WALLET_RPC=/path/to/monero-wallet-rpc
+export MONERO_WALLET_DIR=/path/to/xchain-wallets
+
+mkdir -p "$MONERO_WALLET_DIR"
+
+"$MONERO_WALLET_RPC" \
+  --daemon-address 127.0.0.1:18081 \
+  --trusted-daemon \
+  --rpc-bind-ip 127.0.0.1 \
+  --rpc-bind-port 18088 \
+  --disable-rpc-login \
+  --rpc-ssl disabled \
+  --wallet-dir "$MONERO_WALLET_DIR" \
+  --disable-rpc-ban \
+  --no-initial-sync
+```
+
+Use a **dedicated** `--wallet-dir`. Do not reuse an official-seed wallet directory.
+
+### 3. Point the suite at it
+
+Vite already proxies the browser to localhost:
+
+| Path | Process |
+|---|---|
+| `/xmr-daemon` | `monerod` `:18081` |
+| `/xmr-wallet` | `monero-wallet-rpc` `:18088` |
+
+Optional, in `tools/xchain-suite/.env`:
+
+```bash
+# Wallet creation / first-scan height. Use when the suite address was first funded.
+VITE_XMR_RESTORE_HEIGHT=3626700
+```
+
+Then `yarn dev`, open http://localhost:3000, unlock, and wait for the XMR card. The first sync from `VITE_XMR_RESTORE_HEIGHT` to tip can take a few minutes. Later unlocks reuse the wallet file under `MONERO_WALLET_DIR`.
+
+**History:** Chain → XMR → History uses the same wallet-rpc wallet (`get_transfers`). Incoming senders are hidden (Monero). Outgoing destinations show when this wallet created the spend.
+
+**Transfer:** Chain → XMR → Transfer also uses wallet-rpc (`transfer`). Do not send your entire unlocked balance — the daemon still takes a fee. Incoming outputs need ~10 confirmations before they can be spent. Send a small test amount first.
+
+If the card says **No balance**, the suite SLIP-10 address is empty. Send a test amount from any Monero wallet **to the address shown on the XMR card**.
+
+### Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `ENOSPC: System limit for number of file watchers` | Linux inotify cap. Suite polls instead of watching `packages/*/lib`. Restart `yarn dev` after pulling that change, or `sudo sysctl -w fs.inotify.max_user_watches=524288`. |
+| XMR card errors about wallet RPC | `monero-wallet-rpc` is not on `:18088`. Start it or set `MONERO_WALLET_RPC`. |
+| First load spins for a long time | Expected. wallet-rpc is scanning from restore height. |
+| Balance is 0 / No balance | Different address than your official Monero wallet. Check the address on the card. |
 
 ### Making a Swap
 1. Navigate to **Swap** in the sidebar
@@ -203,7 +291,7 @@ This app runs entirely in the browser. Some notes:
 
 1. Create a feature branch from `master`
 2. Make your changes
-3. Test in browser with `pnpm dev`
+3. Test in browser with `yarn dev`
 4. Submit a PR
 
 ## License

--- a/tools/xchain-suite/src/components/operations/GetHistory.tsx
+++ b/tools/xchain-suite/src/components/operations/GetHistory.tsx
@@ -37,14 +37,14 @@ export function GetHistory({ chainId, client }: GetHistoryProps) {
   }
 
   const formatAmount = (tx: Tx): string => {
-    if (tx.from.length === 0 && tx.to.length === 0) return '-'
-    const firstTo = tx.to[0]
-    if (!firstTo) return '-'
+    const first = tx.to[0] ?? (tx.from[0] ? { amount: tx.from[0].amount } : undefined)
+    if (!first) return '-'
     try {
-      const assetAmt = baseToAsset(firstTo.amount)
-      return formatAssetAmountCurrency({ amount: assetAmt, trimZeros: true })
+      const assetAmt = baseToAsset(first.amount)
+      const formatted = formatAssetAmountCurrency({ amount: assetAmt, asset: tx.asset, trimZeros: true })
+      return tx.to.length === 0 && tx.from.length > 0 ? `-${formatted}` : formatted
     } catch {
-      return firstTo.amount.amount().toString()
+      return first.amount.amount().toString()
     }
   }
 

--- a/tools/xchain-suite/src/lib/clients/factory.ts
+++ b/tools/xchain-suite/src/lib/clients/factory.ts
@@ -513,19 +513,25 @@ export function createClient(chainId: string, config: ClientConfig): XChainClien
     case 'KUJI':
       return new KujiClient({ ...defaultKujiParams, network, phrase })
 
-    // Monero
-    case 'XMR':
+    // Monero — local monerod + monero-wallet-rpc via Vite proxies
+    case 'XMR': {
+      const restoreHeight = Number(import.meta.env.VITE_XMR_RESTORE_HEIGHT) || 3626700
       return new XmrClient({
         ...defaultXMRParams,
         network,
         phrase,
-        restoreHeight: 3626700,
+        restoreHeight,
         daemonUrls: {
           ...defaultXMRParams.daemonUrls!,
-          // Use Vite proxy to avoid CORS issues with daemon HTTP endpoints
           [Network.Mainnet]: ['/xmr-daemon'],
         },
+        walletRpcUrls: {
+          [Network.Mainnet]: ['/xmr-wallet'],
+          [Network.Testnet]: [],
+          [Network.Stagenet]: [],
+        },
       })
+    }
 
     // Other Chains
     case 'SOL': {

--- a/tools/xchain-suite/src/pages/PortfolioPage.tsx
+++ b/tools/xchain-suite/src/pages/PortfolioPage.tsx
@@ -272,7 +272,14 @@ function ChainCard({ entry, onNavigate }: { entry: ChainBalance; onNavigate: (ch
             ) : null}
           </div>
           {loading ? (
-            <div className="mt-1 h-4 w-32 bg-gray-100 dark:bg-gray-700 rounded animate-pulse" />
+            <div className="mt-1">
+              <div className="h-4 w-32 bg-gray-100 dark:bg-gray-700 rounded animate-pulse" />
+              {chain.id === 'XMR' && (
+                <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                  Scanning local monerod via wallet-rpc. First sync can take a few minutes.
+                </p>
+              )}
+            </div>
           ) : error ? (
             <p className="text-xs text-red-500 dark:text-red-400 mt-0.5 truncate">{error}</p>
           ) : balances.length === 0 ? (

--- a/tools/xchain-suite/src/vite-env.d.ts
+++ b/tools/xchain-suite/src/vite-env.d.ts
@@ -17,6 +17,7 @@ interface ImportMetaEnv {
   readonly VITE_SOCHAIN_API_KEY?: string
   readonly VITE_COVALENT_API_KEY?: string
   readonly VITE_SOL_API_KEY?: string
+  readonly VITE_XMR_RESTORE_HEIGHT?: string
   readonly VITE_ASGARDEX_BROKER_URL?: string
   readonly VITE_ASGARDEX_AFFILIATE_BROKERS_ADDRESS?: string
 }

--- a/tools/xchain-suite/vite.config.ts
+++ b/tools/xchain-suite/vite.config.ts
@@ -2,11 +2,91 @@ import react from '@vitejs/plugin-react'
 import nodePolyfills from 'vite-plugin-node-stdlib-browser'
 import wasm from 'vite-plugin-wasm'
 import topLevelAwait from 'vite-plugin-top-level-await'
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import { fileURLToPath, URL } from 'node:url'
+import { spawn, type ChildProcess } from 'node:child_process'
+import { existsSync, mkdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import net from 'node:net'
+
+const LOCAL_MONEROD = 'http://127.0.0.1:18081'
+const LOCAL_WALLET_RPC = 'http://127.0.0.1:18088'
+const WALLET_RPC_BIN = process.env.MONERO_WALLET_RPC || 'monero-wallet-rpc'
+const WALLET_DIR = process.env.MONERO_WALLET_DIR || join(homedir(), '.cache/xchain-suite/monero-wallets')
+const WALLET_RPC_LOG = process.env.MONERO_WALLET_RPC_LOG || join(WALLET_DIR, 'xchain-wallet-rpc.log')
+
+function isPortOpen(port: number, host = '127.0.0.1'): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = net.connect({ port, host }, () => {
+      socket.end()
+      resolve(true)
+    })
+    socket.on('error', () => resolve(false))
+  })
+}
+
+/** Start monero-wallet-rpc against the local monerod when `yarn dev` runs. */
+function moneroWalletRpcPlugin(): Plugin {
+  let child: ChildProcess | null = null
+  return {
+    name: 'monero-wallet-rpc',
+    async configureServer(server) {
+      if (await isPortOpen(18088)) {
+        console.log('[xmr] monero-wallet-rpc already listening on 127.0.0.1:18088')
+        return
+      }
+      // Absolute/relative paths can be checked up front; bare names rely on PATH at spawn.
+      if ((WALLET_RPC_BIN.includes('/') || WALLET_RPC_BIN.startsWith('.')) && !existsSync(WALLET_RPC_BIN)) {
+        console.warn(`[xmr] ${WALLET_RPC_BIN} not found; XMR balances need a running monero-wallet-rpc`)
+        return
+      }
+      mkdirSync(WALLET_DIR, { recursive: true })
+      mkdirSync(dirname(WALLET_RPC_LOG), { recursive: true })
+      child = spawn(
+        WALLET_RPC_BIN,
+        [
+          '--daemon-address',
+          '127.0.0.1:18081',
+          '--trusted-daemon',
+          '--rpc-bind-ip',
+          '127.0.0.1',
+          '--rpc-bind-port',
+          '18088',
+          '--disable-rpc-login',
+          '--rpc-ssl',
+          'disabled',
+          '--wallet-dir',
+          WALLET_DIR,
+          '--disable-rpc-ban',
+          '--no-initial-sync',
+          '--log-file',
+          WALLET_RPC_LOG,
+          '--log-level',
+          '0',
+        ],
+        { stdio: ['ignore', 'pipe', 'pipe'] },
+      )
+      child.stderr?.on('data', (buf) => {
+        const line = String(buf).trim()
+        if (line) console.log(`[xmr-wallet-rpc] ${line}`)
+      })
+      child.on('exit', (code, signal) => {
+        if (code || signal) {
+          console.warn(`[xmr] monero-wallet-rpc exited code=${code} signal=${signal}`)
+        }
+        child = null
+      })
+      console.log(`[xmr] started monero-wallet-rpc (pid ${child.pid}) → 127.0.0.1:18088`)
+      server.httpServer?.once('close', () => {
+        child?.kill('SIGTERM')
+      })
+    },
+  }
+}
 
 export default defineConfig({
-  plugins: [react(), nodePolyfills(), wasm(), topLevelAwait()],
+  plugins: [react(), nodePolyfills(), wasm(), topLevelAwait(), moneroWalletRpcPlugin()],
   define: {
     'process.env': {},
     global: 'globalThis',
@@ -14,7 +94,9 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
+      // Point at package source so suite picks up local WIP without reinstall
       '@xchainjs/xchain-monero': fileURLToPath(new URL('../../packages/xchain-monero/src/index.ts', import.meta.url)),
+      '@xchainjs/xchain-sui': fileURLToPath(new URL('../../packages/xchain-sui/src/index.ts', import.meta.url)),
       stream: 'stream-browserify',
       process: 'process/browser',
       buffer: 'buffer',
@@ -31,16 +113,55 @@ export default defineConfig({
       '@ledgerhq/hw-app-btc',
       '@ledgerhq/hw-app-eth',
     ],
-    exclude: ['@xchainjs/xchain-monero'],
+    // Keep monorepo packages out of the dep optimizer so local edits are live
+    exclude: ['@xchainjs/xchain-monero', '@xchainjs/xchain-sui'],
   },
   server: {
     port: 3000,
+    // This machine is already at the inotify cap (~65k). Don't watch the
+    // monorepo lib/ trees, and poll the small leftover set instead of ENOSPC.
+    watch: {
+      usePolling: true,
+      interval: 1000,
+      ignored: [
+        '**/.git/**',
+        '**/node_modules/**',
+        '**/.turbo/**',
+        '**/lib/**',
+        '**/dist/**',
+        '**/__tests__/**',
+        '**/__e2e__/**',
+        '**/__mocks__/**',
+        '**/stats.html',
+        '../../packages/**/lib/**',
+        '../../packages/**/node_modules/**',
+      ],
+    },
     proxy: {
       '/xmr-daemon': {
-        target: 'https://xmr-node.cakewallet.com:18081',
+        target: LOCAL_MONEROD,
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/xmr-daemon/, ''),
+      },
+      '/xmr-wallet': {
+        target: LOCAL_WALLET_RPC,
+        changeOrigin: true,
+        timeout: 600_000,
+        proxyTimeout: 600_000,
+        rewrite: (path) => path.replace(/^\/xmr-wallet/, ''),
+      },
+      // Optional browser proxies if CORS or grpc-web headers misbehave in some environments
+      '/sui-grpc': {
+        target: 'https://fullnode.mainnet.sui.io:443',
         changeOrigin: true,
         secure: true,
-        rewrite: (path) => path.replace(/^\/xmr-daemon/, ''),
+        rewrite: (path) => path.replace(/^\/sui-grpc/, ''),
+      },
+      '/sui-graphql': {
+        target: 'https://graphql.mainnet.sui.io',
+        changeOrigin: true,
+        secure: true,
+        rewrite: (path) => path.replace(/^\/sui-graphql/, ''),
       },
     },
   },

--- a/tools/xchain-suite/vite.config.ts
+++ b/tools/xchain-suite/vite.config.ts
@@ -2,7 +2,7 @@ import react from '@vitejs/plugin-react'
 import nodePolyfills from 'vite-plugin-node-stdlib-browser'
 import wasm from 'vite-plugin-wasm'
 import topLevelAwait from 'vite-plugin-top-level-await'
-import { defineConfig, type Plugin } from 'vite'
+import { defineConfig, loadEnv, type Plugin } from 'vite'
 import { fileURLToPath, URL } from 'node:url'
 import { spawn, type ChildProcess } from 'node:child_process'
 import { existsSync, mkdirSync } from 'node:fs'
@@ -12,9 +12,7 @@ import net from 'node:net'
 
 const LOCAL_MONEROD = 'http://127.0.0.1:18081'
 const LOCAL_WALLET_RPC = 'http://127.0.0.1:18088'
-const WALLET_RPC_BIN = process.env.MONERO_WALLET_RPC || 'monero-wallet-rpc'
-const WALLET_DIR = process.env.MONERO_WALLET_DIR || join(homedir(), '.cache/xchain-suite/monero-wallets')
-const WALLET_RPC_LOG = process.env.MONERO_WALLET_RPC_LOG || join(WALLET_DIR, 'xchain-wallet-rpc.log')
+const ENV_DIR = fileURLToPath(new URL('.', import.meta.url))
 
 function isPortOpen(port: number, host = '127.0.0.1'): Promise<boolean> {
   return new Promise((resolve) => {
@@ -27,7 +25,7 @@ function isPortOpen(port: number, host = '127.0.0.1'): Promise<boolean> {
 }
 
 /** Start monero-wallet-rpc against the local monerod when `yarn dev` runs. */
-function moneroWalletRpcPlugin(): Plugin {
+function moneroWalletRpcPlugin(walletRpcBin: string, walletDir: string, walletRpcLog: string): Plugin {
   let child: ChildProcess | null = null
   return {
     name: 'monero-wallet-rpc',
@@ -37,14 +35,14 @@ function moneroWalletRpcPlugin(): Plugin {
         return
       }
       // Absolute/relative paths can be checked up front; bare names rely on PATH at spawn.
-      if ((WALLET_RPC_BIN.includes('/') || WALLET_RPC_BIN.startsWith('.')) && !existsSync(WALLET_RPC_BIN)) {
-        console.warn(`[xmr] ${WALLET_RPC_BIN} not found; XMR balances need a running monero-wallet-rpc`)
+      if ((walletRpcBin.includes('/') || walletRpcBin.startsWith('.')) && !existsSync(walletRpcBin)) {
+        console.warn(`[xmr] ${walletRpcBin} not found; XMR balances need a running monero-wallet-rpc`)
         return
       }
-      mkdirSync(WALLET_DIR, { recursive: true })
-      mkdirSync(dirname(WALLET_RPC_LOG), { recursive: true })
+      mkdirSync(walletDir, { recursive: true })
+      mkdirSync(dirname(walletRpcLog), { recursive: true })
       child = spawn(
-        WALLET_RPC_BIN,
+        walletRpcBin,
         [
           '--daemon-address',
           '127.0.0.1:18081',
@@ -57,11 +55,11 @@ function moneroWalletRpcPlugin(): Plugin {
           '--rpc-ssl',
           'disabled',
           '--wallet-dir',
-          WALLET_DIR,
+          walletDir,
           '--disable-rpc-ban',
           '--no-initial-sync',
           '--log-file',
-          WALLET_RPC_LOG,
+          walletRpcLog,
           '--log-level',
           '0',
         ],
@@ -85,89 +83,100 @@ function moneroWalletRpcPlugin(): Plugin {
   }
 }
 
-export default defineConfig({
-  plugins: [react(), nodePolyfills(), wasm(), topLevelAwait(), moneroWalletRpcPlugin()],
-  define: {
-    'process.env': {},
-    global: 'globalThis',
-  },
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-      // Point at package source so suite picks up local WIP without reinstall
-      '@xchainjs/xchain-monero': fileURLToPath(new URL('../../packages/xchain-monero/src/index.ts', import.meta.url)),
-      '@xchainjs/xchain-sui': fileURLToPath(new URL('../../packages/xchain-sui/src/index.ts', import.meta.url)),
-      stream: 'stream-browserify',
-      process: 'process/browser',
-      buffer: 'buffer',
+export default defineConfig(({ mode }) => {
+  // Vite does not put .env into process.env during config eval — load it explicitly.
+  // Shell-exported vars still win over .env values.
+  const env = loadEnv(mode, ENV_DIR, '')
+  const walletRpcBin = process.env.MONERO_WALLET_RPC || env.MONERO_WALLET_RPC || 'monero-wallet-rpc'
+  const walletDir =
+    process.env.MONERO_WALLET_DIR || env.MONERO_WALLET_DIR || join(homedir(), '.cache/xchain-suite/monero-wallets')
+  const walletRpcLog =
+    process.env.MONERO_WALLET_RPC_LOG || env.MONERO_WALLET_RPC_LOG || join(walletDir, 'xchain-wallet-rpc.log')
+
+  return {
+    plugins: [react(), nodePolyfills(), wasm(), topLevelAwait(), moneroWalletRpcPlugin(walletRpcBin, walletDir, walletRpcLog)],
+    define: {
+      'process.env': {},
+      global: 'globalThis',
     },
-  },
-  optimizeDeps: {
-    esbuildOptions: {
-      define: { global: 'globalThis' },
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+        // Point at package source so suite picks up local WIP without reinstall
+        '@xchainjs/xchain-monero': fileURLToPath(new URL('../../packages/xchain-monero/src/index.ts', import.meta.url)),
+        '@xchainjs/xchain-sui': fileURLToPath(new URL('../../packages/xchain-sui/src/index.ts', import.meta.url)),
+        stream: 'stream-browserify',
+        process: 'process/browser',
+        buffer: 'buffer',
+      },
     },
-    include: [
-      'buffer',
-      '@ledgerhq/hw-transport',
-      '@ledgerhq/hw-transport-webhid',
-      '@ledgerhq/hw-app-btc',
-      '@ledgerhq/hw-app-eth',
-    ],
-    // Keep monorepo packages out of the dep optimizer so local edits are live
-    exclude: ['@xchainjs/xchain-monero', '@xchainjs/xchain-sui'],
-  },
-  server: {
-    port: 3000,
-    // This machine is already at the inotify cap (~65k). Don't watch the
-    // monorepo lib/ trees, and poll the small leftover set instead of ENOSPC.
-    watch: {
-      usePolling: true,
-      interval: 1000,
-      ignored: [
-        '**/.git/**',
-        '**/node_modules/**',
-        '**/.turbo/**',
-        '**/lib/**',
-        '**/dist/**',
-        '**/__tests__/**',
-        '**/__e2e__/**',
-        '**/__mocks__/**',
-        '**/stats.html',
-        '../../packages/**/lib/**',
-        '../../packages/**/node_modules/**',
+    optimizeDeps: {
+      esbuildOptions: {
+        define: { global: 'globalThis' },
+      },
+      include: [
+        'buffer',
+        '@ledgerhq/hw-transport',
+        '@ledgerhq/hw-transport-webhid',
+        '@ledgerhq/hw-app-btc',
+        '@ledgerhq/hw-app-eth',
       ],
+      // Keep monorepo packages out of the dep optimizer so local edits are live
+      exclude: ['@xchainjs/xchain-monero', '@xchainjs/xchain-sui'],
     },
-    proxy: {
-      '/xmr-daemon': {
-        target: LOCAL_MONEROD,
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/xmr-daemon/, ''),
+    server: {
+      port: 3000,
+      // This machine is already at the inotify cap (~65k). Don't watch the
+      // monorepo lib/ trees, and poll the small leftover set instead of ENOSPC.
+      watch: {
+        usePolling: true,
+        interval: 1000,
+        ignored: [
+          '**/.git/**',
+          '**/node_modules/**',
+          '**/.turbo/**',
+          '**/lib/**',
+          '**/dist/**',
+          '**/__tests__/**',
+          '**/__e2e__/**',
+          '**/__mocks__/**',
+          '**/stats.html',
+          '../../packages/**/lib/**',
+          '../../packages/**/node_modules/**',
+        ],
       },
-      '/xmr-wallet': {
-        target: LOCAL_WALLET_RPC,
-        changeOrigin: true,
-        timeout: 600_000,
-        proxyTimeout: 600_000,
-        rewrite: (path) => path.replace(/^\/xmr-wallet/, ''),
-      },
-      // Optional browser proxies if CORS or grpc-web headers misbehave in some environments
-      '/sui-grpc': {
-        target: 'https://fullnode.mainnet.sui.io:443',
-        changeOrigin: true,
-        secure: true,
-        rewrite: (path) => path.replace(/^\/sui-grpc/, ''),
-      },
-      '/sui-graphql': {
-        target: 'https://graphql.mainnet.sui.io',
-        changeOrigin: true,
-        secure: true,
-        rewrite: (path) => path.replace(/^\/sui-graphql/, ''),
+      proxy: {
+        '/xmr-daemon': {
+          target: LOCAL_MONEROD,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/xmr-daemon/, ''),
+        },
+        '/xmr-wallet': {
+          target: LOCAL_WALLET_RPC,
+          changeOrigin: true,
+          timeout: 600_000,
+          proxyTimeout: 600_000,
+          rewrite: (path) => path.replace(/^\/xmr-wallet/, ''),
+        },
+        // Optional browser proxies if CORS or grpc-web headers misbehave in some environments
+        '/sui-grpc': {
+          target: 'https://fullnode.mainnet.sui.io:443',
+          changeOrigin: true,
+          secure: true,
+          rewrite: (path) => path.replace(/^\/sui-grpc/, ''),
+        },
+        '/sui-graphql': {
+          target: 'https://graphql.mainnet.sui.io',
+          changeOrigin: true,
+          secure: true,
+          rewrite: (path) => path.replace(/^\/sui-graphql/, ''),
+        },
       },
     },
-  },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: './src/test/setup.ts',
-  },
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: './src/test/setup.ts',
+    },
+  }
 })


### PR DESCRIPTION
monerod has no wallet state. When walletRpcUrls is set, the client now opens or restores a BIP-39 wallet in monero-wallet-rpc and uses it for getBalance, getTransactions, and transfer. xchain-suite proxies the browser to a local monerod and wallet-rpc, and the READMEs document how to run that setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Monero local-node support using `monerod` and `monero-wallet-rpc`.
  * Monero wallets can retrieve balances, transaction history, and execute transfers through wallet RPC.
  * Added configurable wallet RPC endpoints and restore-height settings.
  * Added automatic local wallet RPC support for development environments.

* **Bug Fixes**
  * Improved outgoing-only transaction amount formatting.
  * Added clearer synchronization guidance during wallet loading.
  * Added address validation and improved wallet RPC error handling.

* **Documentation**
  * Expanded Monero setup, configuration, troubleshooting, and wallet behavior guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->