### PR TITLE
fix(cosmos-sdk): avoid duplicate txs on round-robin broadcast retries

### DIFF
--- a/.changeset/fix-thor-maya-rr-dup-tx.md
+++ b/.changeset/fix-thor-maya-rr-dup-tx.md
@@ -1,8 +1,13 @@
 ---
+'@xchainjs/xchain-cosmos-sdk': patch
 '@xchainjs/xchain-thorchain': patch
 '@xchainjs/xchain-mayachain': patch
 '@xchainjs/xchain-cosmos': patch
 '@xchainjs/xchain-kujira': patch
 ---
 
-Fix duplicate transactions when round-robin retries after a sign-and-broadcast transport error by signing once and only round-robinning broadcast of the same signed bytes
+Harden deposit/transfer RPC failover so ambiguous transport failures cannot resign+rebroadcast.
+
+`signAndBroadcast` wrapped in `roundRobinTry` previously retried the entire sign+broadcast on timeout/5xx. If node A accepted the tx but the HTTP response was lost, node B would sign again (often with the next account sequence) and create a second on-chain spend.
+
+Fund-moving paths now sign once, then round-robin broadcast of the **same** TxRaw bytes (idempotent). Shared helper `signOnceThenRoundRobinBroadcast` is available in cosmos-sdk; clients use sign-once + `broadcastTx`. "tx already exists / already in mempool" is treated as success using the known hash (including Ledger/`broadcastTx` paths).

--- a/.changeset/fix-thor-maya-rr-dup-tx.md
+++ b/.changeset/fix-thor-maya-rr-dup-tx.md
@@ -1,0 +1,8 @@
+---
+'@xchainjs/xchain-thorchain': patch
+'@xchainjs/xchain-mayachain': patch
+'@xchainjs/xchain-cosmos': patch
+'@xchainjs/xchain-kujira': patch
+---
+
+Fix duplicate transactions when round-robin retries after a sign-and-broadcast transport error by signing once and only round-robinning broadcast of the same signed bytes

--- a/packages/xchain-cosmos-sdk/__tests__/roundRobin.test.ts
+++ b/packages/xchain-cosmos-sdk/__tests__/roundRobin.test.ts
@@ -79,6 +79,42 @@ describe('roundRobinTry', () => {
       'No clients available. Can not get chain id',
     )
   })
+
+  /**
+   * Guardrail for cosmos keystore clients: never wrap sign+broadcast as one
+   * roundRobinTry unit. A timeout after the first node accepted the tx can
+   * re-sign with a new sequence and submit a second transaction.
+   * Safe pattern: sign once, then round-robin only broadcast of the same bytes.
+   */
+  it('documents that side-effecting callbacks run once per retried endpoint', async () => {
+    let sideEffects = 0
+    const result = await roundRobinTry(['a', 'b'], 'sign and broadcast', async (url) => {
+      sideEffects++
+      if (url === 'a') throw new Error('request timed out')
+      return `hash-from-${url}`
+    })
+    expect(sideEffects).toBe(2)
+    expect(result).toBe('hash-from-b')
+  })
+
+  it('keeps a single signed payload when only broadcast is round-robined', async () => {
+    let signs = 0
+    let broadcasts = 0
+    const signed = await (async () => {
+      signs++
+      return 'same-signed-bytes'
+    })()
+
+    const result = await roundRobinTry(['a', 'b'], 'broadcast transaction', async (url) => {
+      broadcasts++
+      if (url === 'a') throw new Error('request timed out')
+      return `accepted:${signed}`
+    })
+
+    expect(signs).toBe(1)
+    expect(broadcasts).toBe(2)
+    expect(result).toBe('accepted:same-signed-bytes')
+  })
 })
 
 describe('roundRobinGetTx', () => {

--- a/packages/xchain-cosmos-sdk/__tests__/roundRobin.test.ts
+++ b/packages/xchain-cosmos-sdk/__tests__/roundRobin.test.ts
@@ -1,9 +1,12 @@
 import {
   TxNotFoundError,
   createRoundRobinExhaustedError,
+  isAlreadyBroadcastError,
   isRetryableRpcError,
   roundRobinGetTx,
   roundRobinTry,
+  signOnceThenRoundRobinBroadcast,
+  tendermintTxHash,
 } from '../src/roundRobin'
 
 describe('isRetryableRpcError', () => {
@@ -79,42 +82,6 @@ describe('roundRobinTry', () => {
       'No clients available. Can not get chain id',
     )
   })
-
-  /**
-   * Guardrail for cosmos keystore clients: never wrap sign+broadcast as one
-   * roundRobinTry unit. A timeout after the first node accepted the tx can
-   * re-sign with a new sequence and submit a second transaction.
-   * Safe pattern: sign once, then round-robin only broadcast of the same bytes.
-   */
-  it('documents that side-effecting callbacks run once per retried endpoint', async () => {
-    let sideEffects = 0
-    const result = await roundRobinTry(['a', 'b'], 'sign and broadcast', async (url) => {
-      sideEffects++
-      if (url === 'a') throw new Error('request timed out')
-      return `hash-from-${url}`
-    })
-    expect(sideEffects).toBe(2)
-    expect(result).toBe('hash-from-b')
-  })
-
-  it('keeps a single signed payload when only broadcast is round-robined', async () => {
-    let signs = 0
-    let broadcasts = 0
-    const signed = await (async () => {
-      signs++
-      return 'same-signed-bytes'
-    })()
-
-    const result = await roundRobinTry(['a', 'b'], 'broadcast transaction', async (url) => {
-      broadcasts++
-      if (url === 'a') throw new Error('request timed out')
-      return `accepted:${signed}`
-    })
-
-    expect(signs).toBe(1)
-    expect(broadcasts).toBe(2)
-    expect(result).toBe('accepted:same-signed-bytes')
-  })
 })
 
 describe('roundRobinGetTx', () => {
@@ -167,5 +134,99 @@ describe('TxNotFoundError', () => {
     expect(err.name).toBe('TxNotFoundError')
     expect(err.txId).toBe('ABC')
     expect(err.message).toBe('Can not find transaction ABC')
+  })
+})
+
+describe('isAlreadyBroadcastError', () => {
+  it('matches mempool / already-exists messages', () => {
+    expect(isAlreadyBroadcastError(new Error('tx already exists in cache'))).toBe(true)
+    expect(isAlreadyBroadcastError(new Error('tx already in mempool'))).toBe(true)
+    expect(isAlreadyBroadcastError(new Error('Failed to broadcast tx: already in mempool'))).toBe(true)
+  })
+
+  it('does not match unrelated errors', () => {
+    expect(isAlreadyBroadcastError(new Error('request timed out'))).toBe(false)
+    expect(isAlreadyBroadcastError(new Error('insufficient funds'))).toBe(false)
+  })
+})
+
+describe('signOnceThenRoundRobinBroadcast', () => {
+  const txBytesA = new Uint8Array([1, 2, 3, 4])
+  const txBytesB = new Uint8Array([9, 9, 9, 9])
+  const hashA = tendermintTxHash(txBytesA)
+
+  it('signs once then rebroadcasts the same bytes after a timeout on the first URL', async () => {
+    const signCalls: string[] = []
+    const broadcastCalls: { url: string; bytes: Uint8Array }[] = []
+
+    const result = await signOnceThenRoundRobinBroadcast(
+      ['url0', 'url1'],
+      async (url) => {
+        signCalls.push(url)
+        // First URL succeeds at signing — we must never sign again on url1
+        return txBytesA
+      },
+      async (url, txBytes) => {
+        broadcastCalls.push({ url, bytes: txBytes })
+        if (url === 'url0') {
+          throw new Error('request timed out')
+        }
+        // url1 would accept a *new* signature; we assert it only gets the same bytes
+        return { transactionHash: tendermintTxHash(txBytes), code: 0 }
+      },
+    )
+
+    expect(signCalls).toEqual(['url0'])
+    expect(broadcastCalls).toHaveLength(2)
+    expect(broadcastCalls[0].url).toBe('url0')
+    expect(broadcastCalls[1].url).toBe('url1')
+    expect(Array.from(broadcastCalls[0].bytes)).toEqual(Array.from(txBytesA))
+    expect(Array.from(broadcastCalls[1].bytes)).toEqual(Array.from(txBytesA))
+    expect(result.transactionHash).toBe(hashA)
+    // Ensure we did not accidentally produce a second distinct payload
+    expect(Array.from(broadcastCalls[1].bytes)).not.toEqual(Array.from(txBytesB))
+  })
+
+  it('treats already-in-mempool on the second URL as success with the known hash', async () => {
+    const result = await signOnceThenRoundRobinBroadcast(
+      ['url0', 'url1'],
+      async () => txBytesA,
+      async (url) => {
+        if (url === 'url0') throw new Error('Bad status on response: 502')
+        throw new Error('tx already exists in cache')
+      },
+    )
+    expect(result.transactionHash).toBe(hashA)
+    expect(result.code).toBe(0)
+  })
+
+  it('rethrows non-retryable chain errors during broadcast without trying the next URL', async () => {
+    const broadcastUrls: string[] = []
+    await expect(
+      signOnceThenRoundRobinBroadcast(
+        ['url0', 'url1'],
+        async () => txBytesA,
+        async (url) => {
+          broadcastUrls.push(url)
+          throw new Error('insufficient funds: insufficient account funds')
+        },
+      ),
+    ).rejects.toThrow('insufficient funds')
+    expect(broadcastUrls).toEqual(['url0'])
+  })
+
+  it('may try the next URL for sign if the first sign fails with a transport error', async () => {
+    const signCalls: string[] = []
+    const result = await signOnceThenRoundRobinBroadcast(
+      ['url0', 'url1'],
+      async (url) => {
+        signCalls.push(url)
+        if (url === 'url0') throw new Error('Failed to fetch')
+        return txBytesA
+      },
+      async (_url, txBytes) => ({ transactionHash: tendermintTxHash(txBytes), code: 0 }),
+    )
+    expect(signCalls).toEqual(['url0', 'url1'])
+    expect(result.transactionHash).toBe(hashA)
   })
 })

--- a/packages/xchain-cosmos-sdk/src/client.ts
+++ b/packages/xchain-cosmos-sdk/src/client.ts
@@ -33,7 +33,7 @@ import {
   eqAsset,
 } from '@xchainjs/xchain-util'
 
-import { roundRobinGetTx, roundRobinTry } from './roundRobin'
+import { isAlreadyBroadcastError, roundRobinGetTx, roundRobinTry, tendermintTxHash } from './roundRobin'
 import { Balance, CompatibleAsset, Tx, TxFrom, TxParams, TxTo, TxsPage } from './types'
 
 /**
@@ -502,7 +502,18 @@ export default abstract class Client extends BaseXChainClient implements XChainC
    */
   private async roundRobinBroadcast(txHex: Uint8Array): Promise<DeliverTxResponse> {
     const clients = await this.stargateClients.getValue()
-    return roundRobinTry(clients, 'broadcast transaction', (client) => client.broadcastTx(txHex))
+    const knownHash = tendermintTxHash(txHex)
+    return roundRobinTry(clients, 'broadcast transaction', async (client) => {
+      try {
+        return await client.broadcastTx(txHex)
+      } catch (error) {
+        // Same signed bytes already accepted — treat as success for Ledger / offline paths.
+        if (isAlreadyBroadcastError(error)) {
+          return { transactionHash: knownHash, code: 0 } as DeliverTxResponse
+        }
+        throw error
+      }
+    })
   }
 
   /**

--- a/packages/xchain-cosmos-sdk/src/index.ts
+++ b/packages/xchain-cosmos-sdk/src/index.ts
@@ -15,10 +15,13 @@ export {
   TxNotFoundError,
   createRoundRobinExhaustedError,
   errorMessage,
+  isAlreadyBroadcastError,
   isRetryableRpcError,
   roundRobinGetTx,
   roundRobinTry,
+  signOnceThenRoundRobinBroadcast,
+  tendermintTxHash,
 } from './utils'
-export type { RoundRobinTryOptions } from './utils'
+export type { BroadcastResult, RoundRobinTryOptions, SignOnceThenBroadcastOptions } from './utils'
 
 export type { Balance, Tx, TxFrom, TxTo, TxsPage, CompatibleAsset, TxParams } from './types'

--- a/packages/xchain-cosmos-sdk/src/roundRobin.ts
+++ b/packages/xchain-cosmos-sdk/src/roundRobin.ts
@@ -6,8 +6,15 @@
  * surface the last real error so UIs do not only show a generic
  * "No clients available" string.
  *
+ * Fund-moving sign+broadcast must not resign on ambiguous transport failures:
+ * use {@link signOnceThenRoundRobinBroadcast} so the same signed bytes are
+ * rebroadcast (idempotent) instead of a new signature/sequence.
+ *
  * @see https://github.com/xchainjs/xchainjs-lib/issues/1727
  */
+
+import { sha256 } from '@cosmjs/crypto'
+import { toHex } from '@cosmjs/encoding'
 
 /** Tx was not found on any reachable node (distinct from RPC unavailability). */
 export class TxNotFoundError extends Error {
@@ -162,4 +169,86 @@ export async function roundRobinGetTx<TClient, TTx>(
   }
 
   throw createRoundRobinExhaustedError(`retrieve transaction ${txId}`, lastError)
+}
+
+/**
+ * Tendermint tx hash (uppercase hex) from encoded TxRaw bytes — matches CosmJS
+ * `DeliverTxResponse.transactionHash`.
+ */
+export function tendermintTxHash(txBytes: Uint8Array): string {
+  return toHex(sha256(txBytes)).toUpperCase()
+}
+
+/**
+ * True when the node indicates this exact tx was already accepted (mempool/cache).
+ * Safe to treat as success when we already know the hash of the signed bytes.
+ */
+export function isAlreadyBroadcastError(error: unknown): boolean {
+  const msg = errorMessage(error)
+  return (
+    /tx already exists/i.test(msg) ||
+    /already in mempool/i.test(msg) ||
+    /tx in mempool/i.test(msg) ||
+    /retrieved result \([^)]+\) still pending/i.test(msg)
+  )
+}
+
+export type SignOnceThenBroadcastOptions = RoundRobinTryOptions & {
+  signOperation?: string
+  broadcastOperation?: string
+}
+
+export type BroadcastResult = {
+  transactionHash: string
+  code?: number
+  rawLog?: string
+  height?: number
+  gasUsed?: bigint | number
+  gasWanted?: bigint | number
+}
+
+/**
+ * Sign **once** (first successful RPC), then round-robin **broadcast the same
+ * signed bytes**. Prevents double-spend when node A accepts a tx but the HTTP
+ * response times out / 5xxs and a naive signAndBroadcast failover would resign
+ * with the next account sequence on node B.
+ *
+ * Rebroadcasting identical bytes is idempotent; "already in mempool" is treated
+ * as success using the known hash.
+ */
+export async function signOnceThenRoundRobinBroadcast<TResult extends BroadcastResult = BroadcastResult>(
+  urls: readonly string[],
+  sign: (url: string) => Promise<Uint8Array>,
+  broadcast: (url: string, txBytes: Uint8Array) => Promise<TResult>,
+  options: SignOnceThenBroadcastOptions = {},
+): Promise<TResult> {
+  const signOperation = options.signOperation ?? 'sign transaction'
+  const broadcastOperation = options.broadcastOperation ?? 'broadcast transaction'
+
+  // 1) Sign once — retryable failures may try the next URL (no broadcast yet).
+  const txBytes = await roundRobinTry(urls, signOperation, (url) => sign(url), {
+    isRetryable: options.isRetryable,
+    onRetryableError: options.onRetryableError,
+  })
+  const knownHash = tendermintTxHash(txBytes)
+
+  // 2) Broadcast the same bytes across URLs (no resign).
+  return roundRobinTry(
+    urls,
+    broadcastOperation,
+    async (url) => {
+      try {
+        return await broadcast(url, txBytes)
+      } catch (error) {
+        if (isAlreadyBroadcastError(error)) {
+          return { transactionHash: knownHash, code: 0 } as TResult
+        }
+        throw error
+      }
+    },
+    {
+      isRetryable: options.isRetryable,
+      onRetryableError: options.onRetryableError,
+    },
+  )
 }

--- a/packages/xchain-cosmos-sdk/src/utils.ts
+++ b/packages/xchain-cosmos-sdk/src/utils.ts
@@ -36,8 +36,11 @@ export {
   TxNotFoundError,
   createRoundRobinExhaustedError,
   errorMessage,
+  isAlreadyBroadcastError,
   isRetryableRpcError,
   roundRobinGetTx,
   roundRobinTry,
+  signOnceThenRoundRobinBroadcast,
+  tendermintTxHash,
 } from './roundRobin'
-export type { RoundRobinTryOptions } from './roundRobin'
+export type { BroadcastResult, RoundRobinTryOptions, SignOnceThenBroadcastOptions } from './roundRobin'

--- a/packages/xchain-cosmos/src/clientKeystore.ts
+++ b/packages/xchain-cosmos/src/clientKeystore.ts
@@ -1,10 +1,11 @@
-import { fromBase64 } from '@cosmjs/encoding'
+import { fromBase64, toBase64 } from '@cosmjs/encoding'
 import { DecodedTxRaw, DirectSecp256k1HdWallet, EncodeObject, decodeTxRaw } from '@cosmjs/proto-signing'
-import { DeliverTxResponse, SigningStargateClient } from '@cosmjs/stargate'
+import { SigningStargateClient } from '@cosmjs/stargate'
 import { MsgTypes, makeClientPath, roundRobinTry } from '@xchainjs/xchain-cosmos-sdk'
 import { getSeed } from '@xchainjs/xchain-crypto'
 import { bech32 } from '@scure/base'
 import { HDKey } from '@scure/bip32'
+import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx.js'
 import { createHash } from 'crypto'
 import * as secp from '@bitcoin-js/tiny-secp256k1-asmjs'
 
@@ -64,9 +65,11 @@ export class ClientKeystore extends Client {
       hdPaths: [makeClientPath(this.getFullDerivationPath(params.walletIndex || 0))],
     })
 
-    const tx = await this.roundRobinSignAndBroadcast(sender, unsignedTx, signer)
+    // Sign once, then round-robin only the broadcast. Retrying signAndBroadcast after a
+    // transport timeout can re-sign with a new sequence and submit a second transaction.
+    const rawTx = await this.roundRobinSignTransfer(sender, unsignedTx, signer)
 
-    return tx.transactionHash
+    return this.broadcastTx(toBase64(TxRaw.encode(rawTx).finish()))
   }
 
   /**
@@ -84,19 +87,21 @@ export class ClientKeystore extends Client {
   }
 
   /**
-   * Sign a transaction making a round robin over the clients urls provided to the client
+   * Sign a transfer making a round robin over the clients urls provided to the client.
+   * Does not broadcast — callers must broadcast the signed bytes once via broadcastTx.
+   * Named separately from Client.roundRobinSign to avoid a private-member subclass clash.
    *
    * @param {string} sender Sender address
    * @param {DecodedTxRaw} unsignedTx Unsigned transaction
    * @param {DirectSecp256k1HdWallet} signer Signer
-   * @returns {DeliverTxResponse} The transaction broadcasted
+   * @returns {TxRaw} The raw signed transaction
    */
-  private async roundRobinSignAndBroadcast(
+  private async roundRobinSignTransfer(
     sender: string,
     unsignedTx: DecodedTxRaw,
     signer: DirectSecp256k1HdWallet,
-  ): Promise<DeliverTxResponse> {
-    return roundRobinTry(this.clientUrls[this.network], 'sign and broadcast transaction', async (url) => {
+  ): Promise<TxRaw> {
+    return roundRobinTry(this.clientUrls[this.network], 'sign transaction', async (url) => {
       const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
         registry: this.registry,
       })
@@ -105,7 +110,7 @@ export class ClientKeystore extends Client {
         return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
       })
 
-      return signingClient.signAndBroadcast(
+      return signingClient.sign(
         sender,
         messages,
         this.getStandardFee(this.getAssetInfo().asset),

--- a/packages/xchain-cosmos/src/clientLedger.ts
+++ b/packages/xchain-cosmos/src/clientLedger.ts
@@ -1,14 +1,15 @@
 import { OfflineAminoSigner } from '@cosmjs/amino'
-import { fromBase64 } from '@cosmjs/encoding'
+import { fromBase64, toBase64 } from '@cosmjs/encoding'
 import { LedgerSigner } from '@cosmjs/ledger-amino'
 import { DecodedTxRaw, EncodeObject, decodeTxRaw } from '@cosmjs/proto-signing'
-import { DeliverTxResponse, SigningStargateClient } from '@cosmjs/stargate'
+import { SigningStargateClient } from '@cosmjs/stargate'
 import CosmosApp from '@ledgerhq/hw-app-cosmos'
 import type Transport from '@ledgerhq/hw-transport'
 import { TxHash } from '@xchainjs/xchain-client'
 import { MsgTypes, roundRobinTry } from '@xchainjs/xchain-cosmos-sdk'
 import { Address } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
+import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx.js'
 
 import { Client, CosmosClientParams } from './client'
 import { TxParams } from './types'
@@ -61,25 +62,29 @@ export class ClientLedger extends Client {
 
     const unsignedTx: DecodedTxRaw = decodeTxRaw(fromBase64(rawUnsignedTx))
 
-    const tx = await this.roundRobinSignAndBroadcast(fromAddress, unsignedTx, ledgerSigner)
+    // Sign once, then round-robin only the broadcast. Retrying signAndBroadcast after a
+    // transport timeout can re-sign with a new sequence and submit a second transaction.
+    const rawTx = await this.roundRobinSignTransfer(fromAddress, unsignedTx, ledgerSigner)
 
-    return tx.transactionHash
+    return this.broadcastTx(toBase64(TxRaw.encode(rawTx).finish()))
   }
 
   /**
-   * Sign a transaction making a round robin over the clients urls provided to the client
+   * Sign a transfer making a round robin over the clients urls provided to the client.
+   * Does not broadcast — callers must broadcast the signed bytes once via broadcastTx.
+   * Named separately from Client.roundRobinSign to avoid a private-member subclass clash.
    *
    * @param {string} sender Sender address
    * @param {DecodedTxRaw} unsignedTx Unsigned transaction
    * @param {OfflineAminoSigner} signer Signer
-   * @returns {DeliverTxResponse} The transaction broadcasted
+   * @returns {TxRaw} The raw signed transaction
    */
-  private async roundRobinSignAndBroadcast(
+  private async roundRobinSignTransfer(
     sender: string,
     unsignedTx: DecodedTxRaw,
     signer: OfflineAminoSigner,
-  ): Promise<DeliverTxResponse> {
-    return roundRobinTry(this.clientUrls[this.network], 'sign and broadcast transaction', async (url) => {
+  ): Promise<TxRaw> {
+    return roundRobinTry(this.clientUrls[this.network], 'sign transaction', async (url) => {
       const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
         registry: this.registry,
       })
@@ -88,7 +93,7 @@ export class ClientLedger extends Client {
         return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
       })
 
-      return signingClient.signAndBroadcast(
+      return signingClient.sign(
         sender,
         messages,
         this.getStandardFee(this.getAssetInfo().asset),

--- a/packages/xchain-kujira/src/client.ts
+++ b/packages/xchain-kujira/src/client.ts
@@ -7,7 +7,7 @@ import {
   TxBodyEncodeObject,
   decodeTxRaw,
 } from '@cosmjs/proto-signing'
-import { DeliverTxResponse, GasPrice, SigningStargateClient, calculateFee } from '@cosmjs/stargate'
+import { GasPrice, SigningStargateClient, calculateFee } from '@cosmjs/stargate'
 import { AssetInfo, PreparedTx } from '@xchainjs/xchain-client'
 import {
   Client as CosmosSdkClient,
@@ -93,9 +93,11 @@ export class Client extends CosmosSdkClient {
       hdPaths: [makeClientPath(this.getFullDerivationPath(params.walletIndex || 0))],
     })
 
-    const tx = await this.roundRobinSignAndBroadcast(sender, unsignedTx, signer)
+    // Sign once, then round-robin only the broadcast. Retrying signAndBroadcast after a
+    // transport timeout can re-sign with a new sequence and submit a second transaction.
+    const rawTx = await this.roundRobinSign(sender, unsignedTx, signer)
 
-    return tx.transactionHash
+    return this.broadcastTx(toBase64(TxRaw.encode(rawTx).finish()))
   }
 
   /**
@@ -260,19 +262,20 @@ export class Client extends CosmosSdkClient {
   }
 
   /**
-   * Sign and broadcast a transaction making a round robin over the clients urls provided to the client
+   * Sign a transaction making a round robin over the clients urls provided to the client.
+   * Does not broadcast — callers must broadcast the signed bytes once via broadcastTx.
    *
    * @param {string} sender Sender address
    * @param {DecodedTxRaw} unsignedTx Unsigned transaction
    * @param {DirectSecp256k1HdWallet} signer Signer
-   * @returns {DeliverTxResponse} The transaction broadcasted
+   * @returns {TxRaw} The raw signed transaction
    */
-  private async roundRobinSignAndBroadcast(
+  private async roundRobinSign(
     sender: string,
     unsignedTx: DecodedTxRaw,
     signer: DirectSecp256k1HdWallet,
-  ): Promise<DeliverTxResponse> {
-    return roundRobinTry(this.clientUrls[this.network], 'sign and broadcast transaction', async (url) => {
+  ): Promise<TxRaw> {
+    return roundRobinTry(this.clientUrls[this.network], 'sign transaction', async (url) => {
       const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
         registry: this.registry,
       })
@@ -281,7 +284,7 @@ export class Client extends CosmosSdkClient {
         return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
       })
 
-      return signingClient.signAndBroadcast(
+      return signingClient.sign(
         sender,
         messages,
         this.getStandardFee(this.getAssetInfo().asset),

--- a/packages/xchain-mayachain/src/client.ts
+++ b/packages/xchain-mayachain/src/client.ts
@@ -8,7 +8,7 @@ import {
   TxBodyEncodeObject,
   decodeTxRaw,
 } from '@cosmjs/proto-signing'
-import { DeliverTxResponse, SigningStargateClient } from '@cosmjs/stargate'
+import { SigningStargateClient } from '@cosmjs/stargate'
 import { AssetInfo, Network, PreparedTx, TxHash } from '@xchainjs/xchain-client'
 import {
   Client as CosmosSDKClient,
@@ -148,9 +148,16 @@ export class Client extends CosmosSDKClient implements MayachainClient {
         hdPaths: [makeClientPath(this.getFullDerivationPath(params.walletIndex || 0))],
       })
 
-      const tx = await this.roundRobinSignAndBroadcastTx(sender, unsignedTx, signer)
+      // Sign once, then round-robin only the broadcast. Retrying signAndBroadcast after a
+      // transport timeout can re-sign with a new sequence and submit a second transaction.
+      const rawTx = await this.roundRobinSign(
+        sender,
+        unsignedTx,
+        signer,
+        new BigNumber(this.getStandardFee().gas),
+      )
 
-      return tx.transactionHash
+      return this.broadcastTx(toBase64(TxRaw.encode(rawTx).finish()))
     })
   }
 
@@ -315,9 +322,10 @@ export class Client extends CosmosSDKClient implements MayachainClient {
         hdPaths: [makeClientPath(this.getFullDerivationPath(walletIndex || 0))],
       })
 
-      const tx = await this.roundRobinSignAndBroadcastDeposit(sender, signer, gasLimit, amount, memo, asset)
-      // Return the transaction hash
-      return tx.transactionHash
+      // Sign once, then round-robin only the broadcast (same bytes → same tx hash).
+      const rawTx = await this.roundRobinSignDeposit(sender, signer, gasLimit, amount, memo, asset)
+
+      return this.broadcastTx(toBase64(TxRaw.encode(rawTx).finish()))
     })
   }
 
@@ -479,55 +487,30 @@ export class Client extends CosmosSDKClient implements MayachainClient {
   }
 
   /**
-   * Sign and broadcast a transaction making a round robin over the clients urls provided to the client
-   *
-   * @param {string} sender Sender address
-   * @param {DecodedTxRaw} unsignedTx Unsigned transaction
-   * @param {DirectSecp256k1HdWallet} signer Signer
-   * @returns {DeliverTxResponse} The transaction broadcasted
-   */
-  private async roundRobinSignAndBroadcastTx(
-    sender: string,
-    unsignedTx: DecodedTxRaw,
-    signer: DirectSecp256k1HdWallet,
-  ): Promise<DeliverTxResponse> {
-    return roundRobinTry(this.clientUrls[this.network], 'sign and broadcast transaction', async (url) => {
-      const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
-        registry: this.registry,
-      })
-
-      const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
-        return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
-      })
-
-      return signingClient.signAndBroadcast(sender, messages, this.getStandardFee(), unsignedTx.body.memo)
-    })
-  }
-
-  /**
-   * Sign and broadcast a transaction making a round robin over the clients urls provided to the client
+   * Sign a deposit transaction making a round robin over the clients urls provided to the client.
+   * Does not broadcast — callers must broadcast the signed bytes once via broadcastTx.
    *
    * @param {string} sender Sender address
    * @param {DirectSecp256k1HdWallet} signer Signer
    * @param {BigNumber} gasLimit Gas limit for the transaction
    * @param {BaseAmount} amount Amount to deposit
    * @param {string} memo Deposit memo
-   * @param {Asset} asset Asset to deposit
-   * @returns {DeliverTxResponse} The transaction broadcasted
+   * @param {CompatibleAsset} asset Asset to deposit
+   * @returns {TxRaw} The raw signed transaction
    */
-  private async roundRobinSignAndBroadcastDeposit(
+  private async roundRobinSignDeposit(
     sender: string,
     signer: DirectSecp256k1HdWallet,
     gasLimit: BigNumber,
     amount: BaseAmount,
     memo: string,
     asset: CompatibleAsset,
-  ): Promise<DeliverTxResponse> {
-    return roundRobinTry(this.clientUrls[this.network], 'sign and broadcast deposit transaction', async (url) => {
+  ): Promise<TxRaw> {
+    return roundRobinTry(this.clientUrls[this.network], 'sign deposit transaction', async (url) => {
       const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
         registry: this.registry,
       })
-      return signingClient.signAndBroadcast(
+      return signingClient.sign(
         sender,
         [
           {

--- a/packages/xchain-thorchain/src/clientKeystore.ts
+++ b/packages/xchain-thorchain/src/clientKeystore.ts
@@ -1,7 +1,7 @@
 import { Bip39, EnglishMnemonic, Secp256k1, Slip10, Slip10Curve } from '@cosmjs/crypto'
 import { fromBase64, toBase64 } from '@cosmjs/encoding'
 import { DecodedTxRaw, DirectSecp256k1HdWallet, EncodeObject, decodeTxRaw } from '@cosmjs/proto-signing'
-import { Account, DeliverTxResponse, SigningStargateClient } from '@cosmjs/stargate'
+import { Account, SigningStargateClient } from '@cosmjs/stargate'
 import {
   // Import client-related types and functions from @xchainjs/xchain-cosmos-sdk for Cosmos SDK client configuration.
   MsgTypes,
@@ -126,9 +126,16 @@ export class ClientKeystore extends Client {
         hdPaths: [makeClientPath(this.getFullDerivationPath(params.walletIndex || 0))],
       })
 
-      const tx = await this.roundRobinSignAndBroadcastTx(sender, unsignedTx, signer)
+      // Sign once, then round-robin only the broadcast. Retrying signAndBroadcast after a
+      // transport timeout can re-sign with a new sequence and submit a second transaction.
+      const rawTx = await this.roundRobinSign(
+        sender,
+        unsignedTx,
+        signer,
+        new BigNumber(this.getStandardFee().gas),
+      )
 
-      return tx.transactionHash
+      return this.broadcastTx(toBase64(TxRaw.encode(rawTx).finish()))
     })
   }
 
@@ -161,9 +168,10 @@ export class ClientKeystore extends Client {
         hdPaths: [makeClientPath(this.getFullDerivationPath(walletIndex || 0))],
       })
 
-      const tx = await this.roundRobinSignAndBroadcastDeposit(sender, signer, gasLimit, amount, memo, asset)
+      // Sign once, then round-robin only the broadcast (same bytes → same tx hash).
+      const rawTx = await this.roundRobinSignDeposit(sender, signer, gasLimit, amount, memo, asset)
 
-      return tx.transactionHash
+      return this.broadcastTx(toBase64(TxRaw.encode(rawTx).finish()))
     })
   }
 
@@ -257,33 +265,8 @@ export class ClientKeystore extends Client {
   }
 
   /**
-   * Sign and broadcast a transaction making a round robin over the clients urls provided to the client
-   *
-   * @param {string} sender Sender address
-   * @param {DecodedTxRaw} unsignedTx Unsigned transaction
-   * @param {DirectSecp256k1HdWallet} signer Signer
-   * @returns {DeliverTxResponse} The transaction broadcasted
-   */
-  private async roundRobinSignAndBroadcastTx(
-    sender: string,
-    unsignedTx: DecodedTxRaw,
-    signer: DirectSecp256k1HdWallet,
-  ): Promise<DeliverTxResponse> {
-    return roundRobinTry(this.clientUrls[this.network], 'sign and broadcast transaction', async (url) => {
-      const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
-        registry: this.registry,
-      })
-
-      const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
-        return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
-      })
-
-      return signingClient.signAndBroadcast(sender, messages, this.getStandardFee(), unsignedTx.body.memo)
-    })
-  }
-
-  /**
-   * Sign and broadcast a transaction making a round robin over the clients urls provided to the client
+   * Sign a deposit transaction making a round robin over the clients urls provided to the client.
+   * Does not broadcast — callers must broadcast the signed bytes once via broadcastTx.
    *
    * @param {string} sender Sender address
    * @param {DirectSecp256k1HdWallet} signer Signer
@@ -291,53 +274,44 @@ export class ClientKeystore extends Client {
    * @param {BaseAmount} amount Amount to deposit
    * @param {string} memo Deposit memo
    * @param {CompatibleAsset} asset Asset to deposit
-   * @returns {DeliverTxResponse} The transaction broadcasted
+   * @returns {TxRaw} The raw signed transaction
    */
-  private async roundRobinSignAndBroadcastDeposit(
+  private async roundRobinSignDeposit(
     sender: string,
     signer: DirectSecp256k1HdWallet,
     gasLimit: BigNumber,
     amount: BaseAmount,
     memo: string,
     asset: CompatibleAsset,
-  ): Promise<DeliverTxResponse> {
-    return roundRobinTry(
-      this.clientUrls[this.network],
-      'sign and broadcast deposit transaction',
-      async (url) => {
-        const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
-          registry: this.registry,
-        })
+  ): Promise<TxRaw> {
+    return roundRobinTry(this.clientUrls[this.network], 'sign deposit transaction', async (url) => {
+      const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
+        registry: this.registry,
+      })
 
-        return signingClient.signAndBroadcast(
-          sender,
-          [
-            {
-              typeUrl: MSG_DEPOSIT_TYPE_URL,
-              value: {
-                signer: bech32ToBase64(sender),
-                memo,
-                coins: [
-                  {
-                    amount: amount.amount().toString(),
-                    asset: parseAssetToTHORNodeAsset(asset),
-                  },
-                ],
-              },
-            },
-          ],
+      return signingClient.sign(
+        sender,
+        [
           {
-            amount: [],
-            gas: gasLimit.toString(),
+            typeUrl: MSG_DEPOSIT_TYPE_URL,
+            value: {
+              signer: bech32ToBase64(sender),
+              memo,
+              coins: [
+                {
+                  amount: amount.amount().toString(),
+                  asset: parseAssetToTHORNodeAsset(asset),
+                },
+              ],
+            },
           },
-          memo,
-        )
-      },
-      {
-        onRetryableError: (e) => {
-          console.warn(e instanceof Error ? e.message : String(e))
+        ],
+        {
+          amount: [],
+          gas: gasLimit.toString(),
         },
-      },
-    )
+        memo,
+      )
+    })
   }
 }


### PR DESCRIPTION
## Summary
- Cosmos keystore clients wrapped full `signAndBroadcast` inside `roundRobinTry`. A retryable transport error after node A accepted the tx could re-sign with a new sequence and submit a second transaction.
- **Fix:** sign once, then round-robin only broadcast of the same signed bytes.
- Applied to `@xchainjs/xchain-thorchain`, `@xchainjs/xchain-mayachain`, `@xchainjs/xchain-cosmos`, and `@xchainjs/xchain-kujira`.
- Also hardens `@xchainjs/xchain-cosmos-sdk`:
  - shared `signOnceThenRoundRobinBroadcast` helper
  - `isAlreadyBroadcastError` / `tendermintTxHash`
  - base `broadcastTx` treats already-in-mempool as success (covers Ledger/offline paths too)

Incorporates improvements from the parallel approach in #1755 (credit: @underthesun49). Prefer this PR over #1755 — same core fix plus Ledger/`broadcastTx` coverage via the connection pool.

## Test plan
- [x] `yarn workspace @xchainjs/xchain-cosmos-sdk test` (includes sign-once + already-in-mempool cases)
- [x] build + test thorchain, mayachain, cosmos, kujira
- [ ] Manual: flaky first RPC + deposit/transfer → one on-chain tx
- [ ] Close #1755 as superseded after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction reliability during network or transport errors.
  * Transactions are now signed once and safely retried across available broadcast endpoints without creating different signatures.
  * Transactions already accepted by the network are recognized as successful, preventing duplicate-processing errors.
  * Updated transfer and deposit flows across supported Cosmos-based chains, including Ledger transactions.

* **Tests**
  * Added coverage for signing once, broadcast retries, accepted transactions, and non-retryable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->