### PR TITLE
feat(aggregator)!: split Chainflip quote from deposit channel open

### DIFF
--- a/.changeset/chainflip-split-quote-deposit-channel.md
+++ b/.changeset/chainflip-split-quote-deposit-channel.md
@@ -7,8 +7,8 @@
 Previously, providing `fromAddress` + `destinationAddress` called `requestDepositAddressV2` on every quote refresh, creating short-lived channels that could expire before the user deposited.
 
 **Migration:**
-1. Use `estimateSwap` for quote refresh only (`toAddress` / `depositChannelId` are empty for Chainflip; `canSwap` means a usable quote exists).
-2. Immediately before broadcast, call `Aggregator.requestChainflipDepositAddress` (or `ChainflipProtocol.openDepositChannel`) to get `depositAddress`, `depositChannelId`, and `expiresAt`.
-3. Transfer to that address, or use `doSwap` which opens one channel then sends.
+1. Use `estimateSwap` for quote refresh only (`toAddress` / `depositChannelId` are empty for Chainflip; `canSwap` means a usable quote exists — not “ready to send”).
+2. Immediately before broadcast, call `Aggregator.requestChainflipDepositAddress` (or `ChainflipProtocol.openDepositChannel`) to get `depositAddress`, `depositChannelId`, `expiresAt`, and the quote snapshot bound to that channel.
+3. Transfer to that address, or use `doSwap` which opens one channel then sends (prefer the explicit open API when you must track expiry around Ledger signing).
 
-Do not cache deposit addresses across channel expiry.
+Do not cache deposit addresses across channel expiry. Deposit must be **observed** by Chainflip before expiry (broadcast-before-expiry is not enough for slow EVM inclusion).

--- a/.changeset/chainflip-split-quote-deposit-channel.md
+++ b/.changeset/chainflip-split-quote-deposit-channel.md
@@ -1,0 +1,14 @@
+---
+'@xchainjs/xchain-aggregator': major
+---
+
+**Breaking (Chainflip):** `estimateSwap` no longer opens a deposit channel.
+
+Previously, providing `fromAddress` + `destinationAddress` called `requestDepositAddressV2` on every quote refresh, creating short-lived channels that could expire before the user deposited.
+
+**Migration:**
+1. Use `estimateSwap` for quote refresh only (`toAddress` / `depositChannelId` are empty for Chainflip; `canSwap` means a usable quote exists).
+2. Immediately before broadcast, call `Aggregator.requestChainflipDepositAddress` (or `ChainflipProtocol.openDepositChannel`) to get `depositAddress`, `depositChannelId`, and `expiresAt`.
+3. Transfer to that address, or use `doSwap` which opens one channel then sends.
+
+Do not cache deposit addresses across channel expiry.

--- a/packages/xchain-aggregator/README.md
+++ b/packages/xchain-aggregator/README.md
@@ -64,6 +64,18 @@ const aggregator = new Aggregator({
 - Do swaps
 - Get swap history through different protocols
 
+### Chainflip deposit channels
+
+Chainflip `estimateSwap` is **quote-only** — it does **not** open a deposit channel. Wallets that refresh quotes must not call channel creation on every refresh (channels expire; late deposits may not swap or refund).
+
+Recommended flow:
+
+1. `aggregator.estimateSwap(...)` — price discovery / refresh (`toAddress` empty for Chainflip; `canSwap` means a usable quote exists)
+2. At confirm, immediately before broadcast: `aggregator.requestChainflipDepositAddress(...)` — returns `depositAddress`, `depositChannelId`, and `expiresAt`
+3. Transfer to that deposit address (or use `doSwap`, which opens a channel then sends)
+
+Do not cache deposit addresses across `expiresAt`. EVM Chainflip deposit addresses can be reused across channels; always bind signing to a live `depositChannelId` + expiry.
+
 
 ## Examples
 

--- a/packages/xchain-aggregator/README.md
+++ b/packages/xchain-aggregator/README.md
@@ -76,6 +76,8 @@ Recommended flow:
 
 Do not cache deposit addresses across `expiresAt`. EVM Chainflip deposit addresses can be reused across channels; always bind signing to a live `depositChannelId` + expiry.
 
+**Important:** Chainflip must **observe** the deposit before channel expiry. Broadcasting before `expiresAt` is not enough if the source chain (especially EVM) confirms after expiry — funds may not create a swap and may not FoK-refund. Prefer `requestChainflipDepositAddress` over `doSwap` when you need to track `expiresAt` / `depositChannelId` around slow Ledger signing or post-broadcast monitoring (`doSwap` does not return channel metadata).
+
 
 ## Examples
 

--- a/packages/xchain-aggregator/__tests__/chainflipProtocol.test.ts
+++ b/packages/xchain-aggregator/__tests__/chainflipProtocol.test.ts
@@ -15,6 +15,9 @@ import {
 } from '@xchainjs/xchain-util'
 import { Wallet } from '@xchainjs/xchain-wallet'
 
+import { SwapSDK } from '@chainflip/sdk/swap'
+
+import { Aggregator } from '../src'
 import { ChainflipProtocol } from '../src/protocols/chainflip'
 
 jest.setTimeout(60000)
@@ -35,6 +38,10 @@ describe('Chainflip protocol', () => {
     })
 
     protocol = new ChainflipProtocol({ wallet })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
   })
 
   it('Should get supported chains', async () => {
@@ -217,7 +224,7 @@ describe('Chainflip protocol', () => {
     expect(estimatedSwap.expectedAmount.baseAmount.amount().toString()).toBe('51193')
   })
 
-  it('Should open deposit channel with address, channel id, and expiry', async () => {
+  it('Should open deposit channel with address, channel id, expiry, and quote snapshot', async () => {
     const channel = await protocol.openDepositChannel({
       fromAsset: AssetETH,
       destinationAsset: AssetBTC,
@@ -229,6 +236,46 @@ describe('Chainflip protocol', () => {
     expect(channel.depositChannelId).toBe('ethereum-channel-id')
     expect(channel.expiresAt).toEqual(new Date(1716889354 * 1000))
     expect(channel.depositChannelExpiryBlock).toBe(BigInt(20000))
+    expect(channel.expectedAmount.baseAmount.amount().toString()).toBe('51193')
+    expect(channel.slipBasisPoints).toBe(100)
+  })
+
+  it('Should pass dest/src/refund and effective quote slippage into requestDepositAddressV2', async () => {
+    const spy = jest.spyOn(SwapSDK.prototype, 'requestDepositAddressV2')
+
+    await protocol.openDepositChannel({
+      fromAsset: AssetETH,
+      destinationAsset: AssetBTC,
+      fromAddress: 'ETHEREUMrefundAddress',
+      amount: new CryptoAmount(assetToBase(assetAmount(0.01, ETH_GAS_ASSET_DECIMAL)), AssetETH),
+      destinationAddress: 'BITCOINFakeAddress',
+    })
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    const args = spy.mock.calls[0][0]
+    expect(args.destAddress).toBe('BITCOINFakeAddress')
+    expect(args.srcAddress).toBe('ETHEREUMrefundAddress')
+    expect(args.fillOrKillParams.refundAddress).toBe('ETHEREUMrefundAddress')
+    expect(args.fillOrKillParams.slippageTolerancePercent).toBe(args.quote.recommendedSlippageTolerancePercent)
+  })
+
+  it('Should reject channel response without expiry', async () => {
+    jest.spyOn(SwapSDK.prototype, 'requestDepositAddressV2').mockResolvedValueOnce({
+      depositAddress: 'ETHEREUMfakeaddress',
+      depositChannelId: 'ethereum-channel-id',
+      depositChannelExpiryBlock: BigInt(20000),
+      // estimatedDepositChannelExpiryTime intentionally omitted
+    } as never)
+
+    await expect(
+      protocol.openDepositChannel({
+        fromAsset: AssetETH,
+        destinationAsset: AssetBTC,
+        fromAddress: 'ETHEREUMfakeaddress',
+        amount: new CryptoAmount(assetToBase(assetAmount(0.01, ETH_GAS_ASSET_DECIMAL)), AssetETH),
+        destinationAddress: 'BITCOINFakeAddress',
+      }),
+    ).rejects.toThrow(/missing estimatedDepositChannelExpiryTime/)
   })
 
   it('Should require addresses to open deposit channel', async () => {
@@ -248,5 +295,31 @@ describe('Chainflip protocol', () => {
         amount: new CryptoAmount(assetToBase(assetAmount(0.01, ETH_GAS_ASSET_DECIMAL)), AssetETH),
       }),
     ).rejects.toThrow(/destinationAddress is required/)
+  })
+
+  it('Aggregator.requestChainflipDepositAddress should open a channel', async () => {
+    const aggregator = new Aggregator({ protocols: ['Chainflip'] })
+    const channel = await aggregator.requestChainflipDepositAddress({
+      fromAsset: AssetETH,
+      destinationAsset: AssetBTC,
+      fromAddress: 'ETHEREUMfakeaddress',
+      amount: new CryptoAmount(assetToBase(assetAmount(0.01, ETH_GAS_ASSET_DECIMAL)), AssetETH),
+      destinationAddress: 'BITCOINFakeAddress',
+    })
+    expect(channel.depositChannelId).toBe('ethereum-channel-id')
+    expect(channel.expiresAt).toEqual(new Date(1716889354 * 1000))
+  })
+
+  it('Aggregator.requestChainflipDepositAddress should throw if Chainflip disabled', async () => {
+    const aggregator = new Aggregator({ protocols: ['Thorchain'] })
+    await expect(
+      aggregator.requestChainflipDepositAddress({
+        fromAsset: AssetETH,
+        destinationAsset: AssetBTC,
+        fromAddress: 'ETHEREUMfakeaddress',
+        amount: new CryptoAmount(assetToBase(assetAmount(0.01, ETH_GAS_ASSET_DECIMAL)), AssetETH),
+        destinationAddress: 'BITCOINFakeAddress',
+      }),
+    ).rejects.toThrow(/Chainflip protocol is not enabled/)
   })
 })

--- a/packages/xchain-aggregator/__tests__/chainflipProtocol.test.ts
+++ b/packages/xchain-aggregator/__tests__/chainflipProtocol.test.ts
@@ -99,7 +99,9 @@ describe('Chainflip protocol', () => {
       destinationAddress: 'BITCOINFakeAddress',
     })
     expect(estimatedSwap.protocol).toBe('Chainflip')
-    expect(estimatedSwap.toAddress).toBe('ETHEREUMfakeaddress')
+    // Quote-only: no deposit channel opened on estimate
+    expect(estimatedSwap.toAddress).toBe('')
+    expect(estimatedSwap.depositChannelId).toBeUndefined()
     expect(estimatedSwap.memo).toBe('')
     expect(assetToString(estimatedSwap.expectedAmount.asset)).toBe('BTC.BTC')
     expect(estimatedSwap.expectedAmount.baseAmount.amount().toString()).toBe('51193')
@@ -120,7 +122,7 @@ describe('Chainflip protocol', () => {
     expect(estimatedSwap.slipBasisPoints).toBe(100)
     expect(estimatedSwap.canSwap).toBe(true)
     expect(estimatedSwap.errors.length).toBe(0)
-    expect(estimatedSwap.warning).toBe('Do not cache this response. Do not send funds after the expiry.')
+    expect(estimatedSwap.warning).toContain('Open a deposit channel immediately before broadcast')
   })
 
   it('Should estimate from ERC-20 swap', async () => {
@@ -136,7 +138,8 @@ describe('Chainflip protocol', () => {
       destinationAddress: 'ETHEREUMfakeaddress',
     })
     expect(estimatedSwap.protocol).toBe('Chainflip')
-    expect(estimatedSwap.toAddress).toBe('ETHEREUMfakeaddress')
+    expect(estimatedSwap.toAddress).toBe('')
+    expect(estimatedSwap.depositChannelId).toBeUndefined()
     expect(estimatedSwap.memo).toBe('')
     expect(assetToString(estimatedSwap.expectedAmount.asset)).toBe('ETH.ETH')
     expect(estimatedSwap.expectedAmount.baseAmount.amount().toString()).toBe('2063188201000691')
@@ -157,7 +160,7 @@ describe('Chainflip protocol', () => {
     expect(estimatedSwap.slipBasisPoints).toBe(100)
     expect(estimatedSwap.canSwap).toBe(true)
     expect(estimatedSwap.errors.length).toBe(0)
-    expect(estimatedSwap.warning).toBe('Do not cache this response. Do not send funds after the expiry.')
+    expect(estimatedSwap.warning).toContain('Open a deposit channel immediately before broadcast')
   })
 
   it('Should estimate to ERC-20 swap', async () => {
@@ -173,7 +176,8 @@ describe('Chainflip protocol', () => {
       destinationAddress: 'ETHEREUMfakeaddress',
     })
     expect(estimatedSwap.protocol).toBe('Chainflip')
-    expect(estimatedSwap.toAddress).toBe('ETHEREUMfakeaddress')
+    expect(estimatedSwap.toAddress).toBe('')
+    expect(estimatedSwap.depositChannelId).toBeUndefined()
     expect(estimatedSwap.memo).toBe('')
     expect(assetToString(estimatedSwap.expectedAmount.asset)).toBe(
       'ETH.USDT-0xdAC17F958D2ee523a2206206994597C13D831ec7',
@@ -198,6 +202,51 @@ describe('Chainflip protocol', () => {
     expect(estimatedSwap.slipBasisPoints).toBe(100)
     expect(estimatedSwap.canSwap).toBe(true)
     expect(estimatedSwap.errors.length).toBe(0)
-    expect(estimatedSwap.warning).toBe('Do not cache this response. Do not send funds after the expiry.')
+    expect(estimatedSwap.warning).toContain('Open a deposit channel immediately before broadcast')
+  })
+
+  it('Should estimate without addresses (quote refresh path)', async () => {
+    const estimatedSwap = await protocol.estimateSwap({
+      fromAsset: AssetETH,
+      destinationAsset: AssetBTC,
+      amount: new CryptoAmount(assetToBase(assetAmount(0.01, ETH_GAS_ASSET_DECIMAL)), AssetETH),
+    })
+    expect(estimatedSwap.canSwap).toBe(true)
+    expect(estimatedSwap.toAddress).toBe('')
+    expect(estimatedSwap.depositChannelId).toBeUndefined()
+    expect(estimatedSwap.expectedAmount.baseAmount.amount().toString()).toBe('51193')
+  })
+
+  it('Should open deposit channel with address, channel id, and expiry', async () => {
+    const channel = await protocol.openDepositChannel({
+      fromAsset: AssetETH,
+      destinationAsset: AssetBTC,
+      fromAddress: 'ETHEREUMfakeaddress',
+      amount: new CryptoAmount(assetToBase(assetAmount(0.01, ETH_GAS_ASSET_DECIMAL)), AssetETH),
+      destinationAddress: 'BITCOINFakeAddress',
+    })
+    expect(channel.depositAddress).toBe('ETHEREUMfakeaddress')
+    expect(channel.depositChannelId).toBe('ethereum-channel-id')
+    expect(channel.expiresAt).toEqual(new Date(1716889354 * 1000))
+    expect(channel.depositChannelExpiryBlock).toBe(BigInt(20000))
+  })
+
+  it('Should require addresses to open deposit channel', async () => {
+    await expect(
+      protocol.openDepositChannel({
+        fromAsset: AssetETH,
+        destinationAsset: AssetBTC,
+        amount: new CryptoAmount(assetToBase(assetAmount(0.01, ETH_GAS_ASSET_DECIMAL)), AssetETH),
+      }),
+    ).rejects.toThrow(/fromAddress is required/)
+
+    await expect(
+      protocol.openDepositChannel({
+        fromAsset: AssetETH,
+        destinationAsset: AssetBTC,
+        fromAddress: 'ETHEREUMfakeaddress',
+        amount: new CryptoAmount(assetToBase(assetAmount(0.01, ETH_GAS_ASSET_DECIMAL)), AssetETH),
+      }),
+    ).rejects.toThrow(/destinationAddress is required/)
   })
 })

--- a/packages/xchain-aggregator/src/aggregator.ts
+++ b/packages/xchain-aggregator/src/aggregator.ts
@@ -3,6 +3,7 @@ import { assetToString, isTokenAsset } from '@xchainjs/xchain-util'
 
 import { DEFAULT_CONFIG } from './const'
 import { ProtocolFactory } from './protocols'
+import { ChainflipDepositChannel, ChainflipProtocol } from './protocols/chainflip'
 import {
   Config,
   IProtocol,
@@ -102,6 +103,22 @@ export class Aggregator {
       )
 
     return successfulQuotes
+  }
+
+  /**
+   * Open a Chainflip deposit channel for the given swap params.
+   * Call immediately before broadcast; do not cache across expiry.
+   * Chainflip `estimateSwap` is quote-only and does not open a channel.
+   *
+   * @param {QuoteSwapParams} params Must include fromAddress and destinationAddress
+   * @returns {ChainflipDepositChannel} Deposit address, channel id, and expiry
+   */
+  public async requestChainflipDepositAddress(params: QuoteSwapParams): Promise<ChainflipDepositChannel> {
+    const protocol = this.protocols.find((p) => p.name === 'Chainflip')
+    if (!protocol || !(protocol instanceof ChainflipProtocol)) {
+      throw Error('Chainflip protocol is not enabled')
+    }
+    return protocol.openDepositChannel(params)
   }
 
   /**

--- a/packages/xchain-aggregator/src/index.ts
+++ b/packages/xchain-aggregator/src/index.ts
@@ -1,4 +1,6 @@
 export { Aggregator } from './aggregator'
+export { ChainflipProtocol } from './protocols/chainflip'
+export type { ChainflipDepositChannel } from './protocols/chainflip'
 export type {
   IProtocol,
   QuoteSwapParams,

--- a/packages/xchain-aggregator/src/protocols/chainflip/chainflipProtocol.ts
+++ b/packages/xchain-aggregator/src/protocols/chainflip/chainflipProtocol.ts
@@ -141,17 +141,15 @@ export class ChainflipProtocol implements IProtocol {
     const selected = await this.getSelectedQuote(params, srcAssetData, destAssetData)
     if (!selected) throw Error('No suitable Chainflip quote found')
 
-    const quoteToUse =
-      params.enableBoost && selected.selectedQuote.boostQuote
-        ? selected.selectedQuote.boostQuote
-        : selected.selectedQuote
+    const quoteToUse = selected.actualQuote
 
     const resp = await this.sdk.requestDepositAddressV2({
       quote: quoteToUse,
       destAddress: params.destinationAddress,
       srcAddress: params.fromAddress,
       fillOrKillParams: {
-        slippageTolerancePercent: selected.selectedQuote.recommendedSlippageTolerancePercent,
+        // Must match the effective quote (boost vs regular), not the parent wrapper.
+        slippageTolerancePercent: quoteToUse.recommendedSlippageTolerancePercent,
         refundAddress: params.fromAddress,
         retryDurationBlocks: 100,
       },
@@ -168,11 +166,23 @@ export class ChainflipProtocol implements IProtocol {
       depositChannelId: resp.depositChannelId,
       expiresAt: new Date(expiresAtSeconds * 1000),
       depositChannelExpiryBlock: resp.depositChannelExpiryBlock,
+      expectedAmount: new CryptoAmount(
+        baseAmount(quoteToUse.egressAmount, destAssetData.decimals),
+        params.destinationAsset,
+      ),
+      slipBasisPoints: quoteToUse.recommendedSlippageTolerancePercent
+        ? quoteToUse.recommendedSlippageTolerancePercent * 100
+        : 0,
     }
   }
 
   /**
    * Perform a swap: open a deposit channel, then transfer to the deposit address.
+   *
+   * Prefer {@link openDepositChannel} when the UI must track `expiresAt` /
+   * `depositChannelId` around slow signing (e.g. Ledger) or post-broadcast
+   * monitoring — `doSwap` does not return channel metadata.
+   *
    * @param {QuoteSwapParams} params Swap parameters
    * @returns {TxSubmitted} Transaction hash and URL of the swap
    */
@@ -275,21 +285,31 @@ export class ChainflipProtocol implements IProtocol {
     const networkFee = actualQuote.includedFees.find((fee) => fee.type === 'NETWORK')
     const boostFee = actualQuote.includedFees.find((fee) => fee.type === 'BOOST')
 
+    // Never sum base units across assets (NETWORK is typically USDC; BOOST is src asset).
+    const reportedNetworkFee =
+      isUsingBoost && boostFee
+        ? new CryptoAmount(baseAmount(boostFee.amount, srcAssetData.decimals), params.fromAsset)
+        : new CryptoAmount(baseAmount(networkFee ? networkFee.amount : 0, 6), assetUSDC)
+
     const baseWarning =
-      'Do not cache this response. Open a deposit channel immediately before broadcast; do not send funds after channel expiry.'
+      'Do not cache this response. Open a deposit channel immediately before broadcast; do not send funds after channel expiry. Deposit must be observed by Chainflip before expiry (broadcast-before-expiry is not enough for slow EVM inclusion).'
 
     return {
       protocol: this.name,
       // Quote-only: channel is opened via openDepositChannel / doSwap
       toAddress: '',
       memo: '',
-      expectedAmount: new CryptoAmount(baseAmount(actualQuote.egressAmount, destAssetData.decimals), params.destinationAsset),
+      expectedAmount: new CryptoAmount(
+        baseAmount(actualQuote.egressAmount, destAssetData.decimals),
+        params.destinationAsset,
+      ),
       dustThreshold: new CryptoAmount(
         baseAmount(srcAssetData.minimumSwapAmount, srcAssetData.decimals),
         params.fromAsset,
       ),
       totalSwapSeconds: actualQuote.estimatedDurationSeconds ? actualQuote.estimatedDurationSeconds : 0,
       maxStreamingQuantity: undefined,
+      // Usable quote exists — NOT "channel already open". Callers must open a channel before send.
       canSwap: true,
       warning: actualQuote.lowLiquidityWarning
         ? `${baseWarning} The difference in the chainflip swap rate (excluding fees) is lower than the global index rate of the swap by more than a certain threshold (currently set to 5%)`
@@ -302,13 +322,7 @@ export class ChainflipProtocol implements IProtocol {
         : 0,
       fees: {
         asset: assetUSDC,
-        networkFee: new CryptoAmount(
-          baseAmount(
-            (networkFee ? parseInt(networkFee.amount) : 0) + (isUsingBoost && boostFee ? parseInt(boostFee.amount) : 0),
-            isUsingBoost && boostFee ? srcAssetData.decimals : 6,
-          ),
-          isUsingBoost && boostFee ? params.fromAsset : assetUSDC,
-        ),
+        networkFee: reportedNetworkFee,
         outboundFee: new CryptoAmount(
           baseAmount(outboundFee ? outboundFee.amount : 0, destAssetData.decimals),
           params.destinationAsset,

--- a/packages/xchain-aggregator/src/protocols/chainflip/chainflipProtocol.ts
+++ b/packages/xchain-aggregator/src/protocols/chainflip/chainflipProtocol.ts
@@ -19,7 +19,7 @@ import { Wallet } from '@xchainjs/xchain-wallet'
 
 import { IProtocol, ProtocolConfig, QuoteSwap, QuoteSwapParams, SwapHistory, TxSubmitted } from '../../types'
 
-import { CompatibleAsset } from './types'
+import { ChainflipDepositChannel, CompatibleAsset } from './types'
 import { cChainToXChain, xAssetToCAsset } from './utils'
 import { assetUSDC } from '@xchainjs/xchain-thorchain-query'
 
@@ -31,6 +31,14 @@ const networkToChainflip = (network?: Network): 'mainnet' | 'perseverance' => {
     default:
       return 'mainnet'
   }
+}
+
+type SelectedQuoteContext = {
+  srcAssetData: AssetData
+  destAssetData: AssetData
+  selectedQuote: Quote
+  actualQuote: Quote
+  isUsingBoost: boolean
 }
 
 /**
@@ -93,158 +101,91 @@ export class ChainflipProtocol implements IProtocol {
   }
 
   /**
-   * Estimate swap by validating the swap parameters.
+   * Estimate swap (quote only). Does **not** open a deposit channel.
+   *
+   * Call {@link openDepositChannel} (or {@link doSwap}) immediately before broadcast.
    *
    * @param {QuoteSwapParams} quoteSwapParams Swap parameters.
-   * @returns {QuoteSwap} Quote swap result. If swap cannot be done, it returns an empty QuoteSwap with reasons.
+   * @returns {QuoteSwap} Quote swap result. `toAddress` / `depositChannelId` are empty until a channel is opened.
    */
   public async estimateSwap(params: QuoteSwapParams): Promise<QuoteSwap> {
     const srcAssetData = await this.getAssetData(params.fromAsset)
     const destAssetData = await this.getAssetData(params.destinationAsset)
 
     try {
-      let toAddress = ''
-      let depositChannelId = ''
-      const { quotes } = await this.sdk.getQuoteV2({
-        srcChain: srcAssetData.chain,
-        srcAsset: srcAssetData.asset,
-        destChain: destAssetData.chain,
-        destAsset: destAssetData.asset,
-        amount: params.amount.baseAmount.amount().toString(),
-        affiliateBrokers: this.affiliateBrokers,
-      })
-      // Find quote based on user preference for boost
-      let selectedQuote: Quote | undefined
-
-      if (params.enableBoost) {
-        // User wants boost - prioritize DCA with boost > REGULAR with boost > DCA > REGULAR
-        selectedQuote =
-          quotes.find((quote) => quote.type === 'DCA' && quote.boostQuote) ||
-          quotes.find((quote) => quote.type === 'REGULAR' && quote.boostQuote) ||
-          quotes.find((quote) => quote.type === 'DCA') ||
-          quotes.find((quote) => quote.type === 'REGULAR')
-      } else {
-        // User wants regular quotes - prioritize DCA > REGULAR (ignore boost quotes)
-        selectedQuote = quotes.find((quote) => quote.type === 'DCA') || quotes.find((quote) => quote.type === 'REGULAR')
+      const selected = await this.getSelectedQuote(params, srcAssetData, destAssetData)
+      if (!selected) {
+        return this.emptyQuoteSwap(params, srcAssetData, destAssetData, ['No suitable quote found'])
       }
-
-      if (params.destinationAddress && selectedQuote && params.fromAddress) {
-        const quoteToUse = params.enableBoost && selectedQuote.boostQuote ? selectedQuote.boostQuote : selectedQuote
-        const resp = await this.sdk.requestDepositAddressV2({
-          quote: quoteToUse,
-          destAddress: params.destinationAddress,
-          srcAddress: params.fromAddress,
-          fillOrKillParams: {
-            slippageTolerancePercent: selectedQuote.recommendedSlippageTolerancePercent,
-            refundAddress: params.fromAddress,
-            retryDurationBlocks: 100,
-          },
-          affiliateBrokers: this.affiliateBrokers,
-        })
-        toAddress = resp.depositAddress
-        depositChannelId = resp.depositChannelId
-      } else {
-        console.error('No suitable quote found or destination/refund address missing')
-      }
-
-      // Determine which quote to use for fee calculations
-      const actualQuote = params.enableBoost && selectedQuote?.boostQuote ? selectedQuote.boostQuote : selectedQuote
-
-      const outboundFee = actualQuote?.includedFees.find((fee) => fee.type === 'EGRESS')
-      const brokerFee = actualQuote?.includedFees.find((fee) => fee.type === 'BROKER')
-      const networkFee = actualQuote?.includedFees.find((fee) => fee.type === 'NETWORK')
-      const boostFee = actualQuote?.includedFees.find((fee) => fee.type === 'BOOST')
-
-      // Check if boost is actually being used
-      const isUsingBoost = params.enableBoost && selectedQuote?.boostQuote && actualQuote === selectedQuote.boostQuote
-
-      return {
-        protocol: this.name,
-        toAddress,
-        memo: '',
-        expectedAmount: new CryptoAmount(
-          baseAmount(actualQuote?.egressAmount, destAssetData.decimals),
-          params.destinationAsset,
-        ),
-        dustThreshold: new CryptoAmount(
-          baseAmount(srcAssetData.minimumSwapAmount, srcAssetData.decimals),
-          params.fromAsset,
-        ),
-        totalSwapSeconds: actualQuote?.estimatedDurationSeconds ? actualQuote.estimatedDurationSeconds : 0,
-        maxStreamingQuantity: undefined,
-        canSwap: toAddress !== '',
-        warning: actualQuote?.lowLiquidityWarning
-          ? 'Do not cache this response. Do not send funds after the expiry. The difference in the chainflip swap rate (excluding fees) is lower than the global index rate of the swap by more than a certain threshold (currently set to 5%)'
-          : isUsingBoost
-          ? 'Do not cache this response. Do not send funds after the expiry. Boost enabled for faster processing.'
-          : 'Do not cache this response. Do not send funds after the expiry.',
-        errors: [],
-        slipBasisPoints: actualQuote?.recommendedSlippageTolerancePercent
-          ? actualQuote?.recommendedSlippageTolerancePercent * 100
-          : 0,
-        fees: {
-          asset: assetUSDC, // networkFee & broker fee paid in usdc
-          networkFee: new CryptoAmount(
-            baseAmount(
-              (networkFee ? parseInt(networkFee.amount) : 0) +
-                (isUsingBoost && boostFee ? parseInt(boostFee.amount) : 0),
-              isUsingBoost && boostFee ? srcAssetData.decimals : 6,
-            ),
-            isUsingBoost && boostFee ? params.fromAsset : assetUSDC,
-          ),
-          outboundFee: new CryptoAmount(
-            baseAmount(outboundFee ? outboundFee.amount : 0, destAssetData.decimals),
-            params.destinationAsset,
-          ),
-          affiliateFee: new CryptoAmount(baseAmount(brokerFee ? brokerFee.amount : 0, 6), assetUSDC),
-        },
-        depositChannelId,
-      }
+      return this.mapQuoteToQuoteSwap(params, selected)
     } catch (e) {
-      return {
-        protocol: this.name,
-        toAddress: '',
-        memo: '',
-        expectedAmount: new CryptoAmount(baseAmount(0, destAssetData.decimals), params.destinationAsset),
-        dustThreshold: new CryptoAmount(
-          baseAmount(srcAssetData.minimumSwapAmount, srcAssetData.decimals),
-          params.fromAsset,
-        ),
-        totalSwapSeconds: 0,
-        maxStreamingQuantity: 0,
-        canSwap: false,
-        warning: '',
-        errors: [e instanceof Error ? e.message : 'Unknown error'],
-        slipBasisPoints: 0,
-        fees: {
-          asset: params.destinationAsset,
-          outboundFee: new CryptoAmount(baseAmount(0, destAssetData.decimals), params.destinationAsset),
-          networkFee: new CryptoAmount(baseAmount(0, 6), assetUSDC),
-          affiliateFee: new CryptoAmount(baseAmount(0, 6), assetUSDC),
-        },
-        depositChannelId: undefined,
-      }
+      return this.emptyQuoteSwap(params, srcAssetData, destAssetData, [
+        e instanceof Error ? e.message : 'Unknown error',
+      ])
     }
   }
 
   /**
-   * Perform a swap operation between assets.
+   * Open a Chainflip deposit channel for the current quote.
+   * Open immediately before broadcast; do not cache across `expiresAt`.
+   *
+   * @param {QuoteSwapParams} params Must include `fromAddress` and `destinationAddress`
+   * @returns {ChainflipDepositChannel} Deposit address, channel id, and expiry
+   */
+  public async openDepositChannel(params: QuoteSwapParams): Promise<ChainflipDepositChannel> {
+    if (!params.fromAddress) throw Error('fromAddress is required to open a Chainflip deposit channel')
+    if (!params.destinationAddress) throw Error('destinationAddress is required to open a Chainflip deposit channel')
+
+    const srcAssetData = await this.getAssetData(params.fromAsset)
+    const destAssetData = await this.getAssetData(params.destinationAsset)
+    const selected = await this.getSelectedQuote(params, srcAssetData, destAssetData)
+    if (!selected) throw Error('No suitable Chainflip quote found')
+
+    const quoteToUse =
+      params.enableBoost && selected.selectedQuote.boostQuote
+        ? selected.selectedQuote.boostQuote
+        : selected.selectedQuote
+
+    const resp = await this.sdk.requestDepositAddressV2({
+      quote: quoteToUse,
+      destAddress: params.destinationAddress,
+      srcAddress: params.fromAddress,
+      fillOrKillParams: {
+        slippageTolerancePercent: selected.selectedQuote.recommendedSlippageTolerancePercent,
+        refundAddress: params.fromAddress,
+        retryDurationBlocks: 100,
+      },
+      affiliateBrokers: this.affiliateBrokers,
+    })
+
+    const expiresAtSeconds = resp.estimatedDepositChannelExpiryTime
+    if (expiresAtSeconds == null) {
+      throw Error('Chainflip deposit channel response missing estimatedDepositChannelExpiryTime')
+    }
+
+    return {
+      depositAddress: resp.depositAddress,
+      depositChannelId: resp.depositChannelId,
+      expiresAt: new Date(expiresAtSeconds * 1000),
+      depositChannelExpiryBlock: resp.depositChannelExpiryBlock,
+    }
+  }
+
+  /**
+   * Perform a swap: open a deposit channel, then transfer to the deposit address.
    * @param {QuoteSwapParams} params Swap parameters
    * @returns {TxSubmitted} Transaction hash and URL of the swap
    */
   public async doSwap(params: QuoteSwapParams): Promise<TxSubmitted> {
-    const quoteSwap = await this.estimateSwap(params)
-    if (!quoteSwap.canSwap) {
-      throw Error(`Can not make swap. ${quoteSwap.errors.join('\n')}`)
-    }
-
     if (!this.wallet) throw Error('Wallet not configured. Can not do swap')
 
+    const channel = await this.openDepositChannel(params)
+
     const hash = await this.wallet.transfer({
-      recipient: quoteSwap.toAddress,
+      recipient: channel.depositAddress,
       amount: params.amount.baseAmount,
       asset: params.fromAsset as CompatibleAsset,
-      memo: quoteSwap.memo,
+      memo: '',
     })
 
     return {
@@ -284,5 +225,128 @@ export class ChainflipProtocol implements IProtocol {
     })
     if (!assetData) throw Error(`${asset.ticker} asset not supported in ${asset.chain} chain`)
     return assetData
+  }
+
+  private async getSelectedQuote(
+    params: QuoteSwapParams,
+    srcAssetData: AssetData,
+    destAssetData: AssetData,
+  ): Promise<SelectedQuoteContext | undefined> {
+    const { quotes } = await this.sdk.getQuoteV2({
+      srcChain: srcAssetData.chain,
+      srcAsset: srcAssetData.asset,
+      destChain: destAssetData.chain,
+      destAsset: destAssetData.asset,
+      amount: params.amount.baseAmount.amount().toString(),
+      affiliateBrokers: this.affiliateBrokers,
+    })
+
+    let selectedQuote: Quote | undefined
+
+    if (params.enableBoost) {
+      selectedQuote =
+        quotes.find((quote) => quote.type === 'DCA' && quote.boostQuote) ||
+        quotes.find((quote) => quote.type === 'REGULAR' && quote.boostQuote) ||
+        quotes.find((quote) => quote.type === 'DCA') ||
+        quotes.find((quote) => quote.type === 'REGULAR')
+    } else {
+      selectedQuote = quotes.find((quote) => quote.type === 'DCA') || quotes.find((quote) => quote.type === 'REGULAR')
+    }
+
+    if (!selectedQuote) return undefined
+
+    const isUsingBoost = Boolean(params.enableBoost && selectedQuote.boostQuote)
+    const actualQuote = isUsingBoost && selectedQuote.boostQuote ? selectedQuote.boostQuote : selectedQuote
+
+    return {
+      srcAssetData,
+      destAssetData,
+      selectedQuote,
+      actualQuote,
+      isUsingBoost,
+    }
+  }
+
+  private mapQuoteToQuoteSwap(params: QuoteSwapParams, selected: SelectedQuoteContext): QuoteSwap {
+    const { destAssetData, srcAssetData, actualQuote, isUsingBoost } = selected
+
+    const outboundFee = actualQuote.includedFees.find((fee) => fee.type === 'EGRESS')
+    const brokerFee = actualQuote.includedFees.find((fee) => fee.type === 'BROKER')
+    const networkFee = actualQuote.includedFees.find((fee) => fee.type === 'NETWORK')
+    const boostFee = actualQuote.includedFees.find((fee) => fee.type === 'BOOST')
+
+    const baseWarning =
+      'Do not cache this response. Open a deposit channel immediately before broadcast; do not send funds after channel expiry.'
+
+    return {
+      protocol: this.name,
+      // Quote-only: channel is opened via openDepositChannel / doSwap
+      toAddress: '',
+      memo: '',
+      expectedAmount: new CryptoAmount(baseAmount(actualQuote.egressAmount, destAssetData.decimals), params.destinationAsset),
+      dustThreshold: new CryptoAmount(
+        baseAmount(srcAssetData.minimumSwapAmount, srcAssetData.decimals),
+        params.fromAsset,
+      ),
+      totalSwapSeconds: actualQuote.estimatedDurationSeconds ? actualQuote.estimatedDurationSeconds : 0,
+      maxStreamingQuantity: undefined,
+      canSwap: true,
+      warning: actualQuote.lowLiquidityWarning
+        ? `${baseWarning} The difference in the chainflip swap rate (excluding fees) is lower than the global index rate of the swap by more than a certain threshold (currently set to 5%)`
+        : isUsingBoost
+        ? `${baseWarning} Boost enabled for faster processing.`
+        : baseWarning,
+      errors: [],
+      slipBasisPoints: actualQuote.recommendedSlippageTolerancePercent
+        ? actualQuote.recommendedSlippageTolerancePercent * 100
+        : 0,
+      fees: {
+        asset: assetUSDC,
+        networkFee: new CryptoAmount(
+          baseAmount(
+            (networkFee ? parseInt(networkFee.amount) : 0) + (isUsingBoost && boostFee ? parseInt(boostFee.amount) : 0),
+            isUsingBoost && boostFee ? srcAssetData.decimals : 6,
+          ),
+          isUsingBoost && boostFee ? params.fromAsset : assetUSDC,
+        ),
+        outboundFee: new CryptoAmount(
+          baseAmount(outboundFee ? outboundFee.amount : 0, destAssetData.decimals),
+          params.destinationAsset,
+        ),
+        affiliateFee: new CryptoAmount(baseAmount(brokerFee ? brokerFee.amount : 0, 6), assetUSDC),
+      },
+      depositChannelId: undefined,
+    }
+  }
+
+  private emptyQuoteSwap(
+    params: QuoteSwapParams,
+    srcAssetData: AssetData,
+    destAssetData: AssetData,
+    errors: string[],
+  ): QuoteSwap {
+    return {
+      protocol: this.name,
+      toAddress: '',
+      memo: '',
+      expectedAmount: new CryptoAmount(baseAmount(0, destAssetData.decimals), params.destinationAsset),
+      dustThreshold: new CryptoAmount(
+        baseAmount(srcAssetData.minimumSwapAmount, srcAssetData.decimals),
+        params.fromAsset,
+      ),
+      totalSwapSeconds: 0,
+      maxStreamingQuantity: 0,
+      canSwap: false,
+      warning: '',
+      errors,
+      slipBasisPoints: 0,
+      fees: {
+        asset: params.destinationAsset,
+        outboundFee: new CryptoAmount(baseAmount(0, destAssetData.decimals), params.destinationAsset),
+        networkFee: new CryptoAmount(baseAmount(0, 6), assetUSDC),
+        affiliateFee: new CryptoAmount(baseAmount(0, 6), assetUSDC),
+      },
+      depositChannelId: undefined,
+    }
   }
 }

--- a/packages/xchain-aggregator/src/protocols/chainflip/index.ts
+++ b/packages/xchain-aggregator/src/protocols/chainflip/index.ts
@@ -1,1 +1,2 @@
 export { ChainflipProtocol } from './chainflipProtocol'
+export type { ChainflipDepositChannel, CompatibleAsset } from './types'

--- a/packages/xchain-aggregator/src/protocols/chainflip/types.ts
+++ b/packages/xchain-aggregator/src/protocols/chainflip/types.ts
@@ -1,4 +1,4 @@
-import { Asset, TokenAsset } from '@xchainjs/xchain-util'
+import { Asset, CryptoAmount, TokenAsset } from '@xchainjs/xchain-util'
 
 export type CompatibleAsset = Asset | TokenAsset
 
@@ -7,6 +7,8 @@ export type CompatibleAsset = Asset | TokenAsset
  * `Aggregator.requestChainflipDepositAddress`.
  *
  * Do not cache across `expiresAt`. Open immediately before broadcast.
+ * `expectedAmount` / `slipBasisPoints` are from the quote used to open the
+ * channel (may differ from a prior `estimateSwap` if markets moved).
  */
 export type ChainflipDepositChannel = {
   depositAddress: string
@@ -14,4 +16,7 @@ export type ChainflipDepositChannel = {
   /** From SDK `estimatedDepositChannelExpiryTime` (unix seconds). */
   expiresAt: Date
   depositChannelExpiryBlock?: bigint
+  /** Egress amount from the quote bound to this channel. */
+  expectedAmount: CryptoAmount
+  slipBasisPoints: number
 }

--- a/packages/xchain-aggregator/src/protocols/chainflip/types.ts
+++ b/packages/xchain-aggregator/src/protocols/chainflip/types.ts
@@ -1,3 +1,17 @@
 import { Asset, TokenAsset } from '@xchainjs/xchain-util'
 
 export type CompatibleAsset = Asset | TokenAsset
+
+/**
+ * Live Chainflip deposit channel opened via `openDepositChannel` /
+ * `Aggregator.requestChainflipDepositAddress`.
+ *
+ * Do not cache across `expiresAt`. Open immediately before broadcast.
+ */
+export type ChainflipDepositChannel = {
+  depositAddress: string
+  depositChannelId: string
+  /** From SDK `estimatedDepositChannelExpiryTime` (unix seconds). */
+  expiresAt: Date
+  depositChannelExpiryBlock?: bigint
+}


### PR DESCRIPTION
## Summary
- Closes [#1757](https://github.com/xchainjs/xchainjs-lib/issues/1757): Chainflip `estimateSwap` no longer opens a deposit channel on every quote refresh.
- Quote refresh was calling `requestDepositAddressV2`, creating short-lived channels that could expire before deposit (related: [asgardex-desktop#1175](https://github.com/asgardex/asgardex-desktop/issues/1175)).
- **Breaking:** Chainflip `estimateSwap` returns empty `toAddress` / `depositChannelId`; `canSwap` means a usable quote exists.
- New: `ChainflipProtocol.openDepositChannel` and `Aggregator.requestChainflipDepositAddress` return `depositAddress`, `depositChannelId`, `expiresAt`.
- `doSwap` opens one channel then transfers.

## Migration
1. Use `estimateSwap` for quote refresh only.
2. At confirm, call `requestChainflipDepositAddress` immediately before broadcast (or use `doSwap`).
3. Bind UI to address + channel id + expiry; do not cache across expiry.

## Test plan
- [x] `yarn workspace @xchainjs/xchain-aggregator build`
- [x] `yarn workspace @xchainjs/xchain-aggregator test`
- [ ] Asgardex: refresh quotes without channel spam; open channel only on confirm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Breaking Changes**
  - Chainflip quote estimation no longer creates deposit channels or returns deposit addresses.
  - Obtain a deposit channel immediately before broadcasting funds; do not reuse expired or cached addresses.

- **New Features**
  - Added explicit Chainflip deposit-channel requests with address, ID, expiration, expected amount, and slippage details.
  - Swaps now create a fresh deposit channel immediately before funds are transferred.

- **Documentation**
  - Updated guidance covering quote refreshes, channel expiry, deposit observation, and the recommended deposit flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->