### PR TITLE
fix(cosmos): prevent resign+rebroadcast on RPC failover

### DIFF
--- a/.changeset/cosmos-sign-once-broadcast-failover.md
+++ b/.changeset/cosmos-sign-once-broadcast-failover.md
@@ -1,0 +1,13 @@
+---
+'@xchainjs/xchain-cosmos-sdk': patch
+'@xchainjs/xchain-thorchain': patch
+'@xchainjs/xchain-mayachain': patch
+'@xchainjs/xchain-cosmos': patch
+'@xchainjs/xchain-kujira': patch
+---
+
+Harden deposit/transfer RPC failover so ambiguous transport failures cannot resign+rebroadcast.
+
+`signAndBroadcast` wrapped in `roundRobinTry` previously retried the entire sign+broadcast on timeout/5xx. If node A accepted the tx but the HTTP response was lost, node B would sign again (often with the next account sequence) and create a second on-chain spend.
+
+Fund-moving paths now use `signOnceThenRoundRobinBroadcast`: sign once, then round-robin broadcast of the **same** TxRaw bytes (idempotent). "tx already exists / already in mempool" is treated as success using the known hash. Read-only round-robin is unchanged.

--- a/packages/xchain-cosmos-sdk/__tests__/roundRobin.test.ts
+++ b/packages/xchain-cosmos-sdk/__tests__/roundRobin.test.ts
@@ -1,9 +1,12 @@
 import {
   TxNotFoundError,
   createRoundRobinExhaustedError,
+  isAlreadyBroadcastError,
   isRetryableRpcError,
   roundRobinGetTx,
   roundRobinTry,
+  signOnceThenRoundRobinBroadcast,
+  tendermintTxHash,
 } from '../src/roundRobin'
 
 describe('isRetryableRpcError', () => {
@@ -131,5 +134,99 @@ describe('TxNotFoundError', () => {
     expect(err.name).toBe('TxNotFoundError')
     expect(err.txId).toBe('ABC')
     expect(err.message).toBe('Can not find transaction ABC')
+  })
+})
+
+describe('isAlreadyBroadcastError', () => {
+  it('matches mempool / already-exists messages', () => {
+    expect(isAlreadyBroadcastError(new Error('tx already exists in cache'))).toBe(true)
+    expect(isAlreadyBroadcastError(new Error('tx already in mempool'))).toBe(true)
+    expect(isAlreadyBroadcastError(new Error('Failed to broadcast tx: already in mempool'))).toBe(true)
+  })
+
+  it('does not match unrelated errors', () => {
+    expect(isAlreadyBroadcastError(new Error('request timed out'))).toBe(false)
+    expect(isAlreadyBroadcastError(new Error('insufficient funds'))).toBe(false)
+  })
+})
+
+describe('signOnceThenRoundRobinBroadcast', () => {
+  const txBytesA = new Uint8Array([1, 2, 3, 4])
+  const txBytesB = new Uint8Array([9, 9, 9, 9])
+  const hashA = tendermintTxHash(txBytesA)
+
+  it('signs once then rebroadcasts the same bytes after a timeout on the first URL', async () => {
+    const signCalls: string[] = []
+    const broadcastCalls: { url: string; bytes: Uint8Array }[] = []
+
+    const result = await signOnceThenRoundRobinBroadcast(
+      ['url0', 'url1'],
+      async (url) => {
+        signCalls.push(url)
+        // First URL succeeds at signing — we must never sign again on url1
+        return txBytesA
+      },
+      async (url, txBytes) => {
+        broadcastCalls.push({ url, bytes: txBytes })
+        if (url === 'url0') {
+          throw new Error('request timed out')
+        }
+        // url1 would accept a *new* signature; we assert it only gets the same bytes
+        return { transactionHash: tendermintTxHash(txBytes), code: 0 }
+      },
+    )
+
+    expect(signCalls).toEqual(['url0'])
+    expect(broadcastCalls).toHaveLength(2)
+    expect(broadcastCalls[0].url).toBe('url0')
+    expect(broadcastCalls[1].url).toBe('url1')
+    expect(Array.from(broadcastCalls[0].bytes)).toEqual(Array.from(txBytesA))
+    expect(Array.from(broadcastCalls[1].bytes)).toEqual(Array.from(txBytesA))
+    expect(result.transactionHash).toBe(hashA)
+    // Ensure we did not accidentally produce a second distinct payload
+    expect(Array.from(broadcastCalls[1].bytes)).not.toEqual(Array.from(txBytesB))
+  })
+
+  it('treats already-in-mempool on the second URL as success with the known hash', async () => {
+    const result = await signOnceThenRoundRobinBroadcast(
+      ['url0', 'url1'],
+      async () => txBytesA,
+      async (url) => {
+        if (url === 'url0') throw new Error('Bad status on response: 502')
+        throw new Error('tx already exists in cache')
+      },
+    )
+    expect(result.transactionHash).toBe(hashA)
+    expect(result.code).toBe(0)
+  })
+
+  it('rethrows non-retryable chain errors during broadcast without trying the next URL', async () => {
+    const broadcastUrls: string[] = []
+    await expect(
+      signOnceThenRoundRobinBroadcast(
+        ['url0', 'url1'],
+        async () => txBytesA,
+        async (url) => {
+          broadcastUrls.push(url)
+          throw new Error('insufficient funds: insufficient account funds')
+        },
+      ),
+    ).rejects.toThrow('insufficient funds')
+    expect(broadcastUrls).toEqual(['url0'])
+  })
+
+  it('may try the next URL for sign if the first sign fails with a transport error', async () => {
+    const signCalls: string[] = []
+    const result = await signOnceThenRoundRobinBroadcast(
+      ['url0', 'url1'],
+      async (url) => {
+        signCalls.push(url)
+        if (url === 'url0') throw new Error('Failed to fetch')
+        return txBytesA
+      },
+      async (_url, txBytes) => ({ transactionHash: tendermintTxHash(txBytes), code: 0 }),
+    )
+    expect(signCalls).toEqual(['url0', 'url1'])
+    expect(result.transactionHash).toBe(hashA)
   })
 })

--- a/packages/xchain-cosmos-sdk/src/index.ts
+++ b/packages/xchain-cosmos-sdk/src/index.ts
@@ -15,10 +15,13 @@ export {
   TxNotFoundError,
   createRoundRobinExhaustedError,
   errorMessage,
+  isAlreadyBroadcastError,
   isRetryableRpcError,
   roundRobinGetTx,
   roundRobinTry,
+  signOnceThenRoundRobinBroadcast,
+  tendermintTxHash,
 } from './utils'
-export type { RoundRobinTryOptions } from './utils'
+export type { BroadcastResult, RoundRobinTryOptions, SignOnceThenBroadcastOptions } from './utils'
 
 export type { Balance, Tx, TxFrom, TxTo, TxsPage, CompatibleAsset, TxParams } from './types'

--- a/packages/xchain-cosmos-sdk/src/roundRobin.ts
+++ b/packages/xchain-cosmos-sdk/src/roundRobin.ts
@@ -6,8 +6,15 @@
  * surface the last real error so UIs do not only show a generic
  * "No clients available" string.
  *
+ * Fund-moving sign+broadcast must not resign on ambiguous transport failures:
+ * use {@link signOnceThenRoundRobinBroadcast} so the same signed bytes are
+ * rebroadcast (idempotent) instead of a new signature/sequence.
+ *
  * @see https://github.com/xchainjs/xchainjs-lib/issues/1727
  */
+
+import { sha256 } from '@cosmjs/crypto'
+import { toHex } from '@cosmjs/encoding'
 
 /** Tx was not found on any reachable node (distinct from RPC unavailability). */
 export class TxNotFoundError extends Error {
@@ -162,4 +169,86 @@ export async function roundRobinGetTx<TClient, TTx>(
   }
 
   throw createRoundRobinExhaustedError(`retrieve transaction ${txId}`, lastError)
+}
+
+/**
+ * Tendermint tx hash (uppercase hex) from encoded TxRaw bytes — matches CosmJS
+ * `DeliverTxResponse.transactionHash`.
+ */
+export function tendermintTxHash(txBytes: Uint8Array): string {
+  return toHex(sha256(txBytes)).toUpperCase()
+}
+
+/**
+ * True when the node indicates this exact tx was already accepted (mempool/cache).
+ * Safe to treat as success when we already know the hash of the signed bytes.
+ */
+export function isAlreadyBroadcastError(error: unknown): boolean {
+  const msg = errorMessage(error)
+  return (
+    /tx already exists/i.test(msg) ||
+    /already in mempool/i.test(msg) ||
+    /tx in mempool/i.test(msg) ||
+    /retrieved result \([^)]+\) still pending/i.test(msg)
+  )
+}
+
+export type SignOnceThenBroadcastOptions = RoundRobinTryOptions & {
+  signOperation?: string
+  broadcastOperation?: string
+}
+
+export type BroadcastResult = {
+  transactionHash: string
+  code?: number
+  rawLog?: string
+  height?: number
+  gasUsed?: bigint | number
+  gasWanted?: bigint | number
+}
+
+/**
+ * Sign **once** (first successful RPC), then round-robin **broadcast the same
+ * signed bytes**. Prevents double-spend when node A accepts a tx but the HTTP
+ * response times out / 5xxs and a naive signAndBroadcast failover would resign
+ * with the next account sequence on node B.
+ *
+ * Rebroadcasting identical bytes is idempotent; "already in mempool" is treated
+ * as success using the known hash.
+ */
+export async function signOnceThenRoundRobinBroadcast<TResult extends BroadcastResult = BroadcastResult>(
+  urls: readonly string[],
+  sign: (url: string) => Promise<Uint8Array>,
+  broadcast: (url: string, txBytes: Uint8Array) => Promise<TResult>,
+  options: SignOnceThenBroadcastOptions = {},
+): Promise<TResult> {
+  const signOperation = options.signOperation ?? 'sign transaction'
+  const broadcastOperation = options.broadcastOperation ?? 'broadcast transaction'
+
+  // 1) Sign once — retryable failures may try the next URL (no broadcast yet).
+  const txBytes = await roundRobinTry(urls, signOperation, (url) => sign(url), {
+    isRetryable: options.isRetryable,
+    onRetryableError: options.onRetryableError,
+  })
+  const knownHash = tendermintTxHash(txBytes)
+
+  // 2) Broadcast the same bytes across URLs (no resign).
+  return roundRobinTry(
+    urls,
+    broadcastOperation,
+    async (url) => {
+      try {
+        return await broadcast(url, txBytes)
+      } catch (error) {
+        if (isAlreadyBroadcastError(error)) {
+          return { transactionHash: knownHash, code: 0 } as TResult
+        }
+        throw error
+      }
+    },
+    {
+      isRetryable: options.isRetryable,
+      onRetryableError: options.onRetryableError,
+    },
+  )
 }

--- a/packages/xchain-cosmos-sdk/src/utils.ts
+++ b/packages/xchain-cosmos-sdk/src/utils.ts
@@ -36,8 +36,11 @@ export {
   TxNotFoundError,
   createRoundRobinExhaustedError,
   errorMessage,
+  isAlreadyBroadcastError,
   isRetryableRpcError,
   roundRobinGetTx,
   roundRobinTry,
+  signOnceThenRoundRobinBroadcast,
+  tendermintTxHash,
 } from './roundRobin'
-export type { RoundRobinTryOptions } from './roundRobin'
+export type { BroadcastResult, RoundRobinTryOptions, SignOnceThenBroadcastOptions } from './roundRobin'

--- a/packages/xchain-cosmos/src/clientKeystore.ts
+++ b/packages/xchain-cosmos/src/clientKeystore.ts
@@ -1,10 +1,11 @@
 import { fromBase64 } from '@cosmjs/encoding'
 import { DecodedTxRaw, DirectSecp256k1HdWallet, EncodeObject, decodeTxRaw } from '@cosmjs/proto-signing'
-import { DeliverTxResponse, SigningStargateClient } from '@cosmjs/stargate'
-import { MsgTypes, makeClientPath, roundRobinTry } from '@xchainjs/xchain-cosmos-sdk'
+import { DeliverTxResponse, SigningStargateClient, StargateClient } from '@cosmjs/stargate'
+import { MsgTypes, makeClientPath, signOnceThenRoundRobinBroadcast } from '@xchainjs/xchain-cosmos-sdk'
 import { getSeed } from '@xchainjs/xchain-crypto'
 import { bech32 } from '@scure/base'
 import { HDKey } from '@scure/bip32'
+import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx.js'
 import { createHash } from 'crypto'
 import * as secp from '@bitcoin-js/tiny-secp256k1-asmjs'
 
@@ -96,21 +97,32 @@ export class ClientKeystore extends Client {
     unsignedTx: DecodedTxRaw,
     signer: DirectSecp256k1HdWallet,
   ): Promise<DeliverTxResponse> {
-    return roundRobinTry(this.clientUrls[this.network], 'sign and broadcast transaction', async (url) => {
-      const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
-        registry: this.registry,
-      })
-
-      const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
-        return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
-      })
-
-      return signingClient.signAndBroadcast(
-        sender,
-        messages,
-        this.getStandardFee(this.getAssetInfo().asset),
-        unsignedTx.body.memo,
-      )
-    })
+    const urls = this.clientUrls[this.network]
+    return signOnceThenRoundRobinBroadcast(
+      urls,
+      async (url) => {
+        const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
+          registry: this.registry,
+        })
+        const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
+          return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
+        })
+        const txRaw = await signingClient.sign(
+          sender,
+          messages,
+          this.getStandardFee(this.getAssetInfo().asset),
+          unsignedTx.body.memo,
+        )
+        return TxRaw.encode(txRaw).finish()
+      },
+      async (url, txBytes) => {
+        const client = await StargateClient.connect(url)
+        return client.broadcastTx(txBytes)
+      },
+      {
+        signOperation: 'sign transaction',
+        broadcastOperation: 'broadcast transaction',
+      },
+    )
   }
 }

--- a/packages/xchain-cosmos/src/clientLedger.ts
+++ b/packages/xchain-cosmos/src/clientLedger.ts
@@ -2,13 +2,14 @@ import { OfflineAminoSigner } from '@cosmjs/amino'
 import { fromBase64 } from '@cosmjs/encoding'
 import { LedgerSigner } from '@cosmjs/ledger-amino'
 import { DecodedTxRaw, EncodeObject, decodeTxRaw } from '@cosmjs/proto-signing'
-import { DeliverTxResponse, SigningStargateClient } from '@cosmjs/stargate'
+import { DeliverTxResponse, SigningStargateClient, StargateClient } from '@cosmjs/stargate'
 import CosmosApp from '@ledgerhq/hw-app-cosmos'
 import type Transport from '@ledgerhq/hw-transport'
 import { TxHash } from '@xchainjs/xchain-client'
-import { MsgTypes, roundRobinTry } from '@xchainjs/xchain-cosmos-sdk'
+import { MsgTypes, signOnceThenRoundRobinBroadcast } from '@xchainjs/xchain-cosmos-sdk'
 import { Address } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
+import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx.js'
 
 import { Client, CosmosClientParams } from './client'
 import { TxParams } from './types'
@@ -79,21 +80,32 @@ export class ClientLedger extends Client {
     unsignedTx: DecodedTxRaw,
     signer: OfflineAminoSigner,
   ): Promise<DeliverTxResponse> {
-    return roundRobinTry(this.clientUrls[this.network], 'sign and broadcast transaction', async (url) => {
-      const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
-        registry: this.registry,
-      })
-
-      const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
-        return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
-      })
-
-      return signingClient.signAndBroadcast(
-        sender,
-        messages,
-        this.getStandardFee(this.getAssetInfo().asset),
-        unsignedTx.body.memo,
-      )
-    })
+    const urls = this.clientUrls[this.network]
+    return signOnceThenRoundRobinBroadcast(
+      urls,
+      async (url) => {
+        const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
+          registry: this.registry,
+        })
+        const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
+          return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
+        })
+        const txRaw = await signingClient.sign(
+          sender,
+          messages,
+          this.getStandardFee(this.getAssetInfo().asset),
+          unsignedTx.body.memo,
+        )
+        return TxRaw.encode(txRaw).finish()
+      },
+      async (url, txBytes) => {
+        const client = await StargateClient.connect(url)
+        return client.broadcastTx(txBytes)
+      },
+      {
+        signOperation: 'sign transaction',
+        broadcastOperation: 'broadcast transaction',
+      },
+    )
   }
 }

--- a/packages/xchain-kujira/src/client.ts
+++ b/packages/xchain-kujira/src/client.ts
@@ -7,14 +7,14 @@ import {
   TxBodyEncodeObject,
   decodeTxRaw,
 } from '@cosmjs/proto-signing'
-import { DeliverTxResponse, GasPrice, SigningStargateClient, calculateFee } from '@cosmjs/stargate'
+import { DeliverTxResponse, GasPrice, SigningStargateClient, StargateClient, calculateFee } from '@cosmjs/stargate'
 import { AssetInfo, PreparedTx } from '@xchainjs/xchain-client'
 import {
   Client as CosmosSdkClient,
   CosmosSdkClientParams,
   MsgTypes,
   makeClientPath,
-  roundRobinTry,
+  signOnceThenRoundRobinBroadcast,
 } from '@xchainjs/xchain-cosmos-sdk'
 import { getSeed } from '@xchainjs/xchain-crypto'
 import { Address, AssetType, eqAsset } from '@xchainjs/xchain-util'
@@ -272,21 +272,32 @@ export class Client extends CosmosSdkClient {
     unsignedTx: DecodedTxRaw,
     signer: DirectSecp256k1HdWallet,
   ): Promise<DeliverTxResponse> {
-    return roundRobinTry(this.clientUrls[this.network], 'sign and broadcast transaction', async (url) => {
-      const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
-        registry: this.registry,
-      })
-
-      const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
-        return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
-      })
-
-      return signingClient.signAndBroadcast(
-        sender,
-        messages,
-        this.getStandardFee(this.getAssetInfo().asset),
-        unsignedTx.body.memo,
-      )
-    })
+    const urls = this.clientUrls[this.network]
+    return signOnceThenRoundRobinBroadcast(
+      urls,
+      async (url) => {
+        const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
+          registry: this.registry,
+        })
+        const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
+          return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
+        })
+        const txRaw = await signingClient.sign(
+          sender,
+          messages,
+          this.getStandardFee(this.getAssetInfo().asset),
+          unsignedTx.body.memo,
+        )
+        return TxRaw.encode(txRaw).finish()
+      },
+      async (url, txBytes) => {
+        const client = await StargateClient.connect(url)
+        return client.broadcastTx(txBytes)
+      },
+      {
+        signOperation: 'sign transaction',
+        broadcastOperation: 'broadcast transaction',
+      },
+    )
   }
 }

--- a/packages/xchain-mayachain/src/client.ts
+++ b/packages/xchain-mayachain/src/client.ts
@@ -8,7 +8,7 @@ import {
   TxBodyEncodeObject,
   decodeTxRaw,
 } from '@cosmjs/proto-signing'
-import { DeliverTxResponse, SigningStargateClient } from '@cosmjs/stargate'
+import { DeliverTxResponse, SigningStargateClient, StargateClient } from '@cosmjs/stargate'
 import { AssetInfo, Network, PreparedTx, TxHash } from '@xchainjs/xchain-client'
 import {
   Client as CosmosSDKClient,
@@ -17,6 +17,7 @@ import {
   bech32ToBase64,
   makeClientPath,
   roundRobinTry,
+  signOnceThenRoundRobinBroadcast,
 } from '@xchainjs/xchain-cosmos-sdk'
 import { getSeed } from '@xchainjs/xchain-crypto'
 import { Address, BaseAmount, assetFromString, eqAsset, isSynthAsset } from '@xchainjs/xchain-util'
@@ -491,17 +492,28 @@ export class Client extends CosmosSDKClient implements MayachainClient {
     unsignedTx: DecodedTxRaw,
     signer: DirectSecp256k1HdWallet,
   ): Promise<DeliverTxResponse> {
-    return roundRobinTry(this.clientUrls[this.network], 'sign and broadcast transaction', async (url) => {
-      const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
-        registry: this.registry,
-      })
-
-      const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
-        return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
-      })
-
-      return signingClient.signAndBroadcast(sender, messages, this.getStandardFee(), unsignedTx.body.memo)
-    })
+    const urls = this.clientUrls[this.network]
+    return signOnceThenRoundRobinBroadcast(
+      urls,
+      async (url) => {
+        const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
+          registry: this.registry,
+        })
+        const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
+          return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
+        })
+        const txRaw = await signingClient.sign(sender, messages, this.getStandardFee(), unsignedTx.body.memo)
+        return TxRaw.encode(txRaw).finish()
+      },
+      async (url, txBytes) => {
+        const client = await StargateClient.connect(url)
+        return client.broadcastTx(txBytes)
+      },
+      {
+        signOperation: 'sign transaction',
+        broadcastOperation: 'broadcast transaction',
+      },
+    )
   }
 
   /**
@@ -523,33 +535,41 @@ export class Client extends CosmosSDKClient implements MayachainClient {
     memo: string,
     asset: CompatibleAsset,
   ): Promise<DeliverTxResponse> {
-    return roundRobinTry(this.clientUrls[this.network], 'sign and broadcast deposit transaction', async (url) => {
-      const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
-        registry: this.registry,
-      })
-      return signingClient.signAndBroadcast(
-        sender,
-        [
-          {
-            typeUrl: MSG_DEPOSIT_TYPE_URL,
-            value: {
-              signer: bech32ToBase64(sender),
-              memo,
-              coins: [
-                {
-                  amount: amount.amount().toString(),
-                  asset: parseAssetToMayanodeAsset(asset),
-                },
-              ],
+    const urls = this.clientUrls[this.network]
+    const fee = { amount: [], gas: gasLimit.toString() }
+    const messages: EncodeObject[] = [
+      {
+        typeUrl: MSG_DEPOSIT_TYPE_URL,
+        value: {
+          signer: bech32ToBase64(sender),
+          memo,
+          coins: [
+            {
+              amount: amount.amount().toString(),
+              asset: parseAssetToMayanodeAsset(asset),
             },
-          },
-        ],
-        {
-          amount: [],
-          gas: gasLimit.toString(),
+          ],
         },
-        memo,
-      )
-    })
+      },
+    ]
+
+    return signOnceThenRoundRobinBroadcast(
+      urls,
+      async (url) => {
+        const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
+          registry: this.registry,
+        })
+        const txRaw = await signingClient.sign(sender, messages, fee, memo)
+        return TxRaw.encode(txRaw).finish()
+      },
+      async (url, txBytes) => {
+        const client = await StargateClient.connect(url)
+        return client.broadcastTx(txBytes)
+      },
+      {
+        signOperation: 'sign deposit transaction',
+        broadcastOperation: 'broadcast deposit transaction',
+      },
+    )
   }
 }

--- a/packages/xchain-thorchain/src/clientKeystore.ts
+++ b/packages/xchain-thorchain/src/clientKeystore.ts
@@ -1,13 +1,14 @@
 import { Bip39, EnglishMnemonic, Secp256k1, Slip10, Slip10Curve } from '@cosmjs/crypto'
 import { fromBase64, toBase64 } from '@cosmjs/encoding'
 import { DecodedTxRaw, DirectSecp256k1HdWallet, EncodeObject, decodeTxRaw } from '@cosmjs/proto-signing'
-import { Account, DeliverTxResponse, SigningStargateClient } from '@cosmjs/stargate'
+import { Account, DeliverTxResponse, SigningStargateClient, StargateClient } from '@cosmjs/stargate'
 import {
   // Import client-related types and functions from @xchainjs/xchain-cosmos-sdk for Cosmos SDK client configuration.
   MsgTypes,
   bech32ToBase64,
   makeClientPath,
   roundRobinTry,
+  signOnceThenRoundRobinBroadcast,
 } from '@xchainjs/xchain-cosmos-sdk'
 import { getSeed } from '@xchainjs/xchain-crypto'
 import { BaseAmount } from '@xchainjs/xchain-util'
@@ -269,17 +270,29 @@ export class ClientKeystore extends Client {
     unsignedTx: DecodedTxRaw,
     signer: DirectSecp256k1HdWallet,
   ): Promise<DeliverTxResponse> {
-    return roundRobinTry(this.clientUrls[this.network], 'sign and broadcast transaction', async (url) => {
-      const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
-        registry: this.registry,
-      })
-
-      const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
-        return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
-      })
-
-      return signingClient.signAndBroadcast(sender, messages, this.getStandardFee(), unsignedTx.body.memo)
-    })
+    const urls = this.clientUrls[this.network]
+    // Sign once, then rebroadcast the same bytes on failover (never resign).
+    return signOnceThenRoundRobinBroadcast(
+      urls,
+      async (url) => {
+        const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
+          registry: this.registry,
+        })
+        const messages: EncodeObject[] = unsignedTx.body.messages.map((message) => {
+          return { typeUrl: this.getMsgTypeUrlByType(MsgTypes.TRANSFER), value: signingClient.registry.decode(message) }
+        })
+        const txRaw = await signingClient.sign(sender, messages, this.getStandardFee(), unsignedTx.body.memo)
+        return TxRaw.encode(txRaw).finish()
+      },
+      async (url, txBytes) => {
+        const client = await StargateClient.connect(url)
+        return client.broadcastTx(txBytes)
+      },
+      {
+        signOperation: 'sign transaction',
+        broadcastOperation: 'broadcast transaction',
+      },
+    )
   }
 
   /**
@@ -301,42 +314,45 @@ export class ClientKeystore extends Client {
     memo: string,
     asset: CompatibleAsset,
   ): Promise<DeliverTxResponse> {
-    return roundRobinTry(
-      this.clientUrls[this.network],
-      'sign and broadcast deposit transaction',
+    const urls = this.clientUrls[this.network]
+    const fee = { amount: [], gas: gasLimit.toString() }
+    const messages: EncodeObject[] = [
+      {
+        typeUrl: MSG_DEPOSIT_TYPE_URL,
+        value: {
+          signer: bech32ToBase64(sender),
+          memo,
+          coins: [
+            {
+              amount: amount.amount().toString(),
+              asset: parseAssetToTHORNodeAsset(asset),
+            },
+          ],
+        },
+      },
+    ]
+    const onRetryableError = (e: unknown) => {
+      console.warn(e instanceof Error ? e.message : String(e))
+    }
+
+    // Sign once, then rebroadcast the same bytes on failover (never resign).
+    return signOnceThenRoundRobinBroadcast(
+      urls,
       async (url) => {
         const signingClient = await SigningStargateClient.connectWithSigner(url, signer, {
           registry: this.registry,
         })
-
-        return signingClient.signAndBroadcast(
-          sender,
-          [
-            {
-              typeUrl: MSG_DEPOSIT_TYPE_URL,
-              value: {
-                signer: bech32ToBase64(sender),
-                memo,
-                coins: [
-                  {
-                    amount: amount.amount().toString(),
-                    asset: parseAssetToTHORNodeAsset(asset),
-                  },
-                ],
-              },
-            },
-          ],
-          {
-            amount: [],
-            gas: gasLimit.toString(),
-          },
-          memo,
-        )
+        const txRaw = await signingClient.sign(sender, messages, fee, memo)
+        return TxRaw.encode(txRaw).finish()
+      },
+      async (url, txBytes) => {
+        const client = await StargateClient.connect(url)
+        return client.broadcastTx(txBytes)
       },
       {
-        onRetryableError: (e) => {
-          console.warn(e instanceof Error ? e.message : String(e))
-        },
+        signOperation: 'sign deposit transaction',
+        broadcastOperation: 'broadcast deposit transaction',
+        onRetryableError,
       },
     )
   }


### PR DESCRIPTION
## Summary

Closes the remaining **duplicate MsgDeposit / transfer** risk after Asgardex removed app-level `retryWhen` around `deposit()`.

### Bug
`roundRobinSignAndBroadcastDeposit` / `…Tx` called CosmJS `signAndBroadcast` inside `roundRobinTry`. On retryable transport errors (timeout, 502, etc.) after node A **accepted** the tx but the HTTP response was lost, node B **resigned** (often with the next sequence) → a second on-chain spend.

### Fix
New shared helper `signOnceThenRoundRobinBroadcast` in `@xchainjs/xchain-cosmos-sdk`:

1. **Sign once** (first successful RPC; transport failures may try the next URL *before* any broadcast).
2. **Broadcast the same TxRaw bytes** across URLs (idempotent).
3. Treat **already in mempool / tx already exists** as success using the known hash.

Wired into:

- `xchain-thorchain` keystore deposit + transfer  
- `xchain-mayachain` deposit + transfer  
- `xchain-cosmos` keystore + Ledger transfer  
- `xchain-kujira` transfer (same pattern; package deprecated)

Read-only round-robin unchanged. `cosmos-sdk` `broadcastTx(txHex)` already broadcast-only.

### Tests
- Timeout after first broadcast → second URL gets **identical** bytes; **one** sign call  
- Already-in-mempool → success with known hash  
- Insufficient funds → fail immediately, no second URL  

## Test plan

- [x] `yarn turbo run test build` for cosmos-sdk, thorchain, mayachain, cosmos, kujira  
- [ ] Bump Asgardex to fixed package versions; re-run Asgardex deposit no-retry unit tests  
- [ ] Manual: flaky first RPC + deposit → one on-chain MsgDeposit  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Cosmos transaction and deposit broadcasting with automatic failover across available endpoints.
  * Transactions are signed once and safely rebroadcast without creating conflicting signatures.
  * Responses indicating a transaction was already accepted or is in the mempool are now treated as successful.
  * Added public utilities for transaction broadcasting and transaction hash calculation.

* **Bug Fixes**
  * Prevented unnecessary retries for non-retryable blockchain errors while continuing through retryable network failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->